### PR TITLE
fix: strip underscore prefix from digit-starting codes in all serialization paths

### DIFF
--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -171,7 +171,7 @@ def serialize_airport(airport: Airport) -> dict[str, str]:
 
 def serialize_airline(airline: Airline) -> dict[str, str]:
     """Serialize an airline for machine-readable output."""
-    return {"code": airline.name, "name": airline.value}
+    return {"code": airline.name.removeprefix("_"), "name": airline.value}
 
 
 def serialize_flight_leg(leg: Any) -> dict[str, Any]:

--- a/fli/models/google_flights/dates.py
+++ b/fli/models/google_flights/dates.py
@@ -147,7 +147,7 @@ class DateSearchFilters(BaseModel):
 
         def serialize(obj):
             if isinstance(obj, Airport) or isinstance(obj, Airline):
-                return obj.name
+                return obj.name.removeprefix("_")
             if isinstance(obj, Enum):
                 return obj.value
             if isinstance(obj, list):

--- a/fli/models/google_flights/flights.py
+++ b/fli/models/google_flights/flights.py
@@ -55,7 +55,7 @@ class FlightSearchFilters(BaseModel):
 
         def serialize(obj):
             if isinstance(obj, Airport) or isinstance(obj, Airline):
-                return obj.name
+                return obj.name.removeprefix("_")
             if isinstance(obj, Enum):
                 return obj.value
             if isinstance(obj, list):
