### PR TITLE
Python 3.10 Migration (3 - Claude Sonnet 4.5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
 
     steps:

--- a/fli/cli/enums.py
+++ b/fli/cli/enums.py
@@ -1,7 +1,7 @@
-from enum import StrEnum
+from enum import Enum
 
 
-class DayOfWeek(StrEnum):
+class DayOfWeek(str, Enum):
     """Days of the week."""
 
     MONDAY = "monday"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["flights", "google-flights", "travel", "api", "flight-search"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -70,7 +72,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 100
 indent-width = 4
 include = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR attempts to migrate the project from Python 3.12+ to support Python 3.10+ by reverting version constraints, updating test matrix, and converting `StrEnum` to `str, Enum` for the `DayOfWeek` enum. However, the migration is **incomplete**: `Currency` enum in `fli/models/google_flights/base.py` still uses `StrEnum`, which will cause import failures on Python 3.10. Additionally, the development container still uses Python 3.12, which is inconsistent with the minimum supported version. The test workflow will fail when running against Python 3.10-3.11.

<h3>Confidence Score: 1/5</h3>


- This PR has critical compatibility issues that will cause test failures on Python 3.10 and 3.11 during CI execution.
- The PR attempts to add Python 3.10 support but leaves `StrEnum` usage in `fli/models/google_flights/base.py`, which was only introduced in Python 3.11. This is a breaking change that directly contradicts the declared minimum Python version of 3.10 in `pyproject.toml`. The test workflow now tests against Python 3.10-3.11, where this import will fail. Additionally, the development container still uses Python 3.12, creating an inconsistency between the minimum supported version and the development environment.
- `fli/models/google_flights/base.py` requires immediate attention to change `Currency` class from `StrEnum` to `str, Enum` pattern. The `.devcontainer/Dockerfile` should also be updated for consistency.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| fli/cli/enums.py | Changed `DayOfWeek` from `StrEnum` to `str, Enum` to support Python 3.10 (StrEnum was introduced in Python 3.11). This is correct and maintains the same behavior. |
| pyproject.toml | Updated Python version constraints to support Python 3.10+, added classifiers for 3.10 and 3.11, and set Ruff target-version to py310. However, `fli/models/google_flights/base.py` still uses `StrEnum` on line 63, which breaks Python 3.10 compatibility. |
| .github/workflows/test.yml | Extended test matrix to include Python 3.10 and 3.11. This is necessary but will fail during CI because `fli/models/google_flights/base.py` uses `StrEnum` which is incompatible with Python 3.10. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as CI Pipeline
    participant Py310 as Python 3.10
    participant Py311 as Python 3.11
    participant Py312 as Python 3.12
    participant Import as fli import
    participant StrEnum as StrEnum (3.11+)
    participant DayOfWeek as DayOfWeek<br/>(str, Enum)
    participant Currency as Currency<br/>(StrEnum)

    CI->>Py310: Run tests with Python 3.10
    Py310->>Import: Import fli
    Import->>DayOfWeek: Load fli/cli/enums.py ✓
    Import->>Currency: Load fli/models/google_flights/base.py
    Currency->>StrEnum: Attempt StrEnum import ✗
    StrEnum-->>Py310: ImportError: StrEnum not available
    Py310-->>CI: Test fails

    CI->>Py311: Run tests with Python 3.11
    Py311->>Import: Import fli
    Import->>DayOfWeek: Load fli/cli/enums.py ✓
    Import->>Currency: Load fli/models/google_flights/base.py ✓
    Currency->>StrEnum: StrEnum available
    StrEnum-->>Py311: Success
    Py311-->>CI: Test passes

    CI->>Py312: Run tests with Python 3.12
    Py312->>Import: Import fli ✓
    Import-->>CI: All tests pass
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=90a8ba16-9510-4f10-b2ad-cb22d0733792))

<!-- /greptile_comment -->