### PR TITLE
docs: update advanced examples dates and round-trip processing

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -41,7 +41,7 @@ filters = FlightSearchFilters(
         FlightSegment(
             departure_airport=[[Airport.JFK, 0]],
             arrival_airport=[[Airport.LHR, 0]],
-            travel_date="2024-06-01",
+            travel_date="2026-06-01",
         )
     ],
     seat_type=SeatType.BUSINESS,
@@ -75,7 +75,7 @@ filters = FlightSearchFilters(
         FlightSegment(
             departure_airport=[[Airport.JFK, 0]],
             arrival_airport=[[Airport.LAX, 0]],
-            travel_date="2024-06-01",
+            travel_date="2026-06-01",
             time_restrictions=TimeRestrictions(
                 earliest_departure=6,  # 6 AM
                 latest_departure=10,  # 10 AM
@@ -110,11 +110,11 @@ filters = DateSearchFilters(
         FlightSegment(
             departure_airport=[[Airport.JFK, 0]],
             arrival_airport=[[Airport.LAX, 0]],
-            travel_date="2024-06-01",
+            travel_date="2026-06-01",
         )
     ],
-    from_date="2024-06-01",
-    to_date="2024-06-30",
+    from_date="2026-06-01",
+    to_date="2026-06-30",
     seat_type=SeatType.PREMIUM_ECONOMY
 )
 
@@ -145,11 +145,11 @@ def track_prices(days=7):
             FlightSegment(
                 departure_airport=[[Airport.JFK, 0]],
                 arrival_airport=[[Airport.LAX, 0]],
-                travel_date="2024-06-01",
+                travel_date="2026-06-01",
             )
         ],
-        from_date="2024-06-01",
-        to_date="2024-06-07"
+        from_date="2026-06-01",
+        to_date="2026-06-07"
     )
 
     search = SearchDates()
@@ -232,7 +232,7 @@ def analyze_results(results: List[FlightResult]) -> pd.DataFrame:
 from fli.models import (
     Airport, Airline, SeatType, MaxStops,
     PassengerInfo, TimeRestrictions, TripType,
-    FlightSegment, FlightSearchFilters
+    FlightSegment, FlightSearchFilters, LayoverRestrictions
 )
 from fli.search import SearchFlights
 from datetime import datetime, timedelta
