### PR TITLE
Stabilize live API test dates

### DIFF
--- a/tests/live_api_dates.py
+++ b/tests/live_api_dates.py
@@ -1,0 +1,24 @@
+"""Shared future-safe dates for tests that hit the live Google Flights API."""
+
+from datetime import date, timedelta
+
+PRIMARY_TRAVEL_OFFSET_DAYS = 45
+SECONDARY_TRAVEL_OFFSET_DAYS = 75
+SHORT_RETURN_OFFSET_DAYS = 7
+LONG_RETURN_OFFSET_DAYS = 14
+WINDOW_PADDING_DAYS = 14
+
+
+def live_api_date(days_ahead: int) -> str:
+    """Return a date string safely in the future for live API calls."""
+    return (date.today() + timedelta(days=days_ahead)).strftime("%Y-%m-%d")
+
+
+def live_api_window(
+    travel_offset_days: int, *, padding_days: int = WINDOW_PADDING_DAYS
+) -> tuple[str, str]:
+    """Return a strictly-future date window around a travel date."""
+    return (
+        live_api_date(travel_offset_days - padding_days),
+        live_api_date(travel_offset_days + padding_days),
+    )

--- a/tests/mcp/test_mcp_server.py
+++ b/tests/mcp/test_mcp_server.py
@@ -1,18 +1,21 @@
 """Test MCP server functionality."""
 
-from datetime import datetime, timedelta
-
 from fli.mcp.server import (
     DateSearchParams,
     FlightSearchParams,
     search_dates,
     search_flights,
 )
+from tests.live_api_dates import (
+    PRIMARY_TRAVEL_OFFSET_DAYS,
+    SECONDARY_TRAVEL_OFFSET_DAYS,
+    SHORT_RETURN_OFFSET_DAYS,
+    live_api_date,
+    live_api_window,
+)
 
-
-def get_future_date(days: int = 30) -> str:
-    """Generate a future date string in YYYY-MM-DD format."""
-    return (datetime.now() + timedelta(days=days)).strftime("%Y-%m-%d")
+PRIMARY_START_DATE, PRIMARY_END_DATE = live_api_window(PRIMARY_TRAVEL_OFFSET_DAYS)
+SECONDARY_START_DATE, SECONDARY_END_DATE = live_api_window(SECONDARY_TRAVEL_OFFSET_DAYS)
 
 
 class TestMCPServer:
