### PR TITLE
feat: expose aircraft, legroom, amenities, codeshares, and emissions in flight results

### DIFF
--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -331,9 +331,12 @@ def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[s
                 *[_serialize_flight_leg(leg) for leg in return_flight.legs],
             ],
         }
-        emissions = _serialize_emissions(outbound.emissions)
-        if emissions:
-            result["emissions"] = emissions
+        outbound_emissions = _serialize_emissions(outbound.emissions)
+        if outbound_emissions:
+            result["outbound_emissions"] = outbound_emissions
+        return_emissions = _serialize_emissions(return_flight.emissions)
+        if return_emissions:
+            result["return_emissions"] = return_emissions
         return result
     else:
         result = {

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -281,7 +281,7 @@ class DateSearchParams(BaseModel):
 
 def _serialize_flight_leg(leg: Any) -> dict[str, Any]:
     """Serialize a single flight leg to a dictionary."""
-    return {
+    result: dict[str, Any] = {
         "departure_airport": leg.departure_airport,
         "arrival_airport": leg.arrival_airport,
         "departure_time": leg.departure_datetime,
@@ -290,14 +290,40 @@ def _serialize_flight_leg(leg: Any) -> dict[str, Any]:
         "airline": leg.airline,
         "flight_number": leg.flight_number,
     }
+    if leg.aircraft:
+        result["aircraft"] = leg.aircraft
+    if leg.legroom:
+        result["legroom"] = leg.legroom
+    if leg.codeshares:
+        result["codeshares"] = leg.codeshares
+    if leg.wifi is not None:
+        result["wifi"] = leg.wifi
+    if leg.power is not None:
+        result["power"] = leg.power
+    if leg.in_seat_entertainment is not None:
+        result["in_seat_entertainment"] = leg.in_seat_entertainment
+    return result
+
+
+def _serialize_emissions(emissions: Any) -> dict[str, Any] | None:
+    """Serialize emissions data to a dictionary."""
+    if emissions is None:
+        return None
+    result: dict[str, Any] = {}
+    if emissions.co2_grams is not None:
+        result["co2_grams"] = emissions.co2_grams
+    if emissions.typical_co2_grams is not None:
+        result["typical_co2_grams"] = emissions.typical_co2_grams
+    if emissions.diff_percent is not None:
+        result["diff_percent"] = emissions.diff_percent
+    return result or None
 
 
 def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[str, Any]:
     """Serialize a flight result (or round-trip pair) to a dictionary."""
     if is_round_trip and isinstance(flight, tuple):
         outbound, return_flight = flight
-        return {
-            # Google Flights returns the full round-trip price on the outbound leg
+        result: dict[str, Any] = {
             "price": outbound.price,
             "currency": CONFIG.default_currency,
             "legs": [
@@ -305,12 +331,20 @@ def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[s
                 *[_serialize_flight_leg(leg) for leg in return_flight.legs],
             ],
         }
+        emissions = _serialize_emissions(outbound.emissions)
+        if emissions:
+            result["emissions"] = emissions
+        return result
     else:
-        return {
+        result = {
             "price": flight.price,
             "currency": CONFIG.default_currency,
             "legs": [_serialize_flight_leg(leg) for leg in flight.legs],
         }
+        emissions = _serialize_emissions(flight.emissions)
+        if emissions:
+            result["emissions"] = emissions
+        return result
 
 
 def _serialize_date_result(date_result: Any) -> dict[str, Any]:

--- a/fli/models/google_flights/__init__.py
+++ b/fli/models/google_flights/__init__.py
@@ -1,4 +1,5 @@
 from .base import (
+    Emissions,
     FlightLeg,
     FlightResult,
     FlightSegment,
@@ -18,6 +19,7 @@ __all__ = [
     "Airline",
     "Airport",
     "DateSearchFilters",
+    "Emissions",
     "FlightLeg",
     "FlightResult",
     "FlightSearchFilters",

--- a/fli/models/google_flights/base.py
+++ b/fli/models/google_flights/base.py
@@ -131,6 +131,20 @@ class FlightLeg(BaseModel):
     departure_datetime: datetime
     arrival_datetime: datetime
     duration: PositiveInt  # in minutes
+    aircraft: str | None = None
+    legroom: str | None = None
+    codeshares: list[dict[str, str]] | None = None
+    wifi: bool | None = None
+    power: bool | None = None
+    in_seat_entertainment: bool | None = None
+
+
+class Emissions(BaseModel):
+    """CO2 emissions data for a flight itinerary."""
+
+    co2_grams: int | None = None
+    typical_co2_grams: int | None = None
+    diff_percent: int | None = None
 
 
 class FlightResult(BaseModel):
@@ -140,6 +154,7 @@ class FlightResult(BaseModel):
     price: NonNegativeFloat  # in specified currency
     duration: PositiveInt  # total duration in minutes
     stops: NonNegativeInt
+    emissions: Emissions | None = None
 
 
 class FlightSegment(BaseModel):

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -167,14 +167,15 @@ class SearchFlights:
         try:
             if len(fl) > 12 and isinstance(fl[12], list):
                 amenities = fl[12]
-                details["wifi"] = bool(amenities[1]) if len(amenities) > 1 and amenities[1] is not None else None
-                has_ac = len(amenities) > 11 and amenities[11] is not None and amenities[11] >= 3
-                has_usb = len(amenities) > 11 and amenities[11] is not None and amenities[11] >= 2
-                if has_ac or has_usb:
-                    details["power"] = True
-                has_seatback = len(amenities) > 9 and amenities[9] is not None and bool(amenities[9])
-                if has_seatback:
-                    details["in_seat_entertainment"] = True
+                details["wifi"] = (
+                    bool(amenities[1])
+                    if len(amenities) > 1 and amenities[1] is not None
+                    else None
+                )
+                if len(amenities) > 11 and amenities[11] is not None:
+                    details["power"] = amenities[11] >= 2
+                if len(amenities) > 9 and amenities[9] is not None:
+                    details["in_seat_entertainment"] = bool(amenities[9])
         except (IndexError, TypeError):
             pass
 

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -15,7 +15,7 @@ from fli.models import (
     FlightResult,
     FlightSearchFilters,
 )
-from fli.models.google_flights.base import TripType
+from fli.models.google_flights.base import Emissions, TripType
 from fli.search.client import get_client
 
 
@@ -122,11 +122,98 @@ class SearchFlights:
                     departure_datetime=SearchFlights._parse_datetime(fl[20], fl[8]),
                     arrival_datetime=SearchFlights._parse_datetime(fl[21], fl[10]),
                     duration=fl[11],
+                    **SearchFlights._parse_leg_details(fl),
                 )
                 for fl in data[0][2]
             ],
+            emissions=SearchFlights._parse_emissions(data),
         )
         return flight
+
+    @staticmethod
+    def _parse_leg_details(fl: list) -> dict:
+        """Extract aircraft, legroom, codeshares, and amenities from a raw leg.
+
+        Args:
+            fl: Raw leg data array from the API response
+
+        Returns:
+            Dict of optional fields for FlightLeg construction
+
+        """
+        details: dict = {}
+        try:
+            if len(fl) > 17 and isinstance(fl[17], str):
+                details["aircraft"] = fl[17]
+        except (IndexError, TypeError):
+            pass
+
+        try:
+            if len(fl) > 14 and isinstance(fl[14], str):
+                details["legroom"] = fl[14]
+        except (IndexError, TypeError):
+            pass
+
+        try:
+            if len(fl) > 15 and isinstance(fl[15], list):
+                details["codeshares"] = [
+                    {"airline": cs[0], "flight_number": cs[1]}
+                    for cs in fl[15]
+                    if isinstance(cs, list) and len(cs) >= 2
+                ]
+        except (IndexError, TypeError):
+            pass
+
+        try:
+            if len(fl) > 12 and isinstance(fl[12], list):
+                amenities = fl[12]
+                details["wifi"] = bool(amenities[1]) if len(amenities) > 1 and amenities[1] is not None else None
+                has_ac = len(amenities) > 11 and amenities[11] is not None and amenities[11] >= 3
+                has_usb = len(amenities) > 11 and amenities[11] is not None and amenities[11] >= 2
+                if has_ac or has_usb:
+                    details["power"] = True
+                has_seatback = len(amenities) > 9 and amenities[9] is not None and bool(amenities[9])
+                if has_seatback:
+                    details["in_seat_entertainment"] = True
+        except (IndexError, TypeError):
+            pass
+
+        return details
+
+    @staticmethod
+    def _parse_emissions(data: list) -> Emissions | None:
+        """Extract CO2 emissions data from the itinerary-level response.
+
+        The emissions block sits after the legs summary in the itinerary array
+        and contains CO2 grams, typical route average, and a percentage diff.
+
+        Args:
+            data: Raw itinerary data from the API response
+
+        Returns:
+            Emissions object if data is available, otherwise None
+
+        """
+        try:
+            info = data[0]
+            emissions_block = info[18] if len(info) > 18 else None
+            if not isinstance(emissions_block, list) or len(emissions_block) < 11:
+                return None
+
+            co2 = emissions_block[7] if isinstance(emissions_block[7], int) else None
+            typical = emissions_block[8] if isinstance(emissions_block[8], int) else None
+            diff_pct = emissions_block[3] if isinstance(emissions_block[3], int) else None
+
+            if co2 is None and typical is None:
+                return None
+
+            return Emissions(
+                co2_grams=co2,
+                typical_co2_grams=typical,
+                diff_percent=diff_pct,
+            )
+        except (IndexError, TypeError):
+            return None
 
     @staticmethod
     def _parse_price(data: list) -> float:


### PR DESCRIPTION
## Summary

- **Per-leg details**: Parse and return `aircraft` (e.g. "Boeing 777"), `legroom` (e.g. "31 in"), `codeshares` (e.g. `[{"airline": "DL", "flight_number": "8747"}]`), and onboard amenities (`wifi`, `power`, `in_seat_entertainment`) from the raw Google Flights API response.
- **Itinerary-level emissions**: Extract and return CO2 emissions data (`co2_grams`, `typical_co2_grams`, `diff_percent`) when available.
- **Backward compatible**: All new fields are optional (`None` by default) and only included in the MCP JSON output when present, so existing consumers see no change.

### Files changed

| File | What |
|------|------|
| `fli/models/google_flights/base.py` | New `Emissions` model; added optional fields to `FlightLeg` and `FlightResult` |
| `fli/models/google_flights/__init__.py` | Export `Emissions` |
| `fli/search/flights.py` | `_parse_leg_details()` and `_parse_emissions()` static methods to extract new data from raw API arrays |
| `fli/mcp/server.py` | `_serialize_emissions()` helper; updated leg and result serializers to conditionally include new fields |

### Mapping from raw Google Flights data

| Index | Field | Example |
|-------|-------|---------|
| `fl[17]` | Aircraft type | `"Boeing 777"` |
| `fl[14]` | Legroom | `"31 in"` |
| `fl[15]` | Codeshare partners | `[["DL","8747",null,"Delta"]]` |
| `fl[12][1]` | Wi-Fi | `true` |
| `fl[12][11]` | Power (USB/AC) | `3` (AC+USB) |
| `fl[12][9]` | Seatback entertainment | `true` |
| `data[0][18][7/8/3]` | CO2 grams / typical / diff% | `329000 / 369000 / -11` |

## Test plan

- [x] All 125 existing tests pass (1 pre-existing flaky timeout on `test_complex_round_trip_search` — unrelated network issue)
- [ ] Verify new fields appear in MCP output for a live one-way search (e.g. CDG→JFK)
- [ ] Confirm fields are omitted when Google Flights doesn't return them (e.g. some budget carriers)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches flight search results with per-leg details (aircraft type, legroom, codeshares, Wi-Fi/power/entertainment amenities) and itinerary-level CO₂ emissions data, all surfaced as optional fields so existing consumers are unaffected.

- New `Emissions` Pydantic model and optional fields on `FlightLeg`/`FlightResult` are clean and backward-compatible.
- `_parse_leg_details()` defensively handles missing/malformed API array entries.
- `power` and `in_seat_entertainment` are typed `bool | None` in the model but only ever assigned `True` by the parser — `False` is never produced, making it impossible to distinguish "API reported no power" from "API didn't return the field."
- For round-trip results, `return_flight.emissions` is silently discarded; only the outbound leg's CO₂ data appears in the serialised output.
- One line in `_parse_leg_details` (~110 chars) exceeds the project's configured 100-character limit and will fail `make lint`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; all findings are P2 quality/design suggestions with no production breakage.
- No P0 or P1 issues found. The `power`/`in_seat_entertainment` boolean asymmetry and the round-trip emissions omission are design inconsistencies worth addressing but neither breaks existing behaviour, corrupts data, nor fails existing tests. The line-length violation is a style issue. All new fields are optional and the change is fully backward-compatible.
- fli/search/flights.py (boolean semantics + line length) and fli/mcp/server.py (round-trip emissions handling)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/search/flights.py | Adds `_parse_leg_details()` and `_parse_emissions()` static methods; `power`/`in_seat_entertainment` are never set to `False` (type mismatch vs model), and a line exceeds the 100-char style limit. |
| fli/mcp/server.py | Adds `_serialize_emissions()` and conditionally includes new fields in leg/result serializers; round-trip return-leg emissions are silently discarded. |
| fli/models/google_flights/base.py | Adds optional fields to `FlightLeg` and new `Emissions` model; clean, backward-compatible Pydantic changes. |
| fli/models/google_flights/__init__.py | Exports the new `Emissions` model; trivial, correct change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller (MCP / CLI)
    participant S as SearchFlights
    participant A as Google Flights API

    C->>S: search(filters)
    S->>A: POST GetShoppingResults
    A-->>S: raw JSON (data[])
    loop for each flight in data[2/3]
        S->>S: _parse_flights_data(data)
        S->>S: _parse_leg_details(fl) → aircraft, legroom, codeshares, wifi, power, ent.
        S->>S: _parse_emissions(data) → Emissions(co2_grams, typical, diff%)
        S-->>S: FlightResult(legs=[FlightLeg(...)], emissions=...)
    end
    S-->>C: list[FlightResult]
    C->>C: _serialize_flight_result(flight)
    Note over C: round-trip: only outbound.emissions serialised
    C-->>C: dict with optional aircraft/legroom/codeshares/amenities/emissions
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/search/flights.py
Line: 171-177

Comment:
**`power` and `in_seat_entertainment` only ever set to `True`**

Both fields are typed `bool | None` in the model, but the parsing logic never assigns `False` — only `True` or nothing (defaulting to `None`). This means consumers cannot distinguish "the API explicitly reported no power" from "the API didn't return power data at all", and any code doing `if leg.power is False:` will never be reached.

`wifi` is handled correctly (assigned `bool(amenities[1])`, which can be `False`), but `power` and `in_seat_entertainment` are only set when their condition is truthy. Either:
- Set them explicitly to `False` when the amenities block is present but the feature is absent, mirroring `wifi`'s behaviour; or
- Keep `None` as the "no data" sentinel and document that `False` is unused.

```suggestion
                amenities = fl[12]
                details["wifi"] = bool(amenities[1]) if len(amenities) > 1 and amenities[1] is not None else None
                if len(amenities) > 11 and amenities[11] is not None:
                    details["power"] = amenities[11] >= 2
                if len(amenities) > 9 and amenities[9] is not None:
                    details["in_seat_entertainment"] = bool(amenities[9])
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 334-336

Comment:
**Return-leg emissions silently dropped for round trips**

For round-trip results, only `outbound.emissions` is serialised. The `return_flight.emissions` (a separate itinerary with its own `data[0][18]` block from the second API call) is never surfaced, so consumers always see the outbound leg's CO₂ data only.

This may be intentional (e.g. show only the first leg's data), but it's worth being explicit. If the intent is to represent the total trip, consider including both:

```python
outbound_emissions = _serialize_emissions(outbound.emissions)
if outbound_emissions:
    result["outbound_emissions"] = outbound_emissions
return_emissions = _serialize_emissions(return_flight.emissions)
if return_emissions:
    result["return_emissions"] = return_emissions
```

Or, if only one is desired, add a comment explaining why.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/search/flights.py
Line: 170

Comment:
**Line exceeds 100-character limit**

Per the project's Ruff configuration (100-char line length), this line is ~110 characters and will fail `make lint`.

```suggestion
                details["wifi"] = (
                    bool(amenities[1]) if len(amenities) > 1 and amenities[1] is not None else None
                )
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: expose aircraft, legroom, amenitie..."](https://github.com/punitarani/fli/commit/97f6fb5a1d4f8d7f50389226b93adaad152f3ff5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26822937)</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=90a8ba16-9510-4f10-b2ad-cb22d0733792))

<!-- /greptile_comment -->