### PR TITLE
chore: Update `ZG` airline enum from “Groznyy Avia” to “Zipair”

### DIFF
--- a/data/airlines.csv
+++ b/data/airlines.csv
@@ -855,7 +855,7 @@ ZC,Fly Africa Zimbabwe
 ZD,Ewa Air
 ZE,Eastar Jet
 ZF,Azur Air
-ZG,ZIPAIR
+ZG,Zipair
 ZH,Shenzhen Airlines
 ZI,Aigle Azur
 ZJ,Zambezi Airlines

--- a/fli/models/airline.py
+++ b/fli/models/airline.py
@@ -863,7 +863,7 @@ class Airline(Enum):
     ZD = "Ewa Air"
     ZE = "Eastar Jet"
     ZF = "Azur Air"
-    ZG = "ZIPAIR"
+    ZG = "Zipair"
     ZH = "Shenzhen Airlines"
     ZI = "Aigle Azur"
     ZJ = "Zambezi Airlines"


### PR DESCRIPTION
This PR updates the `ZG` airline enum value from `"Groznyy Avia"` to `"Zipair"`.

**Why this change is needed**

`ZG` is currently used by **Zipair**, the Japanese low-cost carrier.
`Groznyy Avia` is a defunct airline, and keeping `ZG = "Groznyy Avia"` causes incorrect airline labeling in current usage.

This can lead to confusion for anyone using the library with modern flight data, where flights marketed or operated by ZIPAIR may be displayed under an outdated and unrelated airline name.

**What this fixes**

* Aligns the enum with current airline code usage
* Prevents incorrect mapping of Zipair flights to Groznyy Avia

**Notes**

This appears to be a stale historical mapping rather than the correct present-day airline name for `ZG`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a stale IATA airline code mapping by updating `ZG` from `"Groznyy Avia"` (a defunct Russian carrier) to `"ZIPAIR"` (the active Japanese low-cost carrier operated by JAL Group). The change is made consistently across both the raw `data/airlines.csv` source file and the derived `fli/models/airline.py` enum.

- The mapping is factually correct: IATA code `ZG` is officially assigned to ZIPAIR Tokyo (confirmed via Wikipedia, Kayak, Airhex, and avcodes.co.uk).
- Both files are updated in sync — the enum key `ZG` is unchanged and only the string value is updated.
- No logic, tests, or other dependent code is affected by this value change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a minimal, factually verified data correction with no logic changes.

Both changed files are updated consistently, the new value is confirmed correct by multiple authoritative IATA sources, and no code logic or API contracts are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| data/airlines.csv | Updates ZG airline entry from "Groznyy Avia" to "ZIPAIR" — factually correct per official IATA records |
| fli/models/airline.py | Updates Airline enum ZG value from "Groznyy Avia" to "ZIPAIR", keeping enum key unchanged and in sync with the CSV source |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["data/airlines.csv\nZG,ZIPAIR"] -->|"Enum generated from CSV"| B["Airline enum\nZG = 'ZIPAIR'"]
    B -->|"Parsed by"| C["fli/core/parsers.py"]
    C -->|"Used in"| D["SearchFlights / SearchDates\nairlines filter"]
    D -->|"Returns results with"| E["FlightResult\nwith correct airline label: ZIPAIR"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: update ZG code to ZIPAIR"](https://github.com/punitarani/fli/commit/20de8eb843308c91f907fb858dbc9ee29c91c473) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26998182)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->