### PR TITLE
docs: remove defunct FastAPI server reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,6 @@ Fli is a Python library that provides programmatic access to Google Flights data
 - **Core utilities** (`fli/core/`) - Shared parsing and building utilities
 - **Search engine** (`fli/search/`) - Flight and date search implementations using Google Flights API
 - **Data models** (`fli/models/`) - Pydantic models for airports, airlines, and flight data structures
-- **FastAPI server** (`fli/server/`) - REST API endpoints for flight search functionality
 
 ## Development Commands
 


### PR DESCRIPTION
## Summary
- Remove the `fli/server/` FastAPI server bullet point from the Project Overview section in CLAUDE.md
- The server module was previously removed from the codebase; this aligns documentation with the current state

## Test plan
- [x] Verified no other references to `fli/server/` exist in CLAUDE.md
- [x] `make test` passes (126 tests)
- [x] No e2e needed (CLAUDE.md is not part of mkdocs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a single stale bullet point from `CLAUDE.md` that referenced the `fli/server/` FastAPI module which no longer exists in the codebase. The change brings the documentation in sync with the actual project structure.

- Removes the `**FastAPI server** (\`fli/server/\`)` line from the Project Overview section.
- No other references to `fli/server/` remain in `CLAUDE.md`.
- No code, tests, or build configuration is affected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only cleanup with no functional impact.

The change is a one-line documentation deletion that accurately reflects the current state of the repository. No code, tests, or build artifacts are touched, and the remaining content of CLAUDE.md is consistent and correct.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Removes the defunct `fli/server/` FastAPI bullet point from the Project Overview; the rest of the document remains accurate and consistent. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI["CLI Interface\nfli/cli/"]
    MCP["MCP Server\nfli/mcp/"]
    CORE["Core Utilities\nfli/core/"]
    SEARCH["Search Engine\nfli/search/"]
    MODELS["Data Models\nfli/models/"]

    CLI --> CORE
    MCP --> CORE
    CORE --> SEARCH
    SEARCH --> MODELS
```

<sub>Reviews (1): Last reviewed commit: ["docs: remove defunct FastAPI server refe..."](https://github.com/punitarani/fli/commit/63716fc317e6f40e7fbf2fe171c5cbc24a47f437) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26681543)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=90a8ba16-9510-4f10-b2ad-cb22d0733792))

<!-- /greptile_comment -->