### PR TITLE
Refactor round-trip search tests to mock HTTP client

### DIFF
--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -335,16 +335,7 @@ def test_basic_round_trip_search(mock_get_client, round_trip_search_params):
 
     search = SearchFlights()
     results = search.search(round_trip_search_params, top_n=2)
-
-    assert results is not None
-    assert isinstance(results, list)
-    # 2 outbound × 2 return = 4 combinations
-    assert len(results) == 4
-    for combo in results:
-        assert isinstance(combo, tuple)
-        assert len(combo) == 2
-        assert isinstance(combo[0], FlightResult)
-        assert isinstance(combo[1], FlightResult)
+    assert len(results) == 4  # 2 outbound × 2 return
     # 1 outbound call + 2 return calls (one per outbound flight)
     assert mock_client.post.call_count == 3
 

--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -337,12 +337,15 @@ def test_basic_round_trip_search(mock_get_client, round_trip_search_params):
 
     assert results is not None
     assert isinstance(results, list)
-    assert len(results) > 0
+    # 2 outbound × 2 return = 4 combinations
+    assert len(results) == 4
     for combo in results:
         assert isinstance(combo, tuple)
         assert len(combo) == 2
         assert isinstance(combo[0], FlightResult)
         assert isinstance(combo[1], FlightResult)
+    # 1 outbound call + 2 return calls (one per outbound flight)
+    assert mock_client.post.call_count == 3
 
 
 @patch("fli.search.flights.get_client")

--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -1,12 +1,15 @@
 """Tests for Search class."""
 