@@ -118,11 +118,11 @@ class FlightSearchFilters(BaseModel):
             if is_multi_leg and segment.selected_flight is not None:
                 selected_flights = [
                     [
-                        serialize(leg.departure_airport.name),
+                        serialize(leg.departure_airport),
                         serialize(leg.departure_datetime.strftime("%Y-%m-%d")),
-                        serialize(leg.arrival_airport.name),
+                        serialize(leg.arrival_airport),
                         None,
-                        serialize(leg.airline.name),
+                        serialize(leg.airline),
                         serialize(leg.flight_number),
                     ]
                     for leg in segment.selected_flight.legs

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -15,6 +15,7 @@ from fli.cli.utils import (
     filter_flights_by_time,
     parse_airlines,
     parse_stops,
+    serialize_airline,
     serialize_date_result,
     serialize_flight_result,
     validate_date,
@@ -113,6 +114,13 @@ def test_parse_airlines_numeric_prefix():
     """Test that airline codes starting with a digit are resolved correctly."""
     result = parse_airlines(["3F"])
     assert result == [Airline._3F]
+
+
+def test_serialize_airline_numeric_prefix():
+    """Test that serialized airline code strips underscore prefix."""
+    result = serialize_airline(Airline._3F)
+    assert result["code"] == "3F"
+    assert result["name"] == "FlyOne Armenia"
 
 
 def test_parse_airlines_invalid():


### PR DESCRIPTION
## Summary

Follow-up to #90 (merged). Addresses the serialization gap flagged
by @punitarani in the [review comment](https://github.com/punitarani/fli/pull/90#issuecomment-2769073653) —
digit-prefixed airline codes like `_3F` were still leaking into API
requests and CLI output through paths not covered by the first PR.

## Changes

- **`removeprefix("_")`** in `flights.py` and `dates.py` `serialize()`
  functions — strip the synthetic underscore before sending codes to
  Google Flights API
- **`serialize_airline()`** in `cli/utils.py` — same fix for CLI JSON output
- **Round-trip `selected_flight`** in `flights.py` — pass enum objects
  (`leg.airline`, `leg.departure_airport`, `leg.arrival_airport`) to
  `serialize()` instead of pre-resolving `.name`, which bypassed the
  `isinstance` check and leaked `_3F` into the request payload
- **Test** for `serialize_airline()` with numeric-prefix code

## Why `removeprefix` over `lstrip`

`lstrip("_")` would strip all leading underscores (`__3F` → `3F`).
`removeprefix("_")` removes exactly one — matching the single underscore
added by `generate_enums.py` for digit-starting IATA codes.

## Test plan

- [x] `serialize_airline(Airline._3F)` returns `{"code": "3F", "name": "FlyOne Armenia"}`
- [x] All 6 airline-related tests pass
- [x] No regressions in existing tests

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the fix for digit-prefixed IATA airline codes (e.g., `_3F`) leaking out of serialization paths, following up on #90. It applies `removeprefix(\"_\")` in the two Google Flights API serializers (`FlightSearchFilters` and `DateSearchFilters`), in the CLI JSON output helper (`serialize_airline`), and — critically — fixes the `selected_flight` round-trip block in `flights.py` that was passing `.name` strings directly to `serialize()`, bypassing the `isinstance(obj, Airline)` branch entirely.

- **`fli/models/google_flights/flights.py`**: `removeprefix(\"_\")` added to `serialize()`, plus `leg.departure_airport`, `leg.arrival_airport`, and `leg.airline` now passed as enum objects (not pre-resolved `.name` strings) in the `selected_flights` builder — this was the root cause of the payload leak.
- **`fli/models/google_flights/dates.py`**: Same `removeprefix(\"_\")` fix applied to the parallel `serialize()` in `DateSearchFilters.format()`.
- **`fli/cli/utils.py`**: `serialize_airline()` now strips the underscore from the `code` key in CLI JSON output.
- **`tests/cli/test_utils.py`**: New `test_serialize_airline_numeric_prefix` test verifies `Airline._3F` → `{\"code\": \"3F\", \"name\": \"FlyOne Armenia\"}`.
- **Minor inconsistency**: `fli/mcp/server.py` line 294 still uses `lstrip(\"_\")` for `airline_code`, which differs from the `removeprefix(\"_\")` approach used everywhere else after this PR. This is a pre-existing gap not introduced here, but worth aligning.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all serialization paths that send data to the Google Flights API or emit CLI/JSON output are correctly fixed.

All changed code is correct. The critical root-cause fix (passing enum objects instead of pre-resolved `.name` strings in the `selected_flights` block) is sound. The only remaining gap is a pre-existing `lstrip("_")` in the MCP server that is not introduced by this PR and is P2 only.

fli/mcp/server.py line 294 — pre-existing `lstrip("_")` inconsistency worth aligning with the `removeprefix("_")` approach used everywhere else after this PR.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| fli/models/google_flights/flights.py | Two fixes: `removeprefix("_")` in `serialize()` for Airport/Airline enums, and passing enum objects (not `.name` strings) to `serialize()` in the `selected_flights` block — closing the bypass of the isinstance check that leaked `_3F` into API payloads. |
| fli/models/google_flights/dates.py | Same `removeprefix("_")` fix applied to the parallel `serialize()` function inside `DateSearchFilters.format()`; no selected-flight block in this model so no further changes needed. |
| fli/cli/utils.py | `serialize_airline()` updated to strip the synthetic underscore from the `code` key in CLI JSON output; `serialize_airport()` is unchanged (correct, as Airport has no digit-starting codes). |
| tests/cli/test_utils.py | New `test_serialize_airline_numeric_prefix` test verifies that `Airline._3F` round-trips to `{"code": "3F", "name": "FlyOne Armenia"}` via `serialize_airline()`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Serializer
    participant GoogleFlightsAPI

    Note over User,GoogleFlightsAPI: Before PR — digit-prefix leak
    User->>Serializer: leg.airline.name passes string "_3F"
    Note over Serializer: No isinstance match, falls through
    Serializer->>GoogleFlightsAPI: payload contains "_3F" (incorrect)

    Note over User,GoogleFlightsAPI: After PR — correct round-trip
    User->>Serializer: leg.airline passes Airline enum object
    Note over Serializer: isinstance(obj, Airline) matches
    Serializer->>GoogleFlightsAPI: obj.name.removeprefix returns "3F" (correct)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `fli/mcp/server.py`, line 294 ([link](https://github.com/punitarani/fli/blob/8b97c11953d6085c04dd6273d663923e12ef1402/fli/mcp/server.py#L294)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inconsistent strip method vs. the rest of the codebase**

   The MCP server still uses `lstrip("_")` here, while every other serialization path in this PR (and the PR description itself) explicitly prefers `removeprefix("_")` — because `lstrip("_")` would strip *all* leading underscores (e.g., a hypothetical `__3F` → `3F`), whereas `removeprefix("_")` removes exactly the one underscore added by `generate_enums.py`.

   For parity with the rest of the codebase after this PR:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: fli/mcp/server.py
   Line: 294

   Comment:
   **Inconsistent strip method vs. the rest of the codebase**

   The MCP server still uses `lstrip("_")` here, while every other serialization path in this PR (and the PR description itself) explicitly prefers `removeprefix("_")` — because `lstrip("_")` would strip *all* leading underscores (e.g., a hypothetical `__3F` → `3F`), whereas `removeprefix("_")` removes exactly the one underscore added by `generate_enums.py`.

   For parity with the rest of the codebase after this PR:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 294

Comment:
**Inconsistent strip method vs. the rest of the codebase**

The MCP server still uses `lstrip("_")` here, while every other serialization path in this PR (and the PR description itself) explicitly prefers `removeprefix("_")` — because `lstrip("_")` would strip *all* leading underscores (e.g., a hypothetical `__3F` → `3F`), whereas `removeprefix("_")` removes exactly the one underscore added by `generate_enums.py`.

For parity with the rest of the codebase after this PR:

```suggestion
        "airline_code": getattr(leg.airline, "name", str(leg.airline)).removeprefix("_"),
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: strip underscore prefix from digit-..."](https://github.com/punitarani/fli/commit/8b97c11953d6085c04dd6273d663923e12ef1402) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26866316)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->