### PR TITLE
Add passenger count options to CLI and MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ The MCP server provides two main tools:
 | `airlines`         | list   | Filter by airline codes (e.g., ['BA', 'AA'])        |
 | `sort_by`          | string | CHEAPEST, DURATION, DEPARTURE_TIME, or ARRIVAL_TIME |
 | `passengers`       | int    | Number of adult passengers                          |
+| `children`         | int    | Number of child passengers                          |
+| `infants_in_seat`  | int    | Number of infants traveling in their own seat       |
+| `infants_on_lap`   | int    | Number of lap infants                               |
 
 #### `search_dates` Parameters
 
@@ -82,6 +85,9 @@ The MCP server provides two main tools:
 | `airlines`         | list   | Filter by airline codes (e.g., ['BA', 'AA']) |
 | `sort_by_price`    | bool   | Sort results by price (lowest first)         |
 | `passengers`       | int    | Number of adult passengers                   |
+| `children`         | int    | Number of child passengers                   |
+| `infants_in_seat`  | int    | Number of infants traveling in their own seat |
+| `infants_on_lap`   | int    | Number of lap infants                        |
 
 ## Quick Start
 
@@ -185,6 +191,9 @@ fli dates JFK LHR \
 | `--class, -c`    | Cabin class           | `ECONOMY`, `BUSINESS`  |
 | `--stops, -s`    | Maximum stops         | `NON_STOP`, `ONE_STOP` |
 | `--sort, -o`     | Sort results by       | `CHEAPEST`, `DURATION` |
+| `--children`     | Number of children    | `2`                    |
+| `--infants-in-seat` | Number of infants in seat | `1`             |
+| `--infants-on-lap` | Number of infants on lap | `1`               |
 | `--format`       | Output format         | `text`, `json`         |
 
 #### Dates Command (`fli dates`)
@@ -200,6 +209,9 @@ fli dates JFK LHR \
 | `--stops, -s`      | Maximum stops          | `NON_STOP`, `ONE_STOP` |
 | `--time`           | Departure time window  | `6-20`                 |
 | `--sort`           | Sort by price          | (flag)                 |
+| `--children`       | Number of children     | `2`                    |
+| `--infants-in-seat` | Number of infants in seat | `1`                |
+| `--infants-on-lap` | Number of infants on lap | `1`                  |
 | `--[day]`          | Day filters            | `--monday`, `--friday` |
 | `--format`         | Output format          | `text`, `json`         |
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ fli dates JFK LHR \
 | `--class, -c`    | Cabin class           | `ECONOMY`, `BUSINESS`  |
 | `--stops, -s`    | Maximum stops         | `NON_STOP`, `ONE_STOP` |
 | `--sort, -o`     | Sort results by       | `CHEAPEST`, `DURATION` |
+| `--passengers`   | Number of adult passengers | `2`               |
 | `--children`     | Number of children    | `2`                    |
 | `--infants-in-seat` | Number of infants in seat | `1`             |
 | `--infants-on-lap` | Number of infants on lap | `1`               |
@@ -209,6 +210,7 @@ fli dates JFK LHR \
 | `--stops, -s`      | Maximum stops          | `NON_STOP`, `ONE_STOP` |
 | `--time`           | Departure time window  | `6-20`                 |
 | `--sort`           | Sort by price          | (flag)                 |
+| `--passengers`     | Number of adult passengers | `2`                |
 | `--children`       | Number of children     | `2`                    |
 | `--infants-in-seat` | Number of infants in seat | `1`                |
 | `--infants-on-lap` | Number of infants on lap | `1`                  |

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -88,6 +88,13 @@ Type of trip for flight search.
 
 Configuration for passenger counts.
 
