### PR TITLE
Fix Cambodia airport codes: KTI (Techo Intl replaces PNH) and add SAI (Siem Reap-Angkor)

### DIFF
--- a/fli/models/airport.py
+++ b/fli/models/airport.py
@@ -7171,7 +7171,7 @@ class Airport(Enum):
     SAF = "Santa Fe"
     SAG = "Shirdi"
     SAH = "Sana'a International Airport"
-    SAI = "Siem Reap-Angkor International Airport"  # Siem Reap, Cambodia — opened Oct 2023, replaced REP
+    SAI = "Siem Reap-Angkor International Airport"
     SAK = "Saudarkrokur"
     SAL = "El Salvador International Airport"
     SAM = "Salamo"


### PR DESCRIPTION
## Changes

Two Cambodia airport code fixes:

### KTI — updated from "Kratie" → "Techo International Airport"
IATA code `KTI` has been reassigned to **Techo International Airport** (Phnom Penh), which opened on **9 September 2025** replacing Phnom Penh International Airport (PNH). The old Kratie domestic airport no longer holds this code.

- IATA: KTI | ICAO: VDTI
- Location: Kandal Province, 19km south of Phnom Penh
- Source: https://en.wikipedia.org/wiki/Techo_International_Airport

### SAI — added "Siem Reap-Angkor International Airport"
`SAI` was missing from the enum entirely. It is the new international airport serving Siem Reap, opened on **16 October 2023**, replacing the old Siem Reap International Airport (REP).

- IATA: SAI | ICAO: VDSA
- Location: Soutr Nikom District, Siem Reap Province
- Source: https://en.wikipedia.org/wiki/Siem_Reap%E2%80%93Angkor_International_Airport