### PR TITLE
fix(cli): flight times and airline hidden at standard terminal widths

### DIFF
--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -180,7 +180,7 @@ def display_flight_results(flights: list):
             segments.add_column("Arrive", style="green", no_wrap=True)
 
             for leg in flight.legs:
-                airline_flight = f"{leg.airline.value} {leg.flight_number}"
+                airline_flight = f"{leg.airline.name} {leg.flight_number}"
                 segments.add_row(
                     airline_flight,
                     format_airport(leg.departure_airport),


### PR DESCRIPTION
## Problem

The flight segments table in `fli flights` output uses 6 columns with hardcoded `width=30` on the From and To columns. This requires ~132 characters of terminal width to render fully. At standard terminal widths (80 cols) and even wide terminals (120 cols), Rich silently truncates the Airline, Flight, Departure, and Arrival columns — which are arguably the most important fields in the output.

**At 80 columns (default terminal):**
```
│ Flight │ From                           │ To                             │
│        │ LAS (McCarran International    │ SFO (San Francisco             │
```
Airline name, flight number, departure time, and arrival time are all invisible.

**At 120 columns:** All columns show but the layout is tight and times wrap across lines.

## Fix

- Merge `Airline` and `Flight` into a single `Flight` column (e.g. `UA 643`) — reduces from 6 to 5 columns
- Remove hardcoded `width=30` on airport columns — lets Rich auto-size based on available space
- Add `no_wrap=True` on time columns to keep timestamps on one line
- Shorten column headers (`Departure` → `Depart`, `Arrival` → `Arrive`)

**After (80 columns):**
```
│ Flight │ From            │ Depart       │ To              │ Arrive       │
│ UA 643 │ LAS (McCarran   │ 06:00 17-Mar │ SFO (San        │ 07:47 17-Mar │
│        │ International   │              │ Francisco       │              │
│        │ Airport)        │              │ International)  │              │
```

### Note on IATA codes

The merged Flight column uses `airline.name` (IATA code, e.g. "UA") rather than `airline.value` (full name, e.g. "United Airlines"). Full airline names in the merged column (e.g. "United Airlines 643") are wide enough to force Rich to truncate the airport columns at 80 cols, defeating the purpose of the fix. IATA codes are compact and universally recognized by flight search users.

## Testing

Verified at 80, 120, and 140 column terminal widths. One-way and multi-leg itineraries both render correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a usability bug where the flight segments table in `fli flights` output was silently truncating the most important columns (Airline, Flight, Departure, Arrival) at standard terminal widths (80–120 cols) due to hardcoded `width=30` on the From/To columns consuming all available space.

**Changes in `fli/cli/utils.py`:**
- Merges the separate `Airline` and `Flight` columns into a single `Flight` column using the IATA code format (e.g. `UA 643`), reducing the column count from 6 to 5
- Removes hardcoded `width=30` on `From`/`To` columns, allowing Rich to auto-size them based on available terminal width
- Adds `no_wrap=True` to the `Flight`, `Depart`, and `Arrive` columns to prevent cell content from wrapping across lines
- Shortens column headers (`Departure` → `Depart`, `Arrival` → `Arrive`) to save a few characters at the header row

The choice to use `leg.airline.name` (IATA code, e.g. `\"UA\"`) rather than `leg.airline.value` (full airline name, e.g. `\"United Airlines\"`) is intentional and documented in the PR: full names are wide enough to still force truncation at 80 columns. The fix is clean, minimal, and well-reasoned.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-justified display fix with no logic changes, no API impact, and no test regressions.

All findings are at P2 or below. The implementation is correct: `Airline.name` on a Python Enum member correctly returns the IATA code key (e.g. `"UA"`), the column merging logic is sound, and Rich's `no_wrap=True` behaves as expected. No existing tests cover `display_flight_results` column names, so nothing breaks.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/cli/utils.py | Merges 6-column flight segments table into 5 columns by combining Airline+Flight, removes hardcoded width=30 on airport columns, and adds no_wrap=True to time columns — all changes are clean and targeted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[display_flight_results called] --> B{flights empty?}
    B -- Yes --> C[Print No flights found panel]
    B -- No --> D[Iterate over each flight_data]
    D --> E{is round-trip?}
    E -- Yes --> F[flight_segments = outbound + return]
    E -- No --> G[flight_segments = single flight]
    F --> H[Build price/duration summary table]
    G --> H
    H --> I[For each flight segment, create Table]
    I --> J[Add columns: Flight / From / Depart / To / Arrive with no_wrap=True on Flight, Depart, Arrive]
    J --> K[For each FlightLeg]
    K --> L[airline_flight = leg.airline.name + leg.flight_number e.g. UA 643]
    L --> M[Add row: airline_flight, format_airport dep, departure time, format_airport arr, arrival time]
    M --> K
    K -- done --> N[Collect all segments tables]
    N --> O[Print Panel with summary + segments]
    O --> D
```

<sub>Reviews (2): Last reviewed commit: ["revert: use IATA code (airline.name) to ..."](https://github.com/punitarani/fli/commit/46bce979bb97a4dcf35ffb206576dc8cd504c447) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=24723241)</sub>

<!-- /greptile_comment -->