+import json
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from fli.models import (
     Airport,
+    FlightResult,
     FlightSearchFilters,
     FlightSegment,
     MaxStops,
@@ -182,15 +185,253 @@ def test_multiple_searches(search, basic_search_params, complex_search_params):
     assert isinstance(results3, list)
 
 
-# TODO: These round-trip tests hit the live Google Flights API with multiple
-# sequential requests (outbound + return for each result), causing frequent
-# timeouts on CI runners. They should be refactored to mock the HTTP client
-# instead of making real API calls. See GitHub issue for follow-up.
-#
-# def test_basic_round_trip_search(search, round_trip_search_params):
-# def test_complex_round_trip_search(search, complex_round_trip_params):
-# def test_round_trip_with_selected_outbound(search, round_trip_search_params):
-# def test_round_trip_result_structure(search, search_params_fixture, request):
+def _make_leg_data(
+    dep_airport,
+    arr_airport,
+    airline_code,
+    flight_num,
+    dep_date,
+    arr_date,
+    dep_time,
+    arr_time,
+    duration,
+):
+    """Build a single leg data entry matching the raw Google Flights API format."""
+    # Indices: 3=dep_airport, 6=arr_airport, 8=dep_time, 10=arr_time,
+    #          11=duration, 20=dep_date, 21=arr_date, 22=[airline, flight_num]
+    leg = [None] * 23
+    leg[3] = dep_airport
+    leg[6] = arr_airport
+    leg[8] = dep_time
+    leg[10] = arr_time
+    leg[11] = duration
+    leg[20] = dep_date
+    leg[21] = arr_date
+    leg[22] = [airline_code, flight_num]
+    return leg
+
+
+def _make_flight_data(legs, total_duration, price):
+    """Build a flight data entry matching the raw Google Flights API format."""
+    flight_info = [None] * 10
+    flight_info[2] = legs
+    flight_info[9] = total_duration
+    price_info = [[None, price], None]
+    return [flight_info, price_info]
+
+
+def _make_api_response(*flight_data_entries):
+    """Build a mock API response matching the raw Google Flights response format."""
+    inner_data = [None, None, [list(flight_data_entries)], None]
+    response_text = ")]}'\n" + json.dumps([[None, None, json.dumps(inner_data)]])
+    mock_response = MagicMock()
+    mock_response.text = response_text
+    return mock_response
+
+
+def _make_outbound_flights():
+    """Create mock outbound flight data (SFO -> JFK)."""
+    return [
+        _make_flight_data(
+            legs=[
+                _make_leg_data(
+                    "SFO", "JFK", "DL", "DL100", [2026, 5, 2], [2026, 5, 2], [8, 0], [16, 30], 330
+                )
+            ],
+            total_duration=330,
+            price=299.99,
+        ),
+        _make_flight_data(
+            legs=[
+                _make_leg_data(
+                    "SFO", "JFK", "UA", "UA200", [2026, 5, 2], [2026, 5, 2], [10, 0], [18, 15], 315
+                )
+            ],
+            total_duration=315,
+            price=349.99,
+        ),
+    ]
+
+
+def _make_return_flights():
+    """Create mock return flight data (JFK -> SFO)."""
+    return [
+        _make_flight_data(
+            legs=[
+                _make_leg_data(
+                    "JFK", "SFO", "DL", "DL101", [2026, 5, 9], [2026, 5, 9], [9, 0], [12, 30], 390
+                )
+            ],
+            total_duration=390,
+            price=279.99,
+        ),
+        _make_flight_data(
+            legs=[
+                _make_leg_data(
+                    "JFK", "SFO", "UA", "UA201", [2026, 5, 9], [2026, 5, 9], [11, 0], [14, 45], 405
+                )
+            ],
+            total_duration=405,
+            price=319.99,
+        ),
+    ]
+
+
+def _make_complex_outbound_flights():
+    """Create mock outbound flights with a connection (LAX -> ORD)."""
+    return [
+        _make_flight_data(
+            legs=[
+                _make_leg_data(
+                    "LAX", "DFW", "AA", "AA300", [2026, 6, 1], [2026, 6, 1], [7, 0], [12, 30], 210
+                ),
+                _make_leg_data(
+                    "DFW", "ORD", "AA", "AA301", [2026, 6, 1], [2026, 6, 1], [14, 0], [16, 30], 150
+                ),
+            ],
+            total_duration=360,
+            price=499.99,
+        ),
+    ]
+
+
+def _make_complex_return_flights():
+    """Create mock return flights with a connection (ORD -> LAX)."""
+    return [
+        _make_flight_data(
+            legs=[
+                _make_leg_data(
+                    "ORD", "DFW", "AA", "AA302", [2026, 6, 15], [2026, 6, 15], [8, 0], [10, 30], 150
+                ),
+                _make_leg_data(
+                    "DFW",
+                    "LAX",
+                    "AA",
+                    "AA303",
+                    [2026, 6, 15],
+                    [2026, 6, 15],
+                    [12, 0],
+                    [13, 30],
+                    210,
+                ),
+            ],
+            total_duration=360,
+            price=479.99,
+        ),
+    ]
+
+
+@patch("fli.search.flights.get_client")
+def test_basic_round_trip_search(mock_get_client, round_trip_search_params):
+    """Test basic round-trip search with mocked HTTP client."""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    outbound_response = _make_api_response(*_make_outbound_flights())
+    return_response = _make_api_response(*_make_return_flights())
+    # First call returns outbound flights, subsequent calls return return flights
+    mock_client.post.side_effect = [outbound_response, return_response, return_response]
+
+    search = SearchFlights()
+    results = search.search(round_trip_search_params, top_n=2)
+
+    assert results is not None
+    assert isinstance(results, list)
+    assert len(results) > 0
+    for combo in results:
+        assert isinstance(combo, tuple)
+        assert len(combo) == 2
+        assert isinstance(combo[0], FlightResult)
+        assert isinstance(combo[1], FlightResult)
+
+
+@patch("fli.search.flights.get_client")
+def test_complex_round_trip_search(mock_get_client, complex_round_trip_params):
+    """Test complex round-trip search with multiple passengers and connections."""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    outbound_response = _make_api_response(*_make_complex_outbound_flights())
+    return_response = _make_api_response(*_make_complex_return_flights())
+    mock_client.post.side_effect = [outbound_response, return_response]
+
+    search = SearchFlights()
+    results = search.search(complex_round_trip_params, top_n=1)
+
+    assert results is not None
+    assert isinstance(results, list)
+    assert len(results) > 0
+    for combo in results:
+        assert isinstance(combo, tuple)
+        assert len(combo) == 2
+        # Outbound has a connection (2 legs)
+        assert combo[0].stops == 1
+        assert len(combo[0].legs) == 2
+        # Return also has a connection (2 legs)
+        assert combo[1].stops == 1
+        assert len(combo[1].legs) == 2
+
+
+@patch("fli.search.flights.get_client")
+def test_round_trip_with_selected_outbound(mock_get_client, round_trip_search_params):
+    """Test that round-trip search selects outbound and fetches returns."""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    outbound_response = _make_api_response(*_make_outbound_flights())
+    return_response = _make_api_response(*_make_return_flights())
+    mock_client.post.side_effect = [outbound_response, return_response]
+
+    search = SearchFlights()
+    results = search.search(round_trip_search_params, top_n=1)
+
+    assert results is not None
+    assert isinstance(results, list)
+    # With top_n=1, only 1 outbound is selected, paired with return options
+    assert len(results) > 0
+    # HTTP client should be called twice: once for outbound, once for return
+    assert mock_client.post.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "search_params_fixture",
+    [
+        "round_trip_search_params",
+        "complex_round_trip_params",
+    ],
+)
+@patch("fli.search.flights.get_client")
+def test_round_trip_result_structure(mock_get_client, search_params_fixture, request):
+    """Test the structure of round-trip search results."""
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
+
+    if search_params_fixture == "round_trip_search_params":
+        outbound_flights = _make_outbound_flights()
+        return_flights = _make_return_flights()
+    else:
+        outbound_flights = _make_complex_outbound_flights()
+        return_flights = _make_complex_return_flights()
+
+    outbound_response = _make_api_response(*outbound_flights)
+    return_response = _make_api_response(*return_flights)
+    mock_client.post.side_effect = [outbound_response, return_response]
+
+    search_params = request.getfixturevalue(search_params_fixture)
+    search = SearchFlights()
+    results = search.search(search_params, top_n=1)
+
+    assert results is not None
+    assert isinstance(results, list)
+    for combo in results:
+        assert isinstance(combo, tuple)
+        assert len(combo) == 2
+        for flight in combo:
+            assert isinstance(flight, FlightResult)
+            assert flight.price > 0
+            assert flight.duration > 0
+            assert flight.stops >= 0
+            assert len(flight.legs) > 0
 
 
 class TestParsePrice:

--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -331,6 +331,7 @@ def test_basic_round_trip_search(mock_get_client, round_trip_search_params):
     return_response = _make_api_response(*_make_return_flights())
     # First call returns outbound flights, subsequent calls return return flights
     mock_client.post.side_effect = [outbound_response, return_response, return_response]
+    # Expect 3 calls: 1 outbound + 1 return per selected outbound (top_n=2)
 
     search = SearchFlights()
     results = search.search(round_trip_search_params, top_n=2)


### PR DESCRIPTION
## Summary
- Replace commented-out round-trip tests with mocked implementations that patch the HTTP client at the `get_client` level
- Add helper functions to build fake API responses matching the raw Google Flights response format
- Implement 4 round-trip tests (`test_basic_round_trip_search`, `test_complex_round_trip_search`, `test_round_trip_with_selected_outbound`, `test_round_trip_result_structure`) that exercise the full recursive search logic without network dependencies

## Test plan
- [x] All 5 new round-trip tests pass (`pytest tests/search/test_search_flights.py -k round_trip -vv`)
- [x] Existing tests unaffected
- [x] Ruff lint and format checks pass

Closes #104

https://claude.ai/code/session_01Wt95AYdD9pXwKsLVUGQH1Z

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces commented-out round-trip search tests with four properly mocked tests that patch `fli.search.flights.get_client` and build synthetic API responses matching the raw Google Flights wire format. The approach is correct: the mock is applied before `SearchFlights()` is instantiated, so `self.client` receives the mock client, and the `side_effect` list is sized to match each test's expected HTTP call count.

<h3>Confidence Score: 5/5</h3>

Safe to merge — mock format matches the real parser, patch target is correct, and side_effect sizes align with expected call counts.

All findings are P2 style suggestions (looser-than-needed assertions and a missing call-count guard). No logic errors, correctness issues, or data-integrity concerns were found. The enum values used in mock data (DL, UA, AA, SFO, JFK, LAX, ORD, DFW) all exist, the response format correctly mirrors what the live parser consumes, and the patch target is applied before SearchFlights() is instantiated.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/search/test_search_flights.py | Adds mock helper functions and four new round-trip tests with correct patch target, valid response format, and properly sized side_effect lists; minor: result-count assertions are looser than the data allows. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test
    participant SC as SearchFlights
    participant MC as MockClient

    T->>SC: search(round_trip_params, top_n=N)
    SC->>MC: post(outbound request)
    MC-->>SC: outbound_response (N flights)

    loop for each outbound flight [:top_n]
        SC->>SC: deepcopy(filters), set selected_flight
        SC->>MC: post(return request)
        MC-->>SC: return_response
        SC-->>SC: combine (outbound, return) tuples
    end

    SC-->>T: list of (FlightResult, FlightResult) tuples
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/search/test_search_flights.py
Line: 336-345

Comment:
**Weaker-than-necessary result count assertion**

`_make_outbound_flights()` returns 2 flights and `top_n=2`, so the search loops over both outbound options and pairs each with the 2 return flights — meaning `results` will always contain exactly 4 combos. `assert len(results) > 0` passes even if only 1 combo is returned, hiding a regression where `top_n` or the pairing logic drops combinations silently. Asserting the exact count would catch that class of bug.

```suggestion
    assert len(results) == 4  # 2 outbound × 2 return
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/search/test_search_flights.py
Line: 333

Comment:
**Missing call-count assertion for `top_n=2` case**

`test_round_trip_with_selected_outbound` explicitly asserts `mock_client.post.call_count == 2`, which is the most useful guard against the recursive search making unexpected extra calls. This test uses `top_n=2` so it should make 3 calls (1 outbound + 2 returns). Adding the same guard here would document the expected behaviour and catch over/under-fetching regressions.

```suggestion
    mock_client.post.side_effect = [outbound_response, return_response, return_response]
    # Expect 3 calls: 1 outbound + 1 return per selected outbound (top_n=2)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refactor round-trip search tests to mock..."](https://github.com/punitarani/fli/commit/39013c037cdf58ab5ec2e5c9417fa3a115e3517b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27133512)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->