@@ -23,7 +26,7 @@ class TestMCPServer:
         params = FlightSearchParams(
             origin="JFK",
             destination="LHR",
-            departure_date=get_future_date(30),
+            departure_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             cabin_class="ECONOMY",
             max_stops="ANY",
             sort_by="CHEAPEST",
@@ -46,8 +49,8 @@ class TestMCPServer:
         params = FlightSearchParams(
             origin="LAX",
             destination="JFK",
-            departure_date=get_future_date(30),
-            return_date=get_future_date(37),
+            departure_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
+            return_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS + SHORT_RETURN_OFFSET_DAYS),
             departure_window="8-20",
             airlines=["AA", "DL"],
             cabin_class="BUSINESS",
@@ -69,14 +72,11 @@ class TestMCPServer:
 
     def test_search_dates_one_way(self):
         """Test one-way date search."""
-        start_date = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
-        end_date = (datetime.now() + timedelta(days=60)).strftime("%Y-%m-%d")
-
         params = DateSearchParams(
             origin="JFK",
             destination="LHR",
-            start_date=start_date,
-            end_date=end_date,
+            start_date=PRIMARY_START_DATE,
+            end_date=PRIMARY_END_DATE,
             is_round_trip=False,
             cabin_class="ECONOMY",
             max_stops="ANY",
@@ -98,14 +98,11 @@ class TestMCPServer:
 
     def test_search_dates_round_trip(self):
         """Test round-trip date search."""
-        start_date = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
-        end_date = (datetime.now() + timedelta(days=60)).strftime("%Y-%m-%d")
-
         params = DateSearchParams(
             origin="LAX",
             destination="MIA",
-            start_date=start_date,
-            end_date=end_date,
+            start_date=SECONDARY_START_DATE,
+            end_date=SECONDARY_END_DATE,
             trip_duration=7,
             is_round_trip=True,
             airlines=["AA", "B6"],
@@ -132,7 +129,9 @@ class TestMCPServer:
     def test_invalid_airport_code(self):
         """Test error handling for invalid airport code."""
         params = FlightSearchParams(
-            origin="INVALID", destination="LHR", departure_date=get_future_date(30)
+            origin="INVALID",
+            destination="LHR",
+            departure_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
         )
 
         result = search_flights.fn(params)
@@ -148,7 +147,7 @@ class TestMCPServer:
         params = FlightSearchParams(
             origin="JFK",
             destination="LHR",
-            departure_date=get_future_date(30),
+            departure_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             departure_window="invalid-time",
         )
 
@@ -165,7 +164,7 @@ class TestMCPServer:
         params = FlightSearchParams(
             origin="JFK",
             destination="LHR",
-            departure_date=get_future_date(30),
+            departure_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             cabin_class="INVALID_CLASS",
         )
 
@@ -182,7 +181,7 @@ class TestMCPServer:
         params = FlightSearchParams(
             origin="JFK",
             destination="LHR",
-            departure_date=get_future_date(30),
+            departure_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             max_stops="INVALID_STOPS",
         )
 
@@ -199,7 +198,7 @@ class TestMCPServer:
         params = FlightSearchParams(
             origin="JFK",
             destination="LHR",
-            departure_date=get_future_date(30),
+            departure_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             airlines=["INVALID_AIRLINE"],
         )
 
@@ -213,7 +212,7 @@ class TestMCPServer:
 
     def test_flight_search_params_validation(self):
         """Test FlightSearchParams validation."""
-        future_date = get_future_date(30)
+        future_date = live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS)
         params = FlightSearchParams(origin="JFK", destination="LHR", departure_date=future_date)
         assert params.origin == "JFK"
         assert params.destination == "LHR"
@@ -224,8 +223,8 @@ class TestMCPServer:
 
     def test_date_search_params_validation(self):
         """Test DateSearchParams validation."""
-        start_date = get_future_date(30)
-        end_date = get_future_date(60)
+        start_date = PRIMARY_START_DATE
+        end_date = PRIMARY_END_DATE
         params = DateSearchParams(
             origin="JFK",
             destination="LHR",

--- a/tests/search/test_search_dates.py
+++ b/tests/search/test_search_dates.py
@@ -1,6 +1,6 @@
 """Tests for SearchDates class."""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import pytest
 
@@ -15,6 +15,14 @@ from fli.models import (
 )
 from fli.models.google_flights.base import TripType
 from fli.search import SearchDates
+from tests.live_api_dates import (
+    LONG_RETURN_OFFSET_DAYS,
+    PRIMARY_TRAVEL_OFFSET_DAYS,
+    SECONDARY_TRAVEL_OFFSET_DAYS,
+    SHORT_RETURN_OFFSET_DAYS,
+    live_api_date,
+    live_api_window,
+)
 
 
 @pytest.fixture
@@ -26,8 +34,7 @@ def search():
 @pytest.fixture
 def basic_search_params():
     """Create basic date search params for testing."""
-    today = datetime.now()
-    future_date = today + timedelta(days=30)
+    from_date, to_date = live_api_window(PRIMARY_TRAVEL_OFFSET_DAYS)
     return DateSearchFilters(
         passenger_info=PassengerInfo(
             adults=1,
@@ -39,22 +46,21 @@ def basic_search_params():
             FlightSegment(
                 departure_airport=[[Airport.PHX, 0]],
                 arrival_airport=[[Airport.SFO, 0]],
-                travel_date=future_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             )
         ],
         stops=MaxStops.NON_STOP,
         seat_type=SeatType.ECONOMY,
         sort_by=SortBy.CHEAPEST,
-        from_date=(future_date - timedelta(days=30)).strftime("%Y-%m-%d"),
-        to_date=(future_date + timedelta(days=30)).strftime("%Y-%m-%d"),
+        from_date=from_date,
+        to_date=to_date,
     )
 
 
 @pytest.fixture
 def complex_search_params():
     """Create more complex date search params for testing."""
-    today = datetime.now()
-    future_date = today + timedelta(days=60)
+    from_date, to_date = live_api_window(SECONDARY_TRAVEL_OFFSET_DAYS)
     return DateSearchFilters(
         passenger_info=PassengerInfo(
             adults=2,
@@ -66,23 +72,21 @@ def complex_search_params():
             FlightSegment(
                 departure_airport=[[Airport.JFK, 0]],
                 arrival_airport=[[Airport.LAX, 0]],
-                travel_date=future_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(SECONDARY_TRAVEL_OFFSET_DAYS),
             )
         ],
         stops=MaxStops.ONE_STOP_OR_FEWER,
         seat_type=SeatType.FIRST,
         sort_by=SortBy.TOP_FLIGHTS,
-        from_date=(future_date - timedelta(days=30)).strftime("%Y-%m-%d"),
-        to_date=(future_date + timedelta(days=30)).strftime("%Y-%m-%d"),
+        from_date=from_date,
+        to_date=to_date,
     )
 
 
 @pytest.fixture
 def round_trip_search_params():
     """Create basic round trip search params for testing."""
-    today = datetime.now()
-    outbound_date = today + timedelta(days=30)
-    return_date = outbound_date + timedelta(days=7)
+    from_date, to_date = live_api_window(PRIMARY_TRAVEL_OFFSET_DAYS)
 
     return DateSearchFilters(
         passenger_info=PassengerInfo(
@@ -95,29 +99,27 @@ def round_trip_search_params():
             FlightSegment(
                 departure_airport=[[Airport.SFO, 0]],
                 arrival_airport=[[Airport.JFK, 0]],
-                travel_date=outbound_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             ),
             FlightSegment(
                 departure_airport=[[Airport.JFK, 0]],
                 arrival_airport=[[Airport.SFO, 0]],
-                travel_date=return_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS + SHORT_RETURN_OFFSET_DAYS),
             ),
         ],
         stops=MaxStops.NON_STOP,
         seat_type=SeatType.ECONOMY,
         sort_by=SortBy.CHEAPEST,
         trip_type=TripType.ROUND_TRIP,
-        from_date=(outbound_date - timedelta(days=30)).strftime("%Y-%m-%d"),
-        to_date=(outbound_date + timedelta(days=30)).strftime("%Y-%m-%d"),
+        from_date=from_date,
+        to_date=to_date,
     )
 
 
 @pytest.fixture
 def complex_round_trip_params():
     """Create more complex round trip search params for testing."""
-    today = datetime.now()
-    outbound_date = today + timedelta(days=60)
-    return_date = outbound_date + timedelta(days=14)
+    from_date, to_date = live_api_window(SECONDARY_TRAVEL_OFFSET_DAYS)
 
     return DateSearchFilters(
         passenger_info=PassengerInfo(
@@ -130,20 +132,20 @@ def complex_round_trip_params():
             FlightSegment(
                 departure_airport=[[Airport.LAX, 0]],
                 arrival_airport=[[Airport.ORD, 0]],
-                travel_date=outbound_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(SECONDARY_TRAVEL_OFFSET_DAYS),
             ),
             FlightSegment(
                 departure_airport=[[Airport.ORD, 0]],
                 arrival_airport=[[Airport.LAX, 0]],
-                travel_date=return_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(SECONDARY_TRAVEL_OFFSET_DAYS + LONG_RETURN_OFFSET_DAYS),
             ),
         ],
         stops=MaxStops.ONE_STOP_OR_FEWER,
         seat_type=SeatType.BUSINESS,
         sort_by=SortBy.TOP_FLIGHTS,
         trip_type=TripType.ROUND_TRIP,
-        from_date=(outbound_date - timedelta(days=30)).strftime("%Y-%m-%d"),
-        to_date=(outbound_date + timedelta(days=30)).strftime("%Y-%m-%d"),
+        from_date=from_date,
+        to_date=to_date,
     )
 
 

--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -1,7 +1,5 @@
 """Tests for Search class."""
 
-from datetime import datetime, timedelta
-
 import pytest
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -16,6 +14,13 @@ from fli.models import (
 )
 from fli.models.google_flights.base import TripType
 from fli.search import SearchFlights
+from tests.live_api_dates import (
+    LONG_RETURN_OFFSET_DAYS,
+    PRIMARY_TRAVEL_OFFSET_DAYS,
+    SECONDARY_TRAVEL_OFFSET_DAYS,
+    SHORT_RETURN_OFFSET_DAYS,
+    live_api_date,
+)
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10), reraise=True)
@@ -36,8 +41,6 @@ def search():
 @pytest.fixture
 def basic_search_params():
     """Create basic search params for testing."""