@@ -241,7 +241,7 @@ from datetime import datetime, timedelta
 outbound = FlightSegment(
     departure_airport=[[Airport.JFK, 0]],
     arrival_airport=[[Airport.LHR, 0]],
-    travel_date="2024-06-01",
+    travel_date="2026-06-01",
     time_restrictions=TimeRestrictions(
         earliest_departure=6,  # 6 AM
         latest_departure=12,   # 12 PM
@@ -253,7 +253,7 @@ outbound = FlightSegment(
 return_flight = FlightSegment(
     departure_airport=[[Airport.LHR, 0]],
     arrival_airport=[[Airport.JFK, 0]],
-    travel_date="2024-06-15",
+    travel_date="2026-06-15",
     time_restrictions=TimeRestrictions(
         earliest_departure=14,  # 2 PM
         latest_departure=20,    # 8 PM
@@ -296,27 +296,21 @@ filters = FlightSearchFilters(
 search = SearchFlights()
 results = search.search(filters)
 
-# Process results with detailed information
-for flight in results:
-    print(f"\nTotal Price: ${flight.total_price}")
-    
-    print("\nOutbound Flight:")
-    for leg in flight.outbound.legs:
-        print(f"Flight: {leg.airline.value} {leg.flight_number}")
-        print(f"From: {leg.departure_airport.value} at {leg.departure_datetime}")
-        print(f"To: {leg.arrival_airport.value} at {leg.arrival_datetime}")
-        print(f"Duration: {leg.duration} minutes")
-        if leg.layover_duration:
-            print(f"Layover: {leg.layover_duration} minutes")
-    
-    print("\nReturn Flight:")
-    for leg in flight.return_flight.legs:
-        print(f"Flight: {leg.airline.value} {leg.flight_number}")
-        print(f"From: {leg.departure_airport.value} at {leg.departure_datetime}")
-        print(f"To: {leg.arrival_airport.value} at {leg.arrival_datetime}")
-        print(f"Duration: {leg.duration} minutes")
-        if leg.layover_duration:
-            print(f"Layover: {leg.layover_duration} minutes")
+# Process results - round trips return tuples of (outbound, return)
+for outbound, return_flight in results:
+    print(f"\nOutbound Flight (${outbound.price}):")
+    for leg in outbound.legs:
+        print(f"  Flight: {leg.airline.value} {leg.flight_number}")
+        print(f"  From: {leg.departure_airport.value} at {leg.departure_datetime}")
+        print(f"  To: {leg.arrival_airport.value} at {leg.arrival_datetime}")
+        print(f"  Duration: {leg.duration} minutes")
+
+    print(f"\nReturn Flight:")
+    for leg in return_flight.legs:
+        print(f"  Flight: {leg.airline.value} {leg.flight_number}")
+        print(f"  From: {leg.departure_airport.value} at {leg.departure_datetime}")
+        print(f"  To: {leg.arrival_airport.value} at {leg.arrival_datetime}")
+        print(f"  Duration: {leg.duration} minutes")
 ```
 
 ### Advanced Date Search with Validation
@@ -350,8 +344,8 @@ def validate_dates(from_date: str, to_date: str, min_stay: int, max_stay: int):
         raise ValueError("Minimum stay cannot be greater than maximum stay")
 
 
-from_date = "2024-06-01"
-to_date = "2024-06-30"
+from_date = "2026-06-01"
+to_date = "2026-06-30"
 min_stay = 2
 max_stay = 4
 


### PR DESCRIPTION
## Summary
- Updated all example dates from 2024 to 2026 in `docs/examples/advanced.md` so they remain in the future
- Fixed the "Complex Round Trip Search with Validations" section to correctly process round-trip results as `tuple[FlightResult, FlightResult]` instead of accessing non-existent attributes (`flight.total_price`, `flight.outbound`, `flight.return_flight`, `leg.layover_duration`)
- Added missing `LayoverRestrictions` import that was used but not imported in the Complex Round Trip section

## Test plan
- [x] `make test` passes (126 tests)
- [x] `uv run mkdocs build` fails due to pre-existing missing `libcairo` system dependency (unrelated to these changes)
- [x] Verified all 2024 dates replaced with 2026
- [x] Verified round-trip result processing matches actual `SearchFlights` return type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `docs/examples/advanced.md` to fix two categories of issues: stale dates (all `2024` dates bumped to `2026`) and a broken round-trip result-processing block that referenced non-existent attributes (`flight.total_price`, `flight.outbound`, `flight.return_flight`, `leg.layover_duration`).

**Key changes:**
- All example `travel_date`, `from_date`, and `to_date` values updated from `2024` to `2026` so they remain in the future and pass `FlightSegment`'s `validate_travel_date` validator.
- The "Complex Round Trip Search with Validations" result-processing loop fixed to correctly unpack the `tuple[FlightResult, FlightResult]` pairs returned by `SearchFlights.search()` for round trips, accessing `FlightResult.legs` and `FlightResult.price` (which actually exist on the model).
- Missing `LayoverRestrictions` import added to the Complex Round Trip example's import block.
- One minor style concern: the loop variables `outbound` and `return_flight` on line 300 shadow the earlier `FlightSegment` variables of the same name; using distinct names (e.g. `outbound_result`, `return_result`) would make the example easier to follow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are documentation-only and correct previously broken example code.

All substantive fixes (date updates, correct tuple unpacking, missing import) are accurate and verified against the actual model definitions and SearchFlights return type. The only remaining finding is a P2 style suggestion about variable name shadowing that has no runtime impact.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Dates updated from 2024 → 2026 to keep examples in the future; round-trip result processing corrected to unpack tuple[FlightResult, FlightResult] instead of accessing non-existent attributes; LayoverRestrictions import added. One minor style issue: loop variable names shadow earlier FlightSegment variables. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update advanced examples with corr..."](https://github.com/punitarani/fli/commit/2e6457cb7312f3aecc15a90f79db98ff91f3a28a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26681651)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->