### PR TITLE
Python 3.10 Migration (1 - Claude Sonnet 4.5)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["flights", "google-flights", "travel", "api", "flight-search"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -70,7 +72,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 100
 indent-width = 4
 include = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Reverted Python version requirement from 3.12 back to 3.10 to broaden compatibility while maintaining all existing functionality.

**Changes Made:**
- Updated `requires-python` from `>=3.12` to `>=3.10` in `pyproject.toml`
- Added Python 3.10 and 3.11 to package classifiers
- Updated ruff `target-version` from `py312` to `py310`
- Configured all GitHub Actions workflows to use Python 3.10 as the base version
- Expanded test matrix from [3.12, 3.13] to [3.10, 3.11, 3.12, 3.13]

**Compatibility Assessment:**
The codebase already uses Python 3.10-compatible syntax (PEP 604 union types with `|` operator, generic built-in types like `list[]` and `dict[]`). No Python 3.11+ or 3.12-specific features were detected in the source code, making this migration safe and backward-compatible.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - it's a straightforward version compatibility expansion
- Score reflects the non-invasive nature of the changes (only configuration updates), expanded test coverage across four Python versions (3.10-3.13), and verified absence of Python 3.11+ specific syntax in the codebase
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/docs.yml | Updated Python version from 3.12 to 3.10 for documentation workflow |
| .github/workflows/lint.yml | Updated Python version from 3.12 to 3.10 for linting workflow |
| .github/workflows/publish.yml | Updated Python version from 3.12 to 3.10 for publishing workflow |
| .github/workflows/test.yml | Expanded test matrix from [3.12, 3.13] to [3.10, 3.11, 3.12, 3.13] |
| pyproject.toml | Updated minimum Python version to 3.10, added Python 3.10 and 3.11 classifiers, and updated ruff target version |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GHA as GitHub Actions
    participant UV as uv Package Manager
    participant Python as Python Runtime
    participant Tests as Test Suite
    participant Ruff as Ruff Linter
    participant Docs as MkDocs

    Note over Dev,Docs: Python 3.10 Migration Changes

    Dev->>GHA: Push commit with version changes
    
    rect rgb(240, 248, 255)
        Note over GHA,Python: Test Workflow (.github/workflows/test.yml)
        GHA->>UV: Install uv package manager
        loop For each Python version [3.10, 3.11, 3.12, 3.13]
            UV->>Python: Install Python version
            UV->>Python: Install dependencies via uv sync
            Python->>Tests: Run pytest test suite
            Tests-->>GHA: Return test results
        end
    end

    rect rgb(255, 250, 240)
        Note over GHA,Ruff: Lint Workflow (.github/workflows/lint.yml)
        GHA->>UV: Install uv
        UV->>Python: Install Python 3.10
        UV->>Ruff: Install ruff with target py310
        Ruff->>Python: Check code style and format
        Ruff-->>GHA: Return lint results
    end

    rect rgb(240, 255, 240)
        Note over GHA,Docs: Docs Workflow (.github/workflows/docs.yml)
        GHA->>UV: Install uv
        UV->>Python: Install Python 3.10
        UV->>Docs: Install mkdocs dependencies
        Docs->>Python: Build documentation
        Docs-->>GHA: Deploy to GitHub Pages
    end

    rect rgb(255, 245, 245)
        Note over GHA,Python: Publish Workflow (.github/workflows/publish.yml)
        GHA->>UV: Install uv
        UV->>Python: Install Python 3.10
        UV->>Python: Build package with dependencies
        Python-->>GHA: Create distribution artifacts
    end

    GHA-->>Dev: All workflows pass with Python 3.10+
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->