### PR TITLE
docs: update README dates and missing CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ fli --help
 
 ```bash
 # Basic flight search
-fli flights JFK LHR 2025-10-25
+fli flights JFK LHR 2026-10-25
 
 # Advanced search with filters
-fli flights JFK LHR 2025-10-25 \
+fli flights JFK LHR 2026-10-25 \
     --time 6-20 \             # Departure time window (6 AM - 8 PM)
     --airlines BA KL \        # Airlines (British Airways, KLM)
     --class BUSINESS \        # Cabin class
@@ -149,7 +149,7 @@ fli flights JFK LHR 2025-10-25 \
 >
 > ```bash
 > # Return machine-readable flight results
-> fli flights JFK LHR 2025-10-25 --format json
+> fli flights JFK LHR 2026-10-25 --format json
 > ```
 
 ### Find Cheapest Dates
@@ -160,8 +160,8 @@ fli dates JFK LHR
 
 # Advanced search with date range
 fli dates JFK LHR \
-    --from 2025-01-01 \
-    --to 2025-02-01 \
+    --from 2026-01-01 \
+    --to 2026-02-01 \
     --monday --friday      # Only Mondays and Fridays
 ```
 
@@ -170,7 +170,7 @@ fli dates JFK LHR \
 >
 > ```bash
 > # Return machine-readable date search results
-> fli dates JFK LHR --from 2025-01-01 --to 2025-02-01 --format json
+> fli dates JFK LHR --from 2026-01-01 --to 2026-02-01 --format json
 > ```
 
 ### CLI Options
@@ -179,6 +179,7 @@ fli dates JFK LHR \
 
 | Option           | Description           | Example                |
 |------------------|-----------------------|------------------------|
+| `--return, -r`   | Return date           | `2026-10-30`           |
 | `--time, -t`     | Departure time window | `6-20`                 |
 | `--airlines, -a` | Airline IATA codes    | `BA KL`                |
 | `--class, -c`    | Cabin class           | `ECONOMY`, `BUSINESS`  |
@@ -188,14 +189,19 @@ fli dates JFK LHR \
 
 #### Dates Command (`fli dates`)
 
-| Option        | Description   | Example                |
-|---------------|---------------|------------------------|
-| `--from`      | Start date    | `2025-01-01`           |
-| `--to`        | End date      | `2025-02-01`           |
-| `--class, -c` | Cabin class   | `ECONOMY`, `BUSINESS`  |
-| `--stops, -s` | Maximum stops | `NON_STOP`, `ONE_STOP` |
-| `--[day]`     | Day filters   | `--monday`, `--friday` |
-| `--format`    | Output format | `text`, `json`         |
+| Option             | Description            | Example                |
+|--------------------|------------------------|------------------------|
+| `--from`           | Start date             | `2026-01-01`           |
+| `--to`             | End date               | `2026-02-01`           |
+| `--duration, -d`   | Trip duration in days  | `3`                    |
+| `--round, -R`      | Round-trip search      | (flag)                 |
+| `--airlines, -a`   | Airline IATA codes     | `BA KL`                |
+| `--class, -c`      | Cabin class            | `ECONOMY`, `BUSINESS`  |
+| `--stops, -s`      | Maximum stops          | `NON_STOP`, `ONE_STOP` |
+| `--time`           | Departure time window  | `6-20`                 |
+| `--sort`           | Sort by price          | (flag)                 |
+| `--[day]`          | Day filters            | `--monday`, `--friday` |
+| `--format`         | Output format          | `text`, `json`         |
 
 ## MCP Server Integration
 


### PR DESCRIPTION
## Summary
- Updated all example dates from 2025 to 2026 to reflect the current year
- Added missing `--return, -r` option to the Flights Command CLI options table
- Expanded the Dates Command CLI options table with missing options: `--duration/-d`, `--round/-R`, `--airlines/-a`, `--time`, and `--sort`

## Test plan
- [x] `make test` passes (126 tests)
- [x] mkdocs build skipped (pre-existing cairo dependency issue on this machine)
- [x] Verified markdown table formatting is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only update to `README.md` that refreshes example dates from 2025 to 2026 and fills in previously missing CLI option rows for both the `fli flights` and `fli dates` commands.

- All six example date strings (`2025-10-25`, `2025-01-01`, `2025-02-01`) are correctly updated to their 2026 equivalents, matching the current year.
- `--return, -r` is correctly added to the Flights Command table; the option is verified to exist in `fli/cli/commands/flights.py` (lines 173–180).
- Five options added to the Dates Command table (`--duration/-d`, `--round/-R`, `--airlines/-a`, `--time`, `--sort`) are all verified against `fli/cli/commands/dates.py` — names, short forms, and descriptions match the implementation exactly.
- No code changes are included; this is a pure documentation fix with no risk to runtime behaviour.

<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no code changes; all documented options are verified against the actual CLI implementation.

Every change was cross-checked against the source files — date bumps are correct for the current year, and all newly documented CLI options exist with the exact flags and short-forms shown in the tables. No code was modified, so there is zero risk of runtime regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Documentation-only update: example dates bumped from 2025 → 2026, `--return/-r` added to Flights table, and five previously missing options (`--duration/-d`, `--round/-R`, `--airlines/-a`, `--time`, `--sort`) added to the Dates table — all verified accurate against the actual CLI implementation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    fli["fli (CLI entry-point)"]

    fli --> flights["fli flights &lt;origin&gt; &lt;dest&gt; &lt;date&gt;"]
    fli --> dates["fli dates &lt;origin&gt; &lt;dest&gt;"]

    flights --> fo1["--return, -r  (return date)"]
    flights --> fo2["--time, -t    (departure window)"]
    flights --> fo3["--airlines, -a"]
    flights --> fo4["--class, -c"]
    flights --> fo5["--stops, -s"]
    flights --> fo6["--sort, -o"]
    flights --> fo7["--format"]

    dates --> do1["--from / --to  (date range)"]
    dates --> do2["--duration, -d"]
    dates --> do3["--round, -R    (flag)"]
    dates --> do4["--airlines, -a"]
    dates --> do5["--class, -c"]
    dates --> do6["--stops, -s"]
    dates --> do7["--time"]
    dates --> do8["--sort         (flag)"]
    dates --> do9["--[day]        (--monday … --sunday)"]
    dates --> do10["--format"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: update README with current dates a..."](https://github.com/punitarani/fli/commit/7ccf1ffa2a57638c4e4d1ec105f70ef0df3141ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26681545)</sub>

<!-- /greptile_comment -->