### PR TITLE
docs: update outdated dates in examples and skill docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -198,8 +198,8 @@ from datetime import datetime, timedelta
 future_date = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
 
 # Date ranges
-from_date = "2024-06-01"
-to_date = "2024-06-30"
+from_date = "2026-06-01"
+to_date = "2026-06-30"
 ```
 
 ### Passenger Configuration

--- a/skills/fli/SKILL.md
+++ b/skills/fli/SKILL.md
@@ -105,7 +105,7 @@ Do not tell users to run `pipx install fli`.
 Use:
 
 ```bash
-fli flights JFK LAX 2025-10-25
+fli flights JFK LAX 2026-10-25
 ```
 
 ### Cheapest-date search
@@ -113,7 +113,7 @@ fli flights JFK LAX 2025-10-25
 Use:
 
 ```bash
-fli dates JFK LAX --from 2025-01-01 --to 2025-01-31
+fli dates JFK LAX --from 2026-01-01 --to 2026-01-31
 ```
 
 ### Common filters
@@ -121,7 +121,7 @@ fli dates JFK LAX --from 2025-01-01 --to 2025-01-31
 Use filters like these when the user asks for them:
 
 ```bash
-fli flights JFK LHR 2025-10-25 \
+fli flights JFK LHR 2026-10-25 \
   --time 6-20 \
   --airlines BA KL \
   --class BUSINESS \


### PR DESCRIPTION
## Summary
- Update `examples/README.md`: replace `2024-06-01`/`2024-06-30` with `2026-06-01`/`2026-06-30` in the Date Handling code example
- Update `skills/fli/SKILL.md`: replace all `2025` dates (`2025-10-25`, `2025-01-01`, `2025-01-31`) with `2026` equivalents in CLI usage examples

## Test plan
- [x] `make test` passes (126 tests)
- [x] No e2e needed (these files are not part of mkdocs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only update that advances hardcoded example dates from 2024/2025 to 2026 in `examples/README.md` and `skills/fli/SKILL.md`, keeping the CLI and code snippets from referencing dates that have already passed.

**Changes:**
- `examples/README.md`: `from_date`/`to_date` advanced from June 2024 → June 2026 ✓
- `skills/fli/SKILL.md`: Three date updates from 2025 → 2026
  - `fli flights` basic search: Oct 2025 → Oct 2026 ✓
  - `fli dates` cheapest-date range: Jan 2025 → Jan 2026 — Jan 2026 has already passed (today is 2026-03-29), so this example still points to a past date range
  - `fli flights` with filters: Oct 2025 → Oct 2026 ✓

<h3>Confidence Score: 5/5</h3>

Safe to merge; only documentation date updates with one minor past-date example that can be followed up.

All findings are P2 style suggestions. No code logic, tests, or runtime behaviour is affected. The one stale January 2026 date is a minor docs-quality nit that doesn't block merge.

skills/fli/SKILL.md — the `fli dates` example date range (line 116) is still in the past.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/README.md | Date range updated from 2024 to 2026 (June); both dates are comfortably in the future — no issues. |
| skills/fli/SKILL.md | Three date updates from 2025 → 2026; October dates are future-safe, but the `--from 2026-01-01 --to 2026-01-31` range is already in the past relative to today (2026-03-29). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: Update example dates] --> B[examples/README.md]
    A --> C[skills/fli/SKILL.md]

    B --> D["from_date: 2024-06-01 → 2026-06-01 ✓"]
    B --> E["to_date: 2024-06-30 → 2026-06-30 ✓"]

    C --> F["fli flights basic: 2025-10-25 → 2026-10-25 ✓"]
    C --> G["fli dates range: 2025-01-01/31 → 2026-01-01/31"]
    C --> H["fli flights filters: 2025-10-25 → 2026-10-25 ✓"]

    G --> I["⚠ Jan 2026 already past\n(today = 2026-03-29)"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: update outdated dates in examples/..."](https://github.com/punitarani/fli/commit/3ce057dfa2e4d22320c05d7e66f4409504c14c91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26681555)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->