### PR TITLE
docs: update AGENTS.md and remove stale server targets from Makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ All standard commands are in the `Makefile` and `CLAUDE.md`. Key ones:
 - **Format**: `make format`
 - **Tests**: `make test` (standard), `make test-all` (including fuzz)
 - **CLI**: `uv run fli flights JFK LAX 2026-05-15`
-- **MCP HTTP server**: `uv run fli-mcp-http` (serves at `http://127.0.0.1:8000/mcp`)
+- **MCP HTTP server**: `uv run fli-mcp-http` (serves at `http://127.0.0.1:8000/mcp/`)
 
 ### Testing caveats
 
@@ -26,4 +26,4 @@ All standard commands are in the `Makefile` and `CLAUDE.md`. Key ones:
 ### MCP server notes
 
 - The MCP HTTP endpoint requires `Accept: application/json, text/event-stream` header.
-- The `fli/server/` module referenced in the Makefile (`make server`) does not exist yet; do not attempt to run it.
+- The `fli/server/` module has been removed from the codebase.

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,6 @@ install-dev:
 install-all:
 	uv sync --extra dev
 
-# Run the server
-server:
-	uv run uvicorn fli.server.main:app
-server-dev:
-	uv run uvicorn fli.server.main:app --reload
-
 # Run the MCP server
 mcp:
 	uv run fli-mcp
@@ -75,8 +69,6 @@ help:
 	@echo "  make install     - Install dependencies"
 	@echo "  make install-dev - Install with dev dependencies"
 	@echo "  make install-all - Install all dependencies"
-	@echo "  make server      - Run the server"
-	@echo "  make server-dev  - Run the development server with reload"
 	@echo "  make mcp         - Run the MCP server"
 	@echo "  make docs        - Build the docs"
 	@echo "  make format      - Format code using ruff"
@@ -91,4 +83,4 @@ help:
 	@echo "  make devcontainer - Build dev container image"
 	@echo "  make requirements - Generate the requirements.txt file"
 # Declare the targets as phony
-.PHONY: help install install-dev install-all server server-dev mcp docs format lint lint-fix test test-mcp test-fuzz test-all ci ci-docker devcontainer requirements
+.PHONY: help install install-dev install-all mcp docs format lint lint-fix test test-mcp test-fuzz test-all ci ci-docker devcontainer requirements


### PR DESCRIPTION
## Summary
- Fix MCP HTTP URL in AGENTS.md to include trailing slash (`/mcp/`)
- Update server module note to reflect it has been removed (was "does not exist yet")
- Remove `server` and `server-dev` Makefile targets that reference the removed `fli/server/` module
- Clean up corresponding help text and `.PHONY` declaration

## Test plan
- [x] `make test` passes (126 tests)
- [x] `make help` output is clean with no server references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a targeted documentation and build-system cleanup PR that removes stale references to the deleted `fli/server/` module and corrects the MCP HTTP URL.

**Changes:**
- `AGENTS.md`: Adds a trailing slash to the MCP HTTP URL (`/mcp/`), aligning it with `README.md`, `docs/`, and `skills/fli/SKILL.md`; updates the server module note from \"does not exist yet\" to \"has been removed from the codebase\"
- `Makefile`: Removes the `server` and `server-dev` targets (and their `help` echo lines and `.PHONY` entries) that pointed at the non-existent `fli.server.main:app` entry point

**Minor gap:** `CLAUDE.md` — the primary AI-assistant guidance file — still lists `**FastAPI server** (\\`fli/server/\\`)` as an active project component (line 14), which contradicts this PR's intent and could mislead future coding agents.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are documentation and dead Makefile target removal with no functional impact

All findings are P2. The only remaining issue is a missed CLAUDE.md line that still references the deleted module, which is a documentation inconsistency and does not block a merge.

CLAUDE.md line 14 (not in this PR's diff) still lists the removed FastAPI server as a project component

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Fixes MCP URL trailing slash and updates the server module note to reflect its removal; changes are accurate and consistent with the rest of the codebase |
| Makefile | Removes dead `server` and `server-dev` targets (and their help text and `.PHONY` entries) that referenced the deleted `fli/server/` module; cleanup is complete and correct |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #79 cleanup] --> B[AGENTS.md]
    A --> C[Makefile]
    A -.->|missed| D[CLAUDE.md]

    B --> B1["Fix /mcp → /mcp/ URL"]
    B --> B2["Update server/ note:\n'does not exist yet' → 'has been removed'"]

    C --> C1["Remove 'server' target\n(uv run uvicorn fli.server.main:app)"]
    C --> C2["Remove 'server-dev' target\n(uvicorn --reload)"]
    C --> C3["Remove help text entries"]
    C --> C4["Update .PHONY declaration"]

    D -->|still references| D1["FastAPI server fli/server/\n— stale entry on line 14"]

    style D stroke:#f90,stroke-dasharray:5 5
    style D1 stroke:#f90,stroke-dasharray:5 5
```

<sub>Reviews (1): Last reviewed commit: ["docs: update AGENTS.md and remove stale ..."](https://github.com/punitarani/fli/commit/81b52c96d47ca4702c7082ccaf65f6baf805518e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26681541)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=90a8ba16-9510-4f10-b2ad-cb22d0733792))

<!-- /greptile_comment -->