### PR TITLE
Add airline code to flight leg details

### DIFF
--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -288,7 +288,7 @@ def _serialize_flight_leg(leg: Any) -> dict[str, Any]:
         "arrival_time": leg.arrival_datetime,
         "duration": leg.duration,
         "airline": leg.airline,
-        "airline_code": leg.airline.name.lstrip("_"),
+        "airline_code": getattr(leg.airline, "name", leg.airline).lstrip("_"),
         "flight_number": leg.flight_number,
     }
 


### PR DESCRIPTION
Add `airline_code` field to `_serialize_flight_leg` to expose the IATA carrier code (e.g. "IB") alongside the existing `airline` full name field.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `airline_code` field to `_serialize_flight_leg` in the MCP server, intended to expose the IATA carrier code (e.g. `"IB"`) alongside the existing `airline` full-name field. The approach is nearly correct but has a subtle bug: `leg.airline.name` returns the Python enum member name, which has a leading underscore (`_`) prepended to IATA codes that start with a digit (e.g. `Airline._6E` for IndiGo's `6E` code). This would expose `"_6E"` as the airline code instead of `"6E"`.

- **New field**: `airline_code` is added to the serialized flight leg dict using `leg.airline.name`
- **Bug**: For airlines with digit-starting IATA codes (e.g. `6E`, `0B`), `leg.airline.name` returns a `_`-prefixed string (e.g. `"_6E"`) instead of the correct IATA code
- **Fix**: Use `leg.airline.name.lstrip("_")` to strip the synthetic prefix before exposing it as the public IATA code

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the underscore-prefix issue for digit-starting IATA codes.

One P1 logic defect: `leg.airline.name` leaks an internal `_` prefix for real-world airlines like IndiGo (`6E`) and Blue Air (`0B`), producing incorrect IATA codes for those carriers. A one-character fix resolves it.

fli/mcp/server.py — line 291, the `airline_code` value expression

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/mcp/server.py | Adds `airline_code` field to `_serialize_flight_leg`, but uses `leg.airline.name` which returns the Python enum member name — including a spurious `_` prefix for IATA codes that start with a digit (e.g. `_6E` instead of `6E`). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["leg.airline (Airline enum member)"] --> B{".name"}
    B -->|"IATA starts with letter (e.g. AA, IB)"| C["'AA' / 'IB' ✅"]
    B -->|"IATA starts with digit (e.g. 6E, 0B)"| D["'_6E' / '_0B' ❌"]
    D --> E["strip('_') → '6E' / '0B' ✅"]
    C --> F["airline_code field in serialized leg"]
    E --> F
```

<sub>Reviews (1): Last reviewed commit: ["Add airline code to flight leg details"](https://github.com/punitarani/fli/commit/689bf3df5669197be7d9b9a4b8d21816a16e6749) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26767493)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->