+Fields:
+
+- `adults`
+- `children`
+- `infants_in_seat`
+- `infants_on_lap`
+
 ::: fli.models.google_flights.PassengerInfo
 
 ### TimeRestrictions

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -35,6 +35,7 @@ filters = FlightSearchFilters(
     passenger_info=PassengerInfo(
         adults=2,
         children=1,
+        infants_in_seat=1,
         infants_on_lap=1
     ),
     flight_segments=[
@@ -280,6 +281,7 @@ filters = FlightSearchFilters(
     passenger_info=PassengerInfo(
         adults=2,
         children=1,
+        infants_in_seat=1,
         infants_on_lap=1
     ),
     flight_segments=[outbound, return_flight],

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -78,6 +78,9 @@ Search for flights between two airports on a specific date.
 | `airlines` | list | No | null | Filter by airline codes (e.g., ['BA', 'AA']) |
 | `sort_by` | string | No | CHEAPEST | CHEAPEST, DURATION, DEPARTURE_TIME, or ARRIVAL_TIME |
 | `passengers` | int | No | 1 | Number of adult passengers |
+| `children` | int | No | 0 | Number of child passengers |
+| `infants_in_seat` | int | No | 0 | Number of infants traveling in their own seat |
+| `infants_on_lap` | int | No | 0 | Number of lap infants |
 
 **Example Response:**
 
@@ -126,6 +129,9 @@ Find the cheapest travel dates between two airports within a date range.
 | `airlines` | list | No | null | Filter by airline codes (e.g., ['BA', 'AA']) |
 | `sort_by_price` | bool | No | false | Sort results by price (lowest first) |
 | `passengers` | int | No | 1 | Number of adult passengers |
+| `children` | int | No | 0 | Number of child passengers |
+| `infants_in_seat` | int | No | 0 | Number of infants traveling in their own seat |
+| `infants_on_lap` | int | No | 0 | Number of lap infants |
 
 **Example Response:**
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -211,7 +211,7 @@ from fli.models import PassengerInfo
 PassengerInfo(adults=1)
 
 # Family with children
-PassengerInfo(adults=2, children=2, infants_on_lap=1)
+PassengerInfo(adults=2, children=2, infants_in_seat=1, infants_on_lap=1)
 ```
 
 ## Support

--- a/examples/complex_flight_search.py
+++ b/examples/complex_flight_search.py
@@ -25,7 +25,12 @@ def main():
     # Create detailed filters
     filters = FlightSearchFilters(
         trip_type=TripType.ONE_WAY,
-        passenger_info=PassengerInfo(adults=2, children=1, infants_on_lap=1),
+        passenger_info=PassengerInfo(
+            adults=2,
+            children=1,
+            infants_in_seat=1,
+            infants_on_lap=1,
+        ),
         flight_segments=[
             FlightSegment(
                 departure_airport=[[Airport.JFK, 0]],

--- a/examples/complex_round_trip_validation.py
+++ b/examples/complex_round_trip_validation.py
@@ -80,7 +80,12 @@ def main():
     # Create filters with complex requirements
     filters = FlightSearchFilters(
         trip_type=TripType.ROUND_TRIP,
-        passenger_info=PassengerInfo(adults=2, children=1, infants_on_lap=1),
+        passenger_info=PassengerInfo(
+            adults=2,
+            children=1,
+            infants_in_seat=1,
+            infants_on_lap=1,
+        ),
         flight_segments=[outbound, return_flight],
         stops=MaxStops.ONE_STOP_OR_FEWER,
         seat_type=SeatType.BUSINESS,

--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -80,6 +80,27 @@ def dates(
             help="Trip duration in days",
         ),
     ] = 3,
+    children: Annotated[
+        int,
+        typer.Option(
+            "--children",
+            help="Number of children",
+        ),
+    ] = 0,
+    infants_in_seat: Annotated[
+        int,
+        typer.Option(
+            "--infants-in-seat",
+            help="Number of infants in seat",
+        ),
+    ] = 0,
+    infants_on_lap: Annotated[
+        int,
+        typer.Option(
+            "--infants-on-lap",
+            help="Number of infants on lap",
+        ),
+    ] = 0,
     airlines: Annotated[
         list[str] | None,
         typer.Option(
@@ -226,6 +247,9 @@ def dates(
             "end_date": end_date,
             "trip_duration": trip_duration,
             "is_round_trip": is_round_trip,
+            "children": children,
+            "infants_in_seat": infants_in_seat,
+            "infants_on_lap": infants_on_lap,
             "cabin_class": seat_type.name,
             "max_stops": stops.name,
             "departure_window": (
@@ -260,7 +284,12 @@ def dates(
         # Create search filters
         filters = DateSearchFilters(
             trip_type=trip_type,
-            passenger_info=PassengerInfo(adults=1),
+            passenger_info=PassengerInfo(
+                adults=1,
+                children=children,
+                infants_in_seat=infants_in_seat,
+                infants_on_lap=infants_on_lap,
+            ),
             flight_segments=segments,
             stops=stops,
             seat_type=seat_type,
@@ -320,6 +349,9 @@ def dates(
                         "end_date": end_date,
                         "trip_duration": trip_duration,
                         "is_round_trip": is_round_trip,
+                        "children": children,
+                        "infants_in_seat": infants_in_seat,
+                        "infants_on_lap": infants_on_lap,
                         "cabin_class": cabin_class,
                         "max_stops": max_stops,
                         "departure_window": (

--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -80,11 +80,20 @@ def dates(
             help="Trip duration in days",
         ),
     ] = 3,
+    passengers: Annotated[
+        int,
+        typer.Option(
+            "--passengers",
+            help="Number of adult passengers",
+            min=1,
+        ),
+    ] = 1,
     children: Annotated[
         int,
         typer.Option(
             "--children",
             help="Number of children",
+            min=0,
         ),
     ] = 0,
     infants_in_seat: Annotated[
@@ -92,6 +101,7 @@ def dates(
         typer.Option(
             "--infants-in-seat",
             help="Number of infants in seat",
+            min=0,
         ),
     ] = 0,
     infants_on_lap: Annotated[
@@ -99,6 +109,7 @@ def dates(
         typer.Option(
             "--infants-on-lap",
             help="Number of infants on lap",
+            min=0,
         ),
     ] = 0,
     airlines: Annotated[
@@ -247,6 +258,7 @@ def dates(
             "end_date": end_date,
             "trip_duration": trip_duration,
             "is_round_trip": is_round_trip,
+            "passengers": passengers,
             "children": children,
             "infants_in_seat": infants_in_seat,
             "infants_on_lap": infants_on_lap,
@@ -285,7 +297,7 @@ def dates(
         filters = DateSearchFilters(
             trip_type=trip_type,
             passenger_info=PassengerInfo(
-                adults=1,
+                adults=passengers,
                 children=children,
                 infants_in_seat=infants_in_seat,
                 infants_on_lap=infants_on_lap,
@@ -349,6 +361,7 @@ def dates(
                         "end_date": end_date,
                         "trip_duration": trip_duration,
                         "is_round_trip": is_round_trip,
+                        "passengers": passengers,
                         "children": children,
                         "infants_in_seat": infants_in_seat,
                         "infants_on_lap": infants_on_lap,

--- a/fli/cli/commands/flights.py
+++ b/fli/cli/commands/flights.py
@@ -36,6 +36,9 @@ def _search_flights_core(
     departure_date: str,
     return_date: str | None = None,
     departure_window: str | tuple[int, int] | None = None,
+    children: int = 0,
+    infants_in_seat: int = 0,
+    infants_on_lap: int = 0,
     airlines: list[str] | None = None,
     cabin_class: str = "ECONOMY",
     max_stops: str = "ANY",
@@ -50,6 +53,9 @@ def _search_flights_core(
         "departure_date": departure_date,
         "return_date": return_date,
         "departure_window": None,
+        "children": children,
+        "infants_in_seat": infants_in_seat,
+        "infants_on_lap": infants_on_lap,
         "airlines": [airline.upper() for airline in airlines] if airlines else None,
         "cabin_class": cabin_class.upper(),
         "max_stops": max_stops.upper(),
@@ -96,7 +102,12 @@ def _search_flights_core(
         # Create search filters
         filters = FlightSearchFilters(
             trip_type=trip_type,
-            passenger_info=PassengerInfo(adults=1),
+            passenger_info=PassengerInfo(
+                adults=1,
+                children=children,
+                infants_in_seat=infants_in_seat,
+                infants_on_lap=infants_on_lap,
+            ),
             flight_segments=segments,
             stops=stops,
             seat_type=seat_type,
@@ -188,6 +199,27 @@ def flights(
             help="Departure time window in 24h format (e.g., 6-20)",
         ),
     ] = None,
+    children: Annotated[
+        int,
+        typer.Option(
+            "--children",
+            help="Number of children",
+        ),
+    ] = 0,
+    infants_in_seat: Annotated[
+        int,
+        typer.Option(
+            "--infants-in-seat",
+            help="Number of infants in seat",
+        ),
+    ] = 0,
+    infants_on_lap: Annotated[
+        int,
+        typer.Option(
+            "--infants-on-lap",
+            help="Number of infants on lap",
+        ),
+    ] = 0,
     airlines: Annotated[
         list[str] | None,
         typer.Option(
@@ -251,6 +283,9 @@ def flights(
         departure_date=departure_date,
         return_date=return_date,
         departure_window=departure_window,
+        children=children,
+        infants_in_seat=infants_in_seat,
+        infants_on_lap=infants_on_lap,
         airlines=airlines,
         cabin_class=cabin_class,
         max_stops=max_stops,

--- a/fli/cli/commands/flights.py
+++ b/fli/cli/commands/flights.py
@@ -36,6 +36,7 @@ def _search_flights_core(
     departure_date: str,
     return_date: str | None = None,
     departure_window: str | tuple[int, int] | None = None,
+    passengers: int = 1,
     children: int = 0,
     infants_in_seat: int = 0,
     infants_on_lap: int = 0,
@@ -53,6 +54,7 @@ def _search_flights_core(
         "departure_date": departure_date,
         "return_date": return_date,
         "departure_window": None,
+        "passengers": passengers,
         "children": children,
         "infants_in_seat": infants_in_seat,
         "infants_on_lap": infants_on_lap,
@@ -103,7 +105,7 @@ def _search_flights_core(
         filters = FlightSearchFilters(
             trip_type=trip_type,
             passenger_info=PassengerInfo(
-                adults=1,
+                adults=passengers,
                 children=children,
                 infants_in_seat=infants_in_seat,
                 infants_on_lap=infants_on_lap,
@@ -199,11 +201,20 @@ def flights(
             help="Departure time window in 24h format (e.g., 6-20)",
         ),
     ] = None,
+    passengers: Annotated[
+        int,
+        typer.Option(
+            "--passengers",
+            help="Number of adult passengers",
+            min=1,
+        ),
+    ] = 1,
     children: Annotated[
         int,
         typer.Option(
             "--children",
             help="Number of children",
+            min=0,
         ),
     ] = 0,
     infants_in_seat: Annotated[
@@ -211,6 +222,7 @@ def flights(
         typer.Option(
             "--infants-in-seat",
             help="Number of infants in seat",
+            min=0,
         ),
     ] = 0,
     infants_on_lap: Annotated[
@@ -218,6 +230,7 @@ def flights(
         typer.Option(
             "--infants-on-lap",
             help="Number of infants on lap",
+            min=0,
         ),
     ] = 0,
     airlines: Annotated[
@@ -283,6 +296,7 @@ def flights(
         departure_date=departure_date,
         return_date=return_date,
         departure_window=departure_window,
+        passengers=passengers,
         children=children,
         infants_in_seat=infants_in_seat,
         infants_on_lap=infants_on_lap,

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -240,6 +240,9 @@ class FlightSearchParams(BaseModel):
         ge=1,
         description="Number of adult passengers",
     )
+    children: int = Field(0, ge=0, description="Number of children")
+    infants_in_seat: int = Field(0, ge=0, description="Number of infants in seat")
+    infants_on_lap: int = Field(0, ge=0, description="Number of infants on lap")
     exclude_basic_economy: bool = Field(
         False, description="Exclude basic economy fares from results"
     )
@@ -275,6 +278,9 @@ class DateSearchParams(BaseModel):
         ge=1,
         description="Number of adult passengers",
     )
+    children: int = Field(0, ge=0, description="Number of children")
+    infants_in_seat: int = Field(0, ge=0, description="Number of infants in seat")
+    infants_on_lap: int = Field(0, ge=0, description="Number of infants on lap")
 
 
 # =============================================================================
@@ -359,7 +365,12 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
         # Create search filters
         filters = FlightSearchFilters(
             trip_type=trip_type,
-            passenger_info=PassengerInfo(adults=params.passengers),
+            passenger_info=PassengerInfo(
+                adults=params.passengers,
+                children=params.children,
+                infants_in_seat=params.infants_in_seat,
+                infants_on_lap=params.infants_on_lap,
+            ),
             flight_segments=segments,
             stops=max_stops,
             seat_type=cabin_class,
@@ -425,7 +436,12 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
         # Create search filters
         filters = DateSearchFilters(
             trip_type=trip_type,
-            passenger_info=PassengerInfo(adults=params.passengers),
+            passenger_info=PassengerInfo(
+                adults=params.passengers,
+                children=params.children,
+                infants_in_seat=params.infants_in_seat,
+                infants_on_lap=params.infants_on_lap,
+            ),
             flight_segments=segments,
             stops=max_stops,
             seat_type=cabin_class,
@@ -516,6 +532,18 @@ def search_flights(
         int | None,
         Field(description="Number of adult passengers", ge=1),
     ] = None,
+    children: Annotated[
+        int,
+        Field(description="Number of children", ge=0),
+    ] = 0,
+    infants_in_seat: Annotated[
+        int,
+        Field(description="Number of infants in seat", ge=0),
+    ] = 0,
+    infants_on_lap: Annotated[
+        int,
+        Field(description="Number of infants on lap", ge=0),
+    ] = 0,
     exclude_basic_economy: Annotated[
         bool,
         Field(description="Exclude basic economy fares from results"),
@@ -538,6 +566,9 @@ def search_flights(
         max_stops=max_stops,
         sort_by=sort_by,
         passengers=passengers or CONFIG.default_passengers,
+        children=children,
+        infants_in_seat=infants_in_seat,
+        infants_on_lap=infants_on_lap,
         exclude_basic_economy=exclude_basic_economy,
     )
     return _execute_flight_search(params)
@@ -595,6 +626,18 @@ def search_dates(
         int | None,
         Field(description="Number of adult passengers", ge=1),
     ] = None,
+    children: Annotated[
+        int,
+        Field(description="Number of children", ge=0),
+    ] = 0,
+    infants_in_seat: Annotated[
+        int,
+        Field(description="Number of infants in seat", ge=0),
+    ] = 0,
+    infants_on_lap: Annotated[
+        int,
+        Field(description="Number of infants on lap", ge=0),
+    ] = 0,
 ) -> dict[str, Any]:
     """Find the cheapest travel dates between two airports within a date range.
 
@@ -615,6 +658,9 @@ def search_dates(
         departure_window=effective_departure_window,
         sort_by_price=sort_by_price,
         passengers=passengers or CONFIG.default_passengers,
+        children=children,
+        infants_in_seat=infants_in_seat,
+        infants_on_lap=infants_on_lap,
     )
     return _execute_date_search(params)
 

--- a/tests/cli/test_dates.py
+++ b/tests/cli/test_dates.py
@@ -135,6 +135,39 @@ def test_dates_with_time(runner, mock_search_dates, mock_console):
     mock_search_dates.search.assert_called_once()
 
 
+def test_dates_with_family_passenger_counts(runner, mock_search_dates, mock_console):
+    """Test dates search passes family passenger counts into filters."""
+    mock_search_dates.search.return_value = [
+        DatePrice(
+            date=(datetime.now() + timedelta(days=1),),
+            price=299.99,
+        ),
+    ]
+
+    result = runner.invoke(
+        app,
+        [
+            "dates",
+            "JFK",
+            "LAX",
+            "--children",
+            "2",
+            "--infants-in-seat",
+            "1",
+            "--infants-on-lap",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_search_dates.search.assert_called_once()
+    args, _ = mock_search_dates.search.call_args
+    assert args[0].passenger_info.adults == 1
+    assert args[0].passenger_info.children == 2
+    assert args[0].passenger_info.infants_in_seat == 1
+    assert args[0].passenger_info.infants_on_lap == 1
+
+
 def test_dates_with_sort(runner, mock_search_dates, mock_console):
     """Test dates search with sort option."""
     mock_search_dates.search.return_value = [

--- a/tests/cli/test_dates.py
+++ b/tests/cli/test_dates.py
@@ -150,6 +150,8 @@ def test_dates_with_family_passenger_counts(runner, mock_search_dates, mock_cons
             "dates",
             "JFK",
             "LAX",
+            "--passengers",
+            "2",
             "--children",
             "2",
             "--infants-in-seat",
@@ -162,7 +164,7 @@ def test_dates_with_family_passenger_counts(runner, mock_search_dates, mock_cons
     assert result.exit_code == 0
     mock_search_dates.search.assert_called_once()
     args, _ = mock_search_dates.search.call_args
-    assert args[0].passenger_info.adults == 1
+    assert args[0].passenger_info.adults == 2
     assert args[0].passenger_info.children == 2
     assert args[0].passenger_info.infants_in_seat == 1
     assert args[0].passenger_info.infants_on_lap == 1

--- a/tests/cli/test_flights.py
+++ b/tests/cli/test_flights.py
@@ -103,6 +103,8 @@ def test_flights_with_family_passenger_counts(runner, mock_search_flights, mock_
             "JFK",
             "LAX",
             datetime.now().strftime("%Y-%m-%d"),
+            "--passengers",
+            "2",
             "--children",
             "2",
             "--infants-in-seat",
@@ -115,7 +117,7 @@ def test_flights_with_family_passenger_counts(runner, mock_search_flights, mock_
     assert result.exit_code == 0
     mock_search_flights.search.assert_called_once()
     args, _ = mock_search_flights.search.call_args
-    assert args[0].passenger_info.adults == 1
+    assert args[0].passenger_info.adults == 2
     assert args[0].passenger_info.children == 2
     assert args[0].passenger_info.infants_in_seat == 1
     assert args[0].passenger_info.infants_on_lap == 1

--- a/tests/cli/test_flights.py
+++ b/tests/cli/test_flights.py
@@ -94,6 +94,33 @@ def test_flights_with_stops(runner, mock_search_flights, mock_console):
     mock_search_flights.search.assert_called_once()
 
 
+def test_flights_with_family_passenger_counts(runner, mock_search_flights, mock_console):
+    """Test flights search passes family passenger counts into filters."""
+    result = runner.invoke(
+        app,
+        [
+            "flights",
+            "JFK",
+            "LAX",
+            datetime.now().strftime("%Y-%m-%d"),
+            "--children",
+            "2",
+            "--infants-in-seat",
+            "1",
+            "--infants-on-lap",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_search_flights.search.assert_called_once()
+    args, _ = mock_search_flights.search.call_args
+    assert args[0].passenger_info.adults == 1
+    assert args[0].passenger_info.children == 2
+    assert args[0].passenger_info.infants_in_seat == 1
+    assert args[0].passenger_info.infants_on_lap == 1
+
+
 def test_flights_invalid_airport(runner, mock_search_flights, mock_console):
     """Test flights search with invalid airport code."""
     result = runner.invoke(

--- a/tests/mcp/test_mcp_server.py
+++ b/tests/mcp/test_mcp_server.py
@@ -1,6 +1,7 @@
 """Test MCP server functionality."""
 
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
 from fli.mcp.server import (
     DateSearchParams,
@@ -211,6 +212,53 @@ class TestMCPServer:
         assert "airline" in result["error"].lower()
         assert result["flights"] == []
 
+    def test_search_flights_passes_family_passenger_counts(self, monkeypatch):
+        """Test flight search tool passes family passenger counts into filters."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = []
+        monkeypatch.setattr("fli.mcp.server.SearchFlights", lambda: mock_client)
+
+        result = search_flights(
+            origin="JFK",
+            destination="LHR",
+            departure_date=get_future_date(30),
+            passengers=2,
+            children=1,
+            infants_in_seat=1,
+            infants_on_lap=1,
+        )
+
+        assert result["success"] is True
+        args, _ = mock_client.search.call_args
+        assert args[0].passenger_info.adults == 2
+        assert args[0].passenger_info.children == 1
+        assert args[0].passenger_info.infants_in_seat == 1
+        assert args[0].passenger_info.infants_on_lap == 1
+
+    def test_search_dates_passes_family_passenger_counts(self, monkeypatch):
+        """Test date search tool passes family passenger counts into filters."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = []
+        monkeypatch.setattr("fli.mcp.server.SearchDates", lambda: mock_client)
+
+        result = search_dates(
+            origin="JFK",
+            destination="LHR",
+            start_date=get_future_date(30),
+            end_date=get_future_date(60),
+            passengers=2,
+            children=1,
+            infants_in_seat=1,
+            infants_on_lap=1,
+        )
+
+        assert result["success"] is True
+        args, _ = mock_client.search.call_args
+        assert args[0].passenger_info.adults == 2
+        assert args[0].passenger_info.children == 1
+        assert args[0].passenger_info.infants_in_seat == 1
+        assert args[0].passenger_info.infants_on_lap == 1
+
     def test_flight_search_params_validation(self):
         """Test FlightSearchParams validation."""
         future_date = get_future_date(30)
@@ -221,6 +269,9 @@ class TestMCPServer:
         assert params.cabin_class == "ECONOMY"  # default
         assert params.max_stops == "ANY"  # default
         assert params.sort_by == "CHEAPEST"  # default
+        assert params.children == 0
+        assert params.infants_in_seat == 0
+        assert params.infants_on_lap == 0
 
     def test_date_search_params_validation(self):
         """Test DateSearchParams validation."""
@@ -241,3 +292,6 @@ class TestMCPServer:
         assert params.cabin_class == "ECONOMY"  # default
         assert params.max_stops == "ANY"  # default
         assert params.sort_by_price is False  # default
+        assert params.children == 0
+        assert params.infants_in_seat == 0
+        assert params.infants_on_lap == 0

--- a/tests/models/test_date_search_filters.py
+++ b/tests/models/test_date_search_filters.py
@@ -175,7 +175,7 @@ TEST_CASES = [
         "name": "Test 3: Flight Search Data",
         "search": DateSearchFilters(
             passenger_info=PassengerInfo(
-                adults=2,
+                adults=3,
                 children=3,
                 infants_in_seat=0,
                 infants_on_lap=1,
@@ -215,7 +215,7 @@ TEST_CASES = [
                 None,
                 [],
                 1,
-                [2, 3, 1, 0],
+                [3, 3, 1, 0],
                 [None, 900],
                 None,
                 None,

--- a/tests/models/test_flight_search_filters.py
+++ b/tests/models/test_flight_search_filters.py
@@ -190,7 +190,7 @@ TEST_CASES = [
         "name": "Test 3: Flight Search Data",
         "search": FlightSearchFilters(
             passenger_info=PassengerInfo(
-                adults=2,
+                adults=3,
                 children=3,
                 infants_in_seat=0,
                 infants_on_lap=1,
@@ -228,7 +228,7 @@ TEST_CASES = [
                 None,
                 [],
                 1,
-                [2, 3, 1, 0],
+                [3, 3, 1, 0],
                 [None, 900],
                 None,
                 None,


### PR DESCRIPTION
## Summary
- add `children`, `infants_in_seat`, and `infants_on_lap` options to the `fli flights` and `fli dates` CLI commands
- expose the same passenger fields on the MCP `search_flights` and `search_dates` tools and pass them through to `PassengerInfo`
- add regression coverage for CLI, MCP, and model encoding, and update the passenger-specific docs/examples where those details are reference material

## Why
The Python model layer already supported child and infant passenger counts through `PassengerInfo`, but the CLI and MCP surfaces still hardcoded adult-only behavior. That made family search scenarios available in the underlying library but not accessible from the main user-facing entrypoints.

## Impact
Users can now specify family passenger mixes consistently across the CLI and MCP interfaces, and the docs/examples now show those options only in the places where passenger configuration is directly relevant.

## Root Cause
`PassengerInfo` and the Google Flights encoding already handled the extra passenger fields, but the CLI command builders and MCP parameter models only exposed adult passenger counts.

## Validation
- `./.venv/bin/python -m pytest -q tests/cli tests/mcp`
- `./.venv/bin/python -m pytest -q tests/models/test_flight_search_filters.py tests/models/test_date_search_filters.py`
- `./.venv/bin/python -m ruff check examples/complex_flight_search.py examples/complex_round_trip_validation.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes `children`, `infants_in_seat`, and `infants_on_lap` passenger fields — which were already supported by `PassengerInfo` and the Google Flights encoding layer — through the `fli flights` / `fli dates` CLI commands and the MCP `search_flights` / `search_dates` tools. Documentation, examples, and test coverage are updated consistently.

**Key changes:**
- CLI (`flights.py`, `dates.py`): three new `typer.Option` parameters plumbed through `_search_flights_core` and into `PassengerInfo`.
- MCP (`server.py`): fields added to `FlightSearchParams`, `DateSearchParams`, and both tool function signatures with correct `ge=0` Pydantic constraints.
- Tests: new `test_*_with_family_passenger_counts` tests in CLI and MCP suites; model encoding tests updated to use distinct adult count (2 → 3) for clearer value differentiation.
- **Missing `--passengers` CLI option**: both CLI commands still hardcode `adults=1` with no `--passengers` / `--adults` flag. The MCP already exposes a `passengers` parameter, so family searches with more than one adult cannot be expressed from the CLI — this gap pre-dates the PR but is left unaddressed by it.
- **Incomplete error response in `dates.py`**: the `except (AttributeError, ValueError)` handler builds its own inline `query` dict that omits the three new fields, while the adjacent `except ParseError` handler includes them, producing inconsistent JSON error responses.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style/completeness issues that do not affect runtime correctness of the happy path.

All P2 findings — the missing --passengers CLI option is a pre-existing gap (not introduced by this PR) and the incomplete error-response dict only affects the rarely-hit AttributeError/ValueError JSON error path. Core logic, model encoding, and the full success path are correct and covered by tests. Per guidance, P2-only findings do not reduce the score below 5.

fli/cli/commands/dates.py — the AttributeError/ValueError error handler is missing the new passenger fields in its inline query dict.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| fli/cli/commands/flights.py | Adds --children, --infants-in-seat, --infants-on-lap CLI options and threads them through to PassengerInfo, but adults count remains hardcoded to 1 with no --passengers flag. |
| fli/cli/commands/dates.py | Adds family passenger options correctly, but the AttributeError/ValueError error handler omits the new fields from its inline JSON query dict, creating inconsistent error responses vs. the ParseError handler. |
| fli/mcp/server.py | Correctly adds children, infants_in_seat, and infants_on_lap to both FlightSearchParams and DateSearchParams models, and to the search_flights/search_dates tool function signatures, with proper ge=0 validation. |
| tests/cli/test_flights.py | New test test_flights_with_family_passenger_counts verifies all three new passenger fields are correctly threaded through to the PassengerInfo object. |
| tests/cli/test_dates.py | New test test_dates_with_family_passenger_counts mirrors the flights test and properly verifies all three new passenger fields. |
| tests/mcp/test_mcp_server.py | Two new integration-style tests verify that children/infants fields are passed through to PassengerInfo in both search_flights and search_dates using monkeypatching; default-value assertions also added. |
| tests/models/test_flight_search_filters.py | Test 3 changes adults from 2 to 3 to give unique values across all four passenger fields, making the encoded output [3,3,1,0] more distinguishable; the corresponding expected output is updated correctly. |
| tests/models/test_date_search_filters.py | Same adults=2→3 change as flight filters test for consistency and distinct test data values; expected output updated correctly. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI/MCP
    participant PassengerInfo
    participant SearchEngine
    participant GoogleFlights

    User->>CLI/MCP: --children N / --infants-in-seat N / --infants-on-lap N
    CLI/MCP->>PassengerInfo: PassengerInfo(adults=1, children=N, infants_in_seat=N, infants_on_lap=N)
    PassengerInfo-->>CLI/MCP: validated model
    CLI/MCP->>SearchEngine: FlightSearchFilters(passenger_info=...)
    SearchEngine->>GoogleFlights: encode([adults, children, infants_on_lap, infants_in_seat])
    GoogleFlights-->>SearchEngine: flight results
    SearchEngine-->>CLI/MCP: FlightResult[]
    CLI/MCP-->>User: formatted output
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `fli/cli/commands/dates.py`, line 382-419 ([link](https://github.com/punitarani/fli/blob/a877c4ea4571e3b43a5ca650df65e47ddd2b9dae/fli/cli/commands/dates.py#L382-L419)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing passenger fields in fallback error response**

   The `except (AttributeError, ValueError)` handler builds its own inline `query` dict that omits `children`, `infants_in_seat`, and `infants_on_lap`. The `except ParseError` handler above it (lines 339–379) includes those fields, so the two branches produce inconsistent JSON error responses.

   When a `ValueError` or `AttributeError` is raised during the actual search (e.g. a network timeout re-wrapped as `ValueError`), the caller receives a JSON error response that silently drops the passenger configuration they supplied.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: fli/cli/commands/dates.py
   Line: 382-419

   Comment:
   **Missing passenger fields in fallback error response**

   The `except (AttributeError, ValueError)` handler builds its own inline `query` dict that omits `children`, `infants_in_seat`, and `infants_on_lap`. The `except ParseError` handler above it (lines 339–379) includes those fields, so the two branches produce inconsistent JSON error responses.

   When a `ValueError` or `AttributeError` is raised during the actual search (e.g. a network timeout re-wrapped as `ValueError`), the caller receives a JSON error response that silently drops the passenger configuration they supplied.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/cli/commands/dates.py
Line: 382-419

Comment:
**Missing passenger fields in fallback error response**

The `except (AttributeError, ValueError)` handler builds its own inline `query` dict that omits `children`, `infants_in_seat`, and `infants_on_lap`. The `except ParseError` handler above it (lines 339–379) includes those fields, so the two branches produce inconsistent JSON error responses.

When a `ValueError` or `AttributeError` is raised during the actual search (e.g. a network timeout re-wrapped as `ValueError`), the caller receives a JSON error response that silently drops the passenger configuration they supplied.

```suggestion
    except (AttributeError, ValueError) as e:
        if "module 'fli.search' has no attribute 'SearchDates'" in str(e):
            raise
        if output_format == OutputFormat.JSON:
            emit_json(
                build_json_error_response(
                    search_type="dates",
                    message=str(e),
                    error_type="search_error",
                    query={
                        "origin": origin,
                        "destination": destination,
                        "start_date": start_date,
                        "end_date": end_date,
                        "trip_duration": trip_duration,
                        "is_round_trip": is_round_trip,
                        "children": children,
                        "infants_in_seat": infants_in_seat,
                        "infants_on_lap": infants_on_lap,
                        "cabin_class": cabin_class,
                        "max_stops": max_stops,
                        "departure_window": (
                            f"{departure_window[0]}-{departure_window[1]}"
                            if isinstance(departure_window, tuple)
                            else departure_window
                        ),
                        "airlines": airlines,
                        "sort_by_price": sort_by_price,
                        "days": [
                            day.value
                            for day in _build_selected_days(
                                monday=monday,
                                tuesday=tuesday,
                                wednesday=wednesday,
                                thursday=thursday,
                                friday=friday,
                                saturday=saturday,
                                sunday=sunday,
                            )
                        ],
                    },
                )
            )
            raise typer.Exit(1) from e
        typer.echo(f"Error: {str(e)}")
        raise typer.Exit(1) from e
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/cli/commands/flights.py
Line: 102-110

Comment:
**`adults` count hardcoded to 1 in CLI**

The CLI exposes `--children`, `--infants-in-seat`, and `--infants-on-lap`, but the adult passenger count is unconditionally hardcoded to `1`. A family travelling with 2 adults and 2 children has no way to express `adults=2` through the CLI, while the MCP surface already exposes a `passengers` parameter for this.

As stated in the PR summary, the goal is to let users "specify family passenger mixes consistently across the CLI and MCP interfaces." Without a `--passengers` (or `--adults`) option, the CLI-side adult count will always be 1 regardless of the actual party size, which can produce misleading fare quotes. The same issue exists in `dates.py` (line 288).

Consider adding a `--passengers` option analogous to the MCP `passengers` field and wiring it through to `adults=passengers` in `PassengerInfo`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: Add passenger count options"](https://github.com/punitarani/fli/commit/a877c4ea4571e3b43a5ca650df65e47ddd2b9dae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26945108)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->