### PR TITLE
Python 3.10 Migration (6 - Claude Sonnet 4.5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
 
     steps:

--- a/fli/cli/enums.py
+++ b/fli/cli/enums.py
@@ -1,4 +1,14 @@
-from enum import StrEnum
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Compatibility shim for StrEnum on Python < 3.11."""
+
+        pass
 
 
 class DayOfWeek(StrEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["flights", "google-flights", "travel", "api", "flight-search"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -70,7 +72,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 100
 indent-width = 4
 include = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR migrates the project to support Python 3.10+ by updating version requirements, expanding CI test matrix, and adding a `StrEnum` compatibility shim.

**Key Changes:**
- Updated `requires-python` from `>=3.12` to `>=3.10` in `pyproject.toml`
- Added Python 3.10 and 3.11 to GitHub Actions test matrix
- Implemented `StrEnum` compatibility shim in `fli/cli/enums.py` for Python < 3.11
- Updated Ruff target version to `py310`

**Critical Issue:**
- `fli/models/google_flights/base.py:8` still imports `StrEnum` directly from the enum module, which will cause import failures on Python 3.10 since `StrEnum` was only introduced in Python 3.11. This file needs the same compatibility shim pattern applied in `fli/cli/enums.py`.

**Additional Concern:**
- The `StrEnum` compatibility shim should implement `__str__()` to return `str(self.value)` to properly mimic native `StrEnum` behavior where string operations return the value rather than the enum name.

<h3>Confidence Score: 2/5</h3>


- This PR has a critical incompatibility issue that will break Python 3.10 support
- While the changes in the PR are correct and well-implemented, the migration is incomplete. The file `fli/models/google_flights/base.py` still imports `StrEnum` directly from the enum module, which will cause import failures on Python 3.10 since `StrEnum` was only introduced in Python 3.11. This defeats the entire purpose of the Python 3.10 migration. Additionally, the compatibility shim is missing the `__str__()` method which could lead to behavioral differences between Python versions.
- `fli/models/google_flights/base.py` requires immediate attention - it needs the same `StrEnum` compatibility shim pattern. Also review `fli/cli/enums.py` to add `__str__()` method to the shim.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | Added Python 3.10 and 3.11 to the test matrix to ensure compatibility with the new minimum version requirement |
| fli/cli/enums.py | Added compatibility shim for StrEnum to support Python 3.10 where StrEnum is not available |
| pyproject.toml | Updated Python version requirements from 3.12+ to 3.10+, added classifiers for 3.10 and 3.11, and changed Ruff target to py310 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CI as GitHub Actions
    participant Matrix as Test Matrix
    participant Py310 as Python 3.10
    participant Py311 as Python 3.11
    participant Py312 as Python 3.12
    participant Py313 as Python 3.13
    participant Code as Codebase

    Dev->>CI: Push PR changes
    CI->>Matrix: Initialize test matrix
    
    par Python 3.10
        Matrix->>Py310: Install Python 3.10
        Py310->>Code: Import fli.cli.enums
        Code-->>Py310: sys.version_info < (3, 11)
        Code->>Code: Use compatibility shim (str, Enum)
        Py310->>Code: Run tests
        Code-->>Py310: Return results
    and Python 3.11
        Matrix->>Py311: Install Python 3.11
        Py311->>Code: Import fli.cli.enums
        Code-->>Py311: sys.version_info >= (3, 11)
        Code->>Code: Use native StrEnum
        Py311->>Code: Run tests
        Code-->>Py311: Return results
    and Python 3.12
        Matrix->>Py312: Install Python 3.12
        Py312->>Code: Import fli.cli.enums
        Code-->>Py312: sys.version_info >= (3, 11)
        Code->>Code: Use native StrEnum
        Py312->>Code: Run tests
        Code-->>Py312: Return results
    and Python 3.13
        Matrix->>Py313: Install Python 3.13
        Py313->>Code: Import fli.cli.enums
        Code-->>Py313: sys.version_info >= (3, 11)
        Code->>Code: Use native StrEnum
        Py313->>Code: Run tests
        Code-->>Py313: Return results
    end
    
    Matrix->>CI: Aggregate all results
    CI->>Dev: Report test status
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->