### PR TITLE
docs: update API reference example dates to 2026

### DIFF
--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -17,12 +17,12 @@ flight_segments = [
     FlightSegment(
         departure_airport=[[Airport.JFK, 0]],
         arrival_airport=[[Airport.LAX, 0]],
-        travel_date="2024-06-01",
+        travel_date="2026-06-01",
     ),
     FlightSegment(
         departure_airport=[[Airport.LAX, 0]],
         arrival_airport=[[Airport.JFK, 0]],
-        travel_date="2024-06-15",
+        travel_date="2026-06-15",
     )
 ]
 

--- a/docs/api/search.md
+++ b/docs/api/search.md
@@ -41,7 +41,7 @@ filters = FlightSearchFilters(
         FlightSegment(
             departure_airport=[[Airport.JFK, 0]],
             arrival_airport=[[Airport.LAX, 0]],
-            travel_date="2024-06-01",
+            travel_date="2026-06-01",
         )
     ],
     seat_type=SeatType.ECONOMY
@@ -65,11 +65,11 @@ filters = DateSearchFilters(
         FlightSegment(
             departure_airport=[[Airport.JFK, 0]],
             arrival_airport=[[Airport.LAX, 0]],
-            travel_date="2024-06-01",
+            travel_date="2026-06-01",
         )
     ],
-    from_date="2024-06-01",
-    to_date="2024-06-30"
+    from_date="2026-06-01",
+    to_date="2026-06-30"
 )
 
 # Search dates


### PR DESCRIPTION
## Summary
- Update all example dates in `docs/api/search.md` from 2024 to 2026 (2024-06-01 -> 2026-06-01, 2024-06-30 -> 2026-06-30)
- Update all example dates in `docs/api/models.md` from 2024 to 2026 (2024-06-01 -> 2026-06-01, 2024-06-15 -> 2026-06-15)

## Test plan
- [x] All 126 unit tests pass (`make test`)
- [x] MkDocs builds successfully (`uv run mkdocs build`)
- [x] Only date strings changed; no structural modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates example dates in two API reference documentation files (`docs/api/models.md` and `docs/api/search.md`) from 2024 to 2026 to ensure code snippets remain valid. This is necessary because `FlightSearchFilters` validates that travel dates are not in the past, so stale 2024 example dates would fail validation if copied directly by users.

- Updated `travel_date` in `docs/api/models.md` from `\"2024-06-01\"` / `\"2024-06-15\"` to `\"2026-06-01\"` / `\"2026-06-15\"`
- Updated `travel_date`, `from_date`, and `to_date` in `docs/api/search.md` from `2024-*` to `2026-*`
- No structural, logic, or non-documentation changes were made

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no impact on library logic or tests.

All changes are purely cosmetic date string updates in Markdown documentation. No code logic, models, or tests were modified. The updates are correct and consistent across both files, and they align with the documented validation rule that travel dates cannot be in the past.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/api/models.md | Updated two example travel dates from 2024 to 2026 (2024-06-01 → 2026-06-01, 2024-06-15 → 2026-06-15) to keep examples valid given the "travel dates cannot be in the past" validation rule. |
| docs/api/search.md | Updated three example dates from 2024 to 2026 across two code snippets (Basic Flight Search and Date Range Search), keeping examples consistent with the updated models.md dates. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SearchFlights
    participant FlightSearchFilters
    participant GoogleFlightsAPI

    User->>FlightSearchFilters: Create filters (travel_date="2026-06-01")
    FlightSearchFilters->>FlightSearchFilters: Validate date not in past
    FlightSearchFilters-->>User: Valid filters object
    User->>SearchFlights: search(filters)
    SearchFlights->>GoogleFlightsAPI: POST request with encoded filters
    GoogleFlightsAPI-->>SearchFlights: Raw flight data
    SearchFlights-->>User: List[FlightResult]
```

<sub>Reviews (1): Last reviewed commit: ["docs: update example dates from 2024 to ..."](https://github.com/punitarani/fli/commit/8614dcc7f25edff5206555d8a3095051aa00a255) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26681566)</sub>

<!-- /greptile_comment -->