### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Fli is a Python library providing programmatic access to Google Flights data via reverse-engineered API. It offers a CLI (`fli`), MCP server (`fli-mcp` / `fli-mcp-http`), and Python API. No external services (databases, caches, etc.) are required.
+
+### Development commands
+
+All standard commands are in the `Makefile` and `CLAUDE.md`. Key ones:
+
+- **Install deps**: `uv sync --all-extras`
+- **Lint**: `make lint` (ruff)
+- **Format**: `make format`
+- **Tests**: `make test` (standard), `make test-all` (including fuzz)
+- **CLI**: `uv run fli flights JFK LAX 2026-05-15`
+- **MCP HTTP server**: `uv run fli-mcp-http` (serves at `http://127.0.0.1:8000/mcp`)
+
+### Testing caveats
+
+- Tests under `tests/search/` hit the live Google Flights API and are rate-limited (HTTP 429). These will frequently fail in cloud/CI environments. All other tests (CLI, core, models, MCP) are self-contained and pass reliably.
+- Run `uv run pytest -vv --ignore=tests/search/` to skip flaky API-dependent tests.
+- One MCP test (`test_search_dates_round_trip`) also makes a live API call and may fail with empty results.
+
+### MCP server notes
+
+- The MCP HTTP endpoint requires `Accept: application/json, text/event-stream` header.
+- The `fli/server/` module referenced in the Makefile (`make server`) does not exist yet; do not attempt to run it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents.

### What's included

- Overview of the Fli project and its architecture (CLI, MCP server, Python API)
- Standard development commands (referencing `Makefile` and `CLAUDE.md`)
- Testing caveats: `tests/search/` tests hit the live Google Flights API and fail with HTTP 429 in cloud/CI environments
- MCP server notes: required Accept header, and that `fli/server/` module doesn't exist yet

### Environment setup verified

| Check | Result |
|-------|--------|
| `uv sync --all-extras` | All 124 packages installed |
| `make lint` (ruff) | All checks passed |
| `uv run pytest -vv --ignore=tests/search/` | 94 passed |
| `uv run pytest -vv` (full suite) | 100 passed, 16 failed (all HTTP 429 rate limits) |
| `uv run fli --help` | CLI works |
| `uv run fli flights JFK LAX 2026-05-15` | 30 flight results returned |
| `uv run fli-mcp-http` | MCP server starts on port 8000 |
| `uv run mkdocs build` | Documentation built successfully |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9cecf38-9a7d-46d5-bb9f-f7e35523fc4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9cecf38-9a7d-46d5-bb9f-f7e35523fc4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `AGENTS.md`, a documentation file providing Cursor Cloud-specific development environment setup instructions. It covers the project overview, key development commands, testing caveats, and MCP server notes for cloud agents.

The content is accurate overall and provides useful context for agents, with one minor inaccuracy: line 22 characterises all MCP tests as \"self-contained and pass reliably,\" while `tests/mcp/test_mcp_server.py` actually contains four tests that each invoke the live Google Flights API. They tolerate failures gracefully via an `if result[\"success\"]:` guard, but an agent reading only line 22 could be misled. The note on line 24 partially corrects this, but only names one of the four affected tests.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR; safe to merge with the noted minor inaccuracy about MCP test isolation.

All findings are P2 style/clarity issues. There are no code changes — only a new Markdown documentation file. The sole concern is a slightly misleading description of MCP test behaviour that doesn't affect runtime functionality.

No files require special attention beyond the minor MCP test caveat clarification in AGENTS.md.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | New documentation file for Cursor Cloud agents; content is largely accurate but slightly overstates MCP test isolation on line 22. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent reads AGENTS.md] --> B{Choose test scope}
    B -->|Skip search tests| C["uv run pytest -vv --ignore=tests/search/"]
    B -->|Full suite| D["uv run pytest -vv"]
    C --> E["tests/cli/, tests/models/, tests/core/ — fully self-contained ✅"]
    C --> F["tests/mcp/ — 4 live API calls, gracefully guarded ⚠️"]
    D --> G["tests/search/ — HTTP 429 in CI ❌"]
    D --> F
    F --> H{API reachable?}
    H -->|Yes| I[Tests pass with real data ✅]
    H -->|No — rate limited| J["result['success']=False, if-guard skips assertions ✅"]
    H -->|Yes but empty results| K["test_search_dates_round_trip may fail ⚠️"]
```

<sub>Reviews (1): Last reviewed commit: ["Add AGENTS.md with Cursor Cloud specific..."](https://github.com/punitarani/fli/commit/3a74020ba7aed6ad3497ac3069f18e5f910ac5c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26676005)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->