### PR TITLE
Python 3.10 Migration (4 - Claude Sonnet 4.5)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
 
     steps:

--- a/fli/cli/enums.py
+++ b/fli/cli/enums.py
@@ -1,4 +1,18 @@
-from enum import StrEnum
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Compatibility StrEnum for Python 3.10."""
+
+        def __str__(self) -> str:
+            return str(self.value)
+
+        def _generate_next_value_(name, start, count, last_values):
+            return name.lower()
 
 
 class DayOfWeek(StrEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["flights", "google-flights", "travel", "api", "flight-search"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -70,7 +72,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 100
 indent-width = 4
 include = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR downgrades Python support from 3.12+ to 3.10+ by updating workflow configurations, `pyproject.toml`, and adding a `StrEnum` compatibility shim for Python 3.10. 

**Changes:**
- Updated `pyproject.toml` to require Python >=3.10 and added classifiers for 3.10 and 3.11
- Extended CI test matrix to include Python 3.10, 3.11, 3.12, and 3.13
- Updated all GitHub workflow files to use Python 3.10 as the base version
- Added Python 3.10 compatibility for `StrEnum` in `fli/cli/enums.py` with version check

**Critical Issue:**
`fli/models/google_flights/base.py:8` still imports `StrEnum` directly without the compatibility check, which will cause `ImportError` on Python 3.10. This file was not modified in the PR but needs to be addressed.

**Additional Files Not Updated:**
- `uv.lock` still specifies `requires-python = ">=3.12"`
- `.devcontainer/Dockerfile` still uses `python:3.12-slim`

<h3>Confidence Score: 2/5</h3>


- This PR is not safe to merge as-is due to incomplete migration
- The PR will break on Python 3.10 because `fli/models/google_flights/base.py` still imports `StrEnum` directly from `enum`. Additionally, `uv.lock` and `.devcontainer/Dockerfile` still reference Python 3.12, creating inconsistency.
- Pay close attention to `fli/models/google_flights/base.py` (not in changeset but blocks Python 3.10), and verify `uv.lock` and `.devcontainer/Dockerfile` are updated

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| fli/cli/enums.py | Added Python 3.10 compatibility shim for `StrEnum` with version check, but `_generate_next_value_` is missing `@staticmethod` decorator |
| pyproject.toml | Updated Python requirement to 3.10+, added classifiers for 3.10 and 3.11, changed ruff target to py310 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant UV as UV Package Manager
    participant Proj as pyproject.toml
    participant Enum as fli/cli/enums.py
    participant Base as fli/models/google_flights/base.py
    
    Dev->>Proj: Update requires-python to >=3.10
    Dev->>Proj: Add Python 3.10, 3.11 classifiers
    Dev->>Proj: Change ruff target to py310
    
    Dev->>GH: Update workflow Python versions
    Note over GH: test.yml: 3.10, 3.11, 3.12, 3.13
    Note over GH: lint.yml, docs.yml, publish.yml: 3.10
    
    Dev->>Enum: Add sys.version_info check
    Enum->>Enum: Import StrEnum from enum (3.11+)
    Enum->>Enum: Define compat StrEnum class (3.10)
    
    Note over Base: ⚠️ Still imports StrEnum directly<br/>Will fail on Python 3.10
    
    GH->>UV: Run tests on Python 3.10-3.13
    UV->>Proj: Check requires-python constraint
    UV->>Base: Import Currency(StrEnum)
    Base--xGH: ImportError on Python 3.10
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->