-    today = datetime.now()
-    future_date = today + timedelta(days=30)
     return FlightSearchFilters(
         passenger_info=PassengerInfo(
             adults=1,
@@ -49,7 +52,7 @@ def basic_search_params():
             FlightSegment(
                 departure_airport=[[Airport.PHX, 0]],
                 arrival_airport=[[Airport.SFO, 0]],
-                travel_date=future_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             )
         ],
         stops=MaxStops.NON_STOP,
@@ -62,8 +65,6 @@ def basic_search_params():
 @pytest.fixture
 def complex_search_params():
     """Create more complex search params for testing."""
-    today = datetime.now()
-    future_date = today + timedelta(days=60)
     return FlightSearchFilters(
         passenger_info=PassengerInfo(
             adults=2,
@@ -75,7 +76,7 @@ def complex_search_params():
             FlightSegment(
                 departure_airport=[[Airport.JFK, 0]],
                 arrival_airport=[[Airport.LAX, 0]],
-                travel_date=future_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(SECONDARY_TRAVEL_OFFSET_DAYS),
             )
         ],
         stops=MaxStops.ONE_STOP_OR_FEWER,
@@ -88,10 +89,6 @@ def complex_search_params():
 @pytest.fixture
 def round_trip_search_params():
     """Create basic round trip search params for testing."""
-    today = datetime.now()
-    outbound_date = today + timedelta(days=30)
-    return_date = outbound_date + timedelta(days=7)
-
     return FlightSearchFilters(
         passenger_info=PassengerInfo(
             adults=1,
@@ -103,12 +100,12 @@ def round_trip_search_params():
             FlightSegment(
                 departure_airport=[[Airport.SFO, 0]],
                 arrival_airport=[[Airport.JFK, 0]],
-                travel_date=outbound_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS),
             ),
             FlightSegment(
                 departure_airport=[[Airport.JFK, 0]],
                 arrival_airport=[[Airport.SFO, 0]],
-                travel_date=return_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(PRIMARY_TRAVEL_OFFSET_DAYS + SHORT_RETURN_OFFSET_DAYS),
             ),
         ],
         stops=MaxStops.NON_STOP,
@@ -122,10 +119,6 @@ def round_trip_search_params():
 @pytest.fixture
 def complex_round_trip_params():
     """Create more complex round trip search params for testing."""
-    today = datetime.now()
-    outbound_date = today + timedelta(days=60)
-    return_date = outbound_date + timedelta(days=14)
-
     return FlightSearchFilters(
         passenger_info=PassengerInfo(
             adults=2,
@@ -137,12 +130,12 @@ def complex_round_trip_params():
             FlightSegment(
                 departure_airport=[[Airport.LAX, 0]],
                 arrival_airport=[[Airport.ORD, 0]],
-                travel_date=outbound_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(SECONDARY_TRAVEL_OFFSET_DAYS),
             ),
             FlightSegment(
                 departure_airport=[[Airport.ORD, 0]],
                 arrival_airport=[[Airport.LAX, 0]],
-                travel_date=return_date.strftime("%Y-%m-%d"),
+                travel_date=live_api_date(SECONDARY_TRAVEL_OFFSET_DAYS + LONG_RETURN_OFFSET_DAYS),
             ),
         ],
         stops=MaxStops.ONE_STOP_OR_FEWER,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared helper for dates used by tests that hit the live Google Flights API
- move live search and MCP tests off near-term/today-based dates onto strictly future travel windows
- keep round-trip offsets and date windows consistent across search and MCP coverage

## Testing
- `uv run ruff check tests/live_api_dates.py tests/search/test_search_dates.py tests/search/test_search_flights.py tests/mcp/test_mcp_server.py`
- `uv run pytest -vv tests/search/test_search_dates.py`
- `uv run pytest -vv tests/search/test_search_flights.py`
- `uv run pytest -vv tests/mcp/test_mcp_server.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-891f2801-3de5-4ccc-9ac4-3d417f0d2627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-891f2801-3de5-4ccc-9ac4-3d417f0d2627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

