### PR TITLE
Fix MCP tools/list error: use correct ToolManager API

### DIFF
--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -151,7 +151,7 @@ class FliMCP(FastMCP):
 
     async def list_tools(self) -> list[Tool]:
         """List all available tools with annotations."""
-        tools = (await self._tool_manager.get_tools()).values()
+        tools = list((await self._tool_manager.get_tools()).values())
         return [
             Tool(
                 name=info.name,


### PR DESCRIPTION
## Summary

- Fix `'ToolManager' object has no attribute 'list_tools'` error when MCP clients call `tools/list`
- `ToolManager.list_tools()` doesn't exist in FastMCP 2.14.x — the correct method is `await get_tools()`, which returns `dict[str, Tool]`

Fixes #67

## Test plan

- [ ] Start `fli-mcp` and verify `tools/list` returns both `search_flights` and `search_dates`
- [ ] Verify tools work in Claude Code and Claude Desktop

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a hard crash (`AttributeError: 'ToolManager' object has no attribute 'list_tools'`) that broke the `tools/list` MCP handshake for all clients (Claude Code, Claude Desktop, etc.) on FastMCP 2.14.x. The fix is a single-line change: `self._tool_manager.list_tools()` → `(await self._tool_manager.get_tools()).values()`, correctly using the async dict-returning API introduced in the upgraded FastMCP version.

- **Bug fixed**: `_tool_manager.list_tools()` no longer exists in FastMCP 2.14.x; `get_tools()` is the correct coroutine, returning `dict[str, Tool]`.
- **Scope**: Only `FliMCP.list_tools` (line 154) is touched; no other logic, models, or handlers are affected.
- **Correctness**: `list_tools` was already declared `async`, so `await` is syntactically valid; iterating `.values()` is the right way to enumerate the dict results before building the `mcp.types.Tool` list.
- **Minor style note**: `.values()` returns a live view — materialising it with `list()` would make the one-pass intent explicit, though it causes no functional problem as-is.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted one-line fix that unblocks the MCP tools/list handshake with no side effects.

The change is minimal and correct: it replaces a non-existent synchronous method call with the proper awaited async API. All remaining feedback is P2 style (materialising the dict_values view), which does not affect correctness or reliability.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/mcp/server.py | Single-line bug fix: replaces the non-existent synchronous `_tool_manager.list_tools()` call with the correct `await _tool_manager.get_tools()` (returns `dict[str, Tool]`), then iterates `.values()` — resolves the `AttributeError` that broke `tools/list` for all MCP clients on FastMCP 2.14.x. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant FliMCP as FliMCP.list_tools()
    participant TM as _tool_manager
    participant MCP as mcp.types.Tool

    Client->>FliMCP: tools/list request
    FliMCP->>TM: await get_tools()
    TM-->>FliMCP: dict[str, FastMCPTool]
    FliMCP->>FliMCP: .values() → iterate tools
    loop for each tool
        FliMCP->>MCP: Tool(name, description, inputSchema, annotations)
        MCP-->>FliMCP: mcp.types.Tool instance
    end
    FliMCP-->>Client: list[Tool] (search_flights, search_dates)
```

<sub>Reviews (1): Last reviewed commit: ["Fix MCP tools/list error: use correct To..."](https://github.com/punitarani/fli/commit/9c33190322aa74b31295d97d108f3cc542c0c608) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26661636)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->