### PR TITLE
Python 3.10 Migration (7 - Claude Sonnet 4.5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
 
     steps:

--- a/fli/cli/enums.py
+++ b/fli/cli/enums.py
@@ -1,7 +1,7 @@
-from enum import StrEnum
+from enum import Enum
 
 
-class DayOfWeek(StrEnum):
+class DayOfWeek(str, Enum):
     """Days of the week."""
 
     MONDAY = "monday"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["flights", "google-flights", "travel", "api", "flight-search"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -70,7 +72,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 100
 indent-width = 4
 include = [


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR migrates the project to support Python 3.10+ by updating version requirements and fixing incompatible enum usage.

**Changes:**
- Updated `pyproject.toml` to require Python `>=3.10` (down from `>=3.12`)
- Added Python 3.10 and 3.11 to CI test matrix in `.github/workflows/test.yml`
- Migrated `DayOfWeek` enum from `StrEnum` to `str, Enum` pattern for Python 3.10 compatibility
- Added Python 3.10/3.11 classifiers to package metadata
- Updated Ruff linter target version to `py310`

**Critical Issue:**
The PR missed migrating the `Currency` enum in `fli/models/google_flights/base.py` (line 63), which still uses `StrEnum`. This will cause `ImportError` on Python 3.10/3.11 since `StrEnum` was introduced in Python 3.11. The same `str, Enum` pattern used for `DayOfWeek` needs to be applied to `Currency`.

**Test Coverage:**
The expanded CI matrix will validate compatibility across all supported Python versions (3.10-3.13) once the remaining `StrEnum` usage is fixed.

<h3>Confidence Score: 2/5</h3>


- This PR cannot be merged in its current state due to a critical Python 3.10/3.11 compatibility issue
- The PR correctly updates configuration files and fixes `DayOfWeek` enum, but misses the `Currency` enum in `fli/models/google_flights/base.py` which still uses `StrEnum` (Python 3.11+). This will cause immediate `ImportError` on Python 3.10/3.11, breaking the stated compatibility goal. The fix is straightforward (change `Currency(StrEnum)` to `Currency(str, Enum)`), but this is a blocking issue that must be resolved before merge.
- Pay close attention to `fli/models/google_flights/base.py` which contains incompatible `StrEnum` usage

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.yml | Added Python 3.10 and 3.11 to test matrix for backward compatibility testing |
| fli/cli/enums.py | Correctly migrated `DayOfWeek` from `StrEnum` to `str, Enum` for Python 3.10 compatibility |
| pyproject.toml | Updated `requires-python` to `>=3.10`, added Python 3.10/3.11 classifiers, updated Ruff target version |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR as Pull Request
    participant CI as CI/CD (GitHub Actions)
    participant Tests as Test Suite
    participant Lint as Linter (Ruff)
    
    Dev->>PR: Update pyproject.toml (requires-python >=3.10)
    Dev->>PR: Update .github/workflows/test.yml (add Python 3.10, 3.11)
    Dev->>PR: Fix fli/cli/enums.py (StrEnum → str, Enum)
    
    PR->>CI: Trigger workflow on push/PR
    CI->>Lint: Run lint workflow
    Lint-->>CI: ✓ Linting passed
    
    CI->>Tests: Run test matrix (Python 3.10, 3.11, 3.12, 3.13)
    
    Note over Tests: Each Python version tested in parallel
    
    Tests->>Tests: Install uv package manager
    Tests->>Tests: Install Python version from matrix
    Tests->>Tests: Install dependencies (uv sync --extra dev)
    Tests->>Tests: Run pytest with --all flag
    
    alt Python 3.10/3.11 Test
        Tests-->>CI: ❌ ImportError: StrEnum in base.py
    else Python 3.12/3.13 Test
        Tests-->>CI: ✓ Tests passed
    end
    
    CI->>CI: Collect test results (junit.xml)
    CI->>CI: Upload artifacts
    CI->>CI: Publish test results
    CI-->>PR: ❌ Build failed on Python 3.10/3.11
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->