### PR TITLE
feat: add Docker support for running MCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Production Dockerfile for Fli MCP Server
+# Build: docker build -t fli-mcp .
+# Run:   docker run -d -p 8000:8000 fli-mcp
+#
+# Note: This is separate from .devcontainer/Dockerfile which is for development.
+# The devcontainer includes dev tools (git, make, act) and dev dependencies,
+# resulting in a larger image (~500MB+). This production Dockerfile creates a
+# minimal image (~350MB) with only runtime dependencies needed to run the MCP server.
+
+FROM python:3.10-slim
+
+# Install uv for fast dependency management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+# Copy dependency files first for better layer caching
+COPY pyproject.toml uv.lock README.md ./
+
+# Copy source code
+COPY fli/ ./fli/
+
+# Install production dependencies only (no dev extras)
+RUN uv sync --frozen --no-dev
+
+# Add virtual environment to PATH
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Configure server to bind to all interfaces
+ENV HOST=0.0.0.0
+ENV PORT=8000
+
+# Expose the MCP HTTP server port
+EXPOSE 8000
+
+# Run the MCP HTTP server
+CMD ["fli-mcp-http"]

--- a/README.md
+++ b/README.md
@@ -370,6 +370,22 @@ docker run --rm fli-dev make lint
 docker run --rm fli-dev make test-all
 ```
 
+### Running MCP Server with Docker
+
+```bash
+# Using Docker Compose (recommended)
+docker compose up -d
+
+# Or run directly with docker
+docker run -d -p 8000:8000 ashayc/fli-mcp:latest
+
+# Or build and run locally
+docker build -t fli-mcp .
+docker run -d -p 8000:8000 fli-mcp
+```
+
+The MCP server will be available at `http://localhost:8000/mcp/`
+
 ### Running CI Locally with act
 
 To run GitHub Actions locally, install [act](https://github.com/nektos/act):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+# Docker Compose for Fli MCP Server
+# Usage: docker compose up -d
+# MCP endpoint: http://localhost:8000/mcp/
+
+services:
+  fli-mcp:
+    image: ashayc/fli-mcp:latest
+    # To build locally instead of using pre-built image, comment out 'image' and uncomment 'build':
+    # build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - HOST=0.0.0.0
+      - PORT=8000
+      # Optional MCP server configuration:
+      # - FLI_MCP_DEFAULT_PASSENGERS=1
+      # - FLI_MCP_DEFAULT_CURRENCY=USD
+      # - FLI_MCP_DEFAULT_CABIN_CLASS=ECONOMY
+      # - FLI_MCP_DEFAULT_SORT_BY=CHEAPEST
+      # - FLI_MCP_MAX_RESULTS=10
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

This PR adds Docker support for easily running the Fli MCP server in a container.

- **Dockerfile**: Production-ready image based on `python:3.10-slim` with `uv` for fast dependency management
- **docker-compose.yml**: One-command startup with pre-built image reference
- **README.md**: Minimal addition documenting Docker usage

## Usage

```bash
# Using Docker Compose
docker compose up -d

# Or run directly
docker run -d -p 8000:8000 ashayc/fli-mcp:latest

# Or build locally
docker build -t fli-mcp .
docker run -d -p 8000:8000 fli-mcp
```

MCP server will be available at `http://localhost:8000/mcp/`

## Note for Maintainer

The `docker-compose.yml` currently references `ashayc/fli-mcp:latest` as the pre-built image. Feel free to change this to your preferred Docker Hub username/registry if you'd like to host the official image under your namespace.

Alternatively, you can set up automated builds with GitHub Actions to publish to `ghcr.io/punitarani/fli-mcp` or Docker Hub.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Docker support for the Fli MCP server by introducing a production `Dockerfile`, a `docker-compose.yml`, and a README section documenting usage.

The `Dockerfile` is well-structured — it copies only the necessary files, installs production dependencies with `uv sync --frozen --no-dev`, and correctly sets `HOST=0.0.0.0` so the server (which defaults to `127.0.0.1`) binds to all container interfaces. It is consistent with the existing `.devcontainer/Dockerfile`.

**Key issues to resolve before merging:**

- **Unverified personal Docker Hub image**: Both `docker-compose.yml` and the README direct users to `ashayc/fli-mcp:latest` — a personal account with no affiliation to this repository. The recommended fix is to make `build: .` the default in compose (with the pre-built image referenced only in a comment) and remove the `ashayc/` image from the README's `docker run` example until an official registry path is established under the project's namespace (e.g. `ghcr.io/punitarani/fli-mcp`).
- **Unpinned `uv` version** (`uv:latest`): Minor reproducibility risk; consider pinning to a specific release.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is; the compose file and README must stop directing users to a personal, unverified Docker Hub image before this ships.

There is one clear P1 defect: the default `docker compose up -d` workflow pulls from `ashayc/fli-mcp:latest`, an uncontrolled third-party image. This is a present supply-chain trust and reliability issue for anyone who follows the documentation. Once the image reference is replaced with a local build default, the remaining feedback is P2 (unpinned uv version), which would not block merge.

docker-compose.yml and README.md both need the ashayc/fli-mcp:latest reference removed or replaced.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Dockerfile | New production Dockerfile based on python:3.10-slim; structure is correct and consistent with the devcontainer, but uv version is unpinned (latest). |
| docker-compose.yml | New compose file defaults to a personal Docker Hub image (ashayc/fli-mcp:latest) rather than building locally; this is a supply-chain trust risk that must be addressed before merging. |
| README.md | Adds Docker usage documentation; the 'docker run' example references the same unverified personal image from docker-compose.yml and should be removed or replaced. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User: docker compose up -d] --> B{Image source?}
    B -- "Current: image: ashayc/fli-mcp:latest" --> C[Pull from personal Docker Hub ⚠️]
    B -- "Recommended: build: ." --> D[Build from local Dockerfile]
    C --> E[Container starts\nHOST=0.0.0.0 PORT=8000]
    D --> E
    E --> F[uv sync --frozen --no-dev]
    F --> G[CMD: fli-mcp-http]
    G --> H["run_http() reads HOST/PORT env vars"]
    H --> I[MCP HTTP server at 0.0.0.0:8000]
    I --> J[Exposed on host as localhost:8000/mcp/]
```

<sub>Reviews (1): Last reviewed commit: ["feat: add Docker support for running MCP..."](https://github.com/punitarani/fli/commit/77ae8bc666e760b6f1633509cda8205be9b41980) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=20590299)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->