### PR TITLE
Python 3.10 Migration (5 - Claude Sonnet 4.5)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           version: "latest"
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
 
     steps:

--- a/fli/cli/enums.py
+++ b/fli/cli/enums.py
@@ -1,7 +1,7 @@
-from enum import StrEnum
+from enum import Enum
 
 
-class DayOfWeek(StrEnum):
+class DayOfWeek(str, Enum):
     """Days of the week."""
 
     MONDAY = "monday"

--- a/fli/models/google_flights/base.py
+++ b/fli/models/google_flights/base.py
@@ -5,7 +5,7 @@ Models are designed to match Google Flights' APIs while providing a clean python
 """
 
 from datetime import datetime
-from enum import Enum, StrEnum
+from enum import Enum
 
 from pydantic import (
     BaseModel,
@@ -60,7 +60,7 @@ class MaxStops(Enum):
     TWO_OR_FEWER_STOPS = 3
 
 
-class Currency(StrEnum):
+class Currency(str, Enum):
     """Supported currencies for pricing. Currently only USD."""
 
     USD = "USD"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["flights", "google-flights", "travel", "api", "flight-search"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -70,7 +72,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 100
 indent-width = 4
 include = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Migrated the project from Python 3.12 to Python 3.10 as the minimum supported version. The migration involved replacing `StrEnum` (Python 3.11+) with `str, Enum` pattern in two files: `fli/cli/enums.py` and `fli/models/google_flights/base.py`. The project configuration was updated to reflect the new version requirements, and CI workflows were adjusted to test across Python 3.10, 3.11, 3.12, and 3.13.

Key changes:
- Replaced `StrEnum` with `str, Enum` for `DayOfWeek` and `Currency` enums
- Updated `requires-python` from `>=3.12` to `>=3.10` in `pyproject.toml`
- Added Python 3.10 and 3.11 classifiers to package metadata
- Changed ruff target version from `py312` to `py310`
- Expanded test matrix to include all four Python versions
- Updated all CI workflows to use Python 3.10 as the default version

The migration is complete and correct. The codebase already uses Python 3.10-compatible syntax (pipe union operator `X | Y` instead of `Union[X, Y]`), and no Python 3.12+ exclusive features were found.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it's a straightforward Python version migration with all necessary changes correctly implemented
- The migration is complete and methodical. All instances of `StrEnum` (Python 3.11+ feature) have been correctly replaced with the `str, Enum` pattern which is compatible with Python 3.10+. The codebase already uses Python 3.10-compatible features (pipe union syntax), and no Python 3.12+ exclusive features were found. All configuration files and CI workflows have been properly updated to reflect the new minimum version. The expanded test matrix ensures compatibility across Python 3.10-3.13.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| fli/cli/enums.py | Replaced `StrEnum` with `str, Enum` for Python 3.10 compatibility |
| fli/models/google_flights/base.py | Replaced `StrEnum` with `str, Enum` for `Currency` class |
| pyproject.toml | Updated Python version requirement to 3.10+, added classifiers for 3.10 and 3.11, changed ruff target to py310 |
| .github/workflows/test.yml | Expanded test matrix to include Python 3.10, 3.11, 3.12, and 3.13 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR as PR #34
    participant Code as Source Code
    participant Config as Project Config
    participant CI as GitHub Actions

    Dev->>Code: Replace StrEnum imports
    Code->>Code: Update DayOfWeek enum (fli/cli/enums.py)
    Code->>Code: Update Currency enum (fli/models/google_flights/base.py)
    
    Dev->>Config: Update Python version requirements
    Config->>Config: Change requires-python to >=3.10
    Config->>Config: Add Python 3.10 & 3.11 classifiers
    Config->>Config: Update ruff target-version to py310
    
    Dev->>CI: Update workflow configurations
    CI->>CI: Change default Python from 3.12 to 3.10
    CI->>CI: Expand test matrix [3.10, 3.11, 3.12, 3.13]
    
    PR->>CI: Trigger CI workflows
    CI->>CI: Run tests on all Python versions
    CI->>CI: Run linting with py310 target
    CI->>PR: All checks pass
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->