### PR TITLE
feat: support multiple origin/destination airports in MCP search

### DIFF
--- a/fli/core/builders.py
+++ b/fli/core/builders.py
@@ -66,8 +66,8 @@ def build_time_restrictions(
 
 
 def build_flight_segments(
-    origin: Airport,
-    destination: Airport,
+    origin: Airport | list[Airport],
+    destination: Airport | list[Airport],
     departure_date: str,
     return_date: str | None = None,
     time_restrictions: TimeRestrictions | None = None,
@@ -75,8 +75,8 @@ def build_flight_segments(
     """Build flight segments for a search request.
 
     Args:
-        origin: Departure airport
-        destination: Arrival airport
+        origin: Departure airport(s) - single Airport or list for multi-airport search
+        destination: Arrival airport(s) - single Airport or list for multi-airport search
         departure_date: Outbound travel date in YYYY-MM-DD format
         return_date: Return travel date in YYYY-MM-DD format (optional)
         time_restrictions: Time restrictions to apply to segments
@@ -87,10 +87,14 @@ def build_flight_segments(
     """
     departure_date = normalize_date(departure_date)
 
+    # Normalize to lists for uniform handling
+    origins = origin if isinstance(origin, list) else [origin]
+    destinations = destination if isinstance(destination, list) else [destination]
+
     segments = [
         FlightSegment(
-            departure_airport=[[origin, 0]],
-            arrival_airport=[[destination, 0]],
+            departure_airport=[[apt, 0] for apt in origins],
+            arrival_airport=[[apt, 0] for apt in destinations],
             travel_date=departure_date,
             time_restrictions=time_restrictions,
         )
@@ -103,8 +107,8 @@ def build_flight_segments(
         trip_type = TripType.ROUND_TRIP
         segments.append(
             FlightSegment(
-                departure_airport=[[destination, 0]],
-                arrival_airport=[[origin, 0]],
+                departure_airport=[[apt, 0] for apt in destinations],
+                arrival_airport=[[apt, 0] for apt in origins],
                 travel_date=return_date,
                 time_restrictions=time_restrictions,
             )
@@ -146,8 +150,8 @@ def build_multi_city_segments(
 
 
 def build_date_search_segments(
-    origin: Airport,
-    destination: Airport,
+    origin: Airport | list[Airport],
+    destination: Airport | list[Airport],
     start_date: str,
     trip_duration: int | None = None,
     is_round_trip: bool = False,
@@ -156,8 +160,8 @@ def build_date_search_segments(
     """Build flight segments for a date range search.
 
     Args:
-        origin: Departure airport
-        destination: Arrival airport
+        origin: Departure airport(s) - single Airport or list for multi-airport search
+        destination: Arrival airport(s) - single Airport or list for multi-airport search
         start_date: Start date of the search range in YYYY-MM-DD format
         trip_duration: Duration of the trip in days (for round trips)
         is_round_trip: Whether to search for round-trip flights
@@ -169,10 +173,14 @@ def build_date_search_segments(
     """
     start_date = normalize_date(start_date)
 
+    # Normalize to lists for uniform handling
+    origins = origin if isinstance(origin, list) else [origin]
+    destinations = destination if isinstance(destination, list) else [destination]
+
     segments = [
         FlightSegment(
-            departure_airport=[[origin, 0]],
-            arrival_airport=[[destination, 0]],
+            departure_airport=[[apt, 0] for apt in origins],
+            arrival_airport=[[apt, 0] for apt in destinations],
             travel_date=start_date,
             time_restrictions=time_restrictions,
         )
@@ -188,8 +196,8 @@ def build_date_search_segments(
 
         segments.append(
             FlightSegment(
-                departure_airport=[[destination, 0]],
-                arrival_airport=[[origin, 0]],
+                departure_airport=[[apt, 0] for apt in destinations],
+                arrival_airport=[[apt, 0] for apt in origins],
                 travel_date=return_date,
                 time_restrictions=time_restrictions,
             )

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -40,6 +40,7 @@ from fli.core import (
 )
 from fli.core.parsers import ParseError
 from fli.models import (
+    Airport,
     BagsFilter,
     DateSearchFilters,
     FlightSearchFilters,
@@ -214,8 +215,12 @@ mcp = FliMCP("Flight Search MCP Server")
 class FlightSearchParams(BaseModel):
     """Parameters for searching flights on a specific date."""
 
-    origin: str = Field(description="Departure airport IATA code (e.g., 'JFK', 'LAX')")
-    destination: str = Field(description="Arrival airport IATA code (e.g., 'LHR', 'NRT')")
+    origin: str = Field(
+        description="Departure airport IATA code(s), comma-separated for multiple (e.g., 'JFK,LGA')"
+    )
+    destination: str = Field(
+        description="Arrival airport IATA code(s), comma-separated for multiple (e.g., 'LHR,CDG')"
+    )
     departure_date: str = Field(description="Outbound travel date in YYYY-MM-DD format")
     return_date: str | None = Field(
         None, description="Return date in YYYY-MM-DD format (omit for one-way)"
@@ -258,8 +263,12 @@ class FlightSearchParams(BaseModel):
 class DateSearchParams(BaseModel):
     """Parameters for finding the cheapest travel dates within a range."""
 
-    origin: str = Field(description="Departure airport IATA code (e.g., 'JFK', 'LAX')")
-    destination: str = Field(description="Arrival airport IATA code (e.g., 'LHR', 'NRT')")
+    origin: str = Field(
+        description="Departure airport IATA code(s), comma-separated for multiple (e.g., 'JFK,LGA')"
+    )
+    destination: str = Field(
+        description="Arrival airport IATA code(s), comma-separated for multiple (e.g., 'LHR,CDG')"
+    )
     start_date: str = Field(description="Start of date range in YYYY-MM-DD format")
     end_date: str = Field(description="End of date range in YYYY-MM-DD format")
     trip_duration: int = Field(
@@ -354,12 +363,17 @@ def _serialize_date_result(date_result: Any) -> dict[str, Any]:
 # =============================================================================
 
 
+def _resolve_airports(codes: str) -> list[Airport]:
+    """Resolve one or more comma-separated airport codes."""
+    return [resolve_airport(code.strip()) for code in codes.split(",") if code.strip()]
+
+
 def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
     """Execute a flight search and return formatted results."""
     try:
-        # Parse inputs using shared utilities
-        origin = resolve_airport(params.origin)
-        destination = resolve_airport(params.destination)
+        # Parse inputs using shared utilities (supports comma-separated multi-airport)
+        origins = _resolve_airports(params.origin)
+        destinations = _resolve_airports(params.destination)
         cabin_class = parse_cabin_class(params.cabin_class)
         max_stops = parse_max_stops(params.max_stops)
         sort_by = parse_sort_by(params.sort_by)
@@ -369,10 +383,10 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
         departure_window = params.departure_window or CONFIG.default_departure_window
         time_restrictions = build_time_restrictions(departure_window) if departure_window else None
 
-        # Build flight segments
+        # Build flight segments (pass full lists for multi-airport support)
         segments, trip_type = build_flight_segments(
-            origin=origin,
-            destination=destination,
+            origin=origins,
+            destination=destinations,
             departure_date=params.departure_date,
             return_date=params.return_date,
             time_restrictions=time_restrictions,
@@ -432,9 +446,9 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
 def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
     """Execute a date search and return formatted results."""
     try:
-        # Parse inputs using shared utilities
-        origin = resolve_airport(params.origin)
-        destination = resolve_airport(params.destination)
+        # Parse inputs using shared utilities (supports comma-separated multi-airport)
+        origins = _resolve_airports(params.origin)
+        destinations = _resolve_airports(params.destination)
         cabin_class = parse_cabin_class(params.cabin_class)
         max_stops = parse_max_stops(params.max_stops)
         airlines = parse_airlines(params.airlines)
@@ -443,10 +457,10 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
         departure_window = params.departure_window or CONFIG.default_departure_window
         time_restrictions = build_time_restrictions(departure_window) if departure_window else None
 
-        # Build flight segments
+        # Build flight segments (pass full lists for multi-airport support)
         segments, trip_type = build_date_search_segments(
-            origin=origin,
-            destination=destination,
+            origin=origins,
+            destination=destinations,
             start_date=params.start_date,
             trip_duration=params.trip_duration,
             is_round_trip=params.is_round_trip,

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -365,7 +365,10 @@ def _serialize_date_result(date_result: Any) -> dict[str, Any]:
 
 def _resolve_airports(codes: str) -> list[Airport]:
     """Resolve one or more comma-separated airport codes."""
-    return [resolve_airport(code.strip()) for code in codes.split(",") if code.strip()]
+    airports = [resolve_airport(code.strip()) for code in codes.split(",") if code.strip()]
+    if not airports:
+        raise ParseError(f"No valid airport codes found in: '{codes}'")
+    return airports
 
 
 def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -533,8 +533,20 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
     },
 )
 def search_flights(
-    origin: Annotated[str, Field(description="Departure airport IATA code (e.g., 'JFK')")],
-    destination: Annotated[str, Field(description="Arrival airport IATA code (e.g., 'LHR')")],
+    origin: Annotated[
+        str,
+        Field(
+            description="Departure airport IATA code(s), comma-separated for multiple "
+            "(e.g., 'JFK' or 'JFK,LGA')"
+        ),
+    ],
+    destination: Annotated[
+        str,
+        Field(
+            description="Arrival airport IATA code(s), comma-separated for multiple "
+            "(e.g., 'LHR' or 'LHR,CDG')"
+        ),
+    ],
     departure_date: Annotated[str, Field(description="Travel date in YYYY-MM-DD format")],
     return_date: Annotated[
         str | None,
@@ -630,8 +642,20 @@ search_flights.fn = _search_flights_from_params  # type: ignore[attr-defined]
     },
 )
 def search_dates(
-    origin: Annotated[str, Field(description="Departure airport IATA code (e.g., 'JFK')")],
-    destination: Annotated[str, Field(description="Arrival airport IATA code (e.g., 'LHR')")],
+    origin: Annotated[
+        str,
+        Field(
+            description="Departure airport IATA code(s), comma-separated for multiple "
+            "(e.g., 'JFK' or 'JFK,LGA')"
+        ),
+    ],
+    destination: Annotated[
+        str,
+        Field(
+            description="Arrival airport IATA code(s), comma-separated for multiple "
+            "(e.g., 'LHR' or 'LHR,CDG')"
+        ),
+    ],
     start_date: Annotated[str, Field(description="Start of date range in YYYY-MM-DD format")],
     end_date: Annotated[str, Field(description="End of date range in YYYY-MM-DD format")],
     trip_duration: Annotated[

--- a/tests/core/test_builders.py
+++ b/tests/core/test_builders.py
@@ -73,3 +73,96 @@ class TestBuildDateSearchSegments:
         assert trip_type == TripType.ROUND_TRIP
         assert segments[0].travel_date == "2027-01-15"
         assert segments[1].travel_date == "2027-01-22"
+
+
+class TestBuildFlightSegmentsMultiAirport:
+    """Tests for multi-airport support in build_flight_segments."""
+
+    def test_single_airport_wraps_to_list(self):
+        segments, _ = build_flight_segments(
+            origin=Airport.JFK,
+            destination=Airport.LAX,
+            departure_date="2027-03-15",
+        )
+        assert segments[0].departure_airport == [[Airport.JFK, 0]]
+        assert segments[0].arrival_airport == [[Airport.LAX, 0]]
+
+    def test_list_of_origins(self):
+        segments, _ = build_flight_segments(
+            origin=[Airport.JFK, Airport.LGA],
+            destination=Airport.LHR,
+            departure_date="2027-03-15",
+        )
+        assert segments[0].departure_airport == [[Airport.JFK, 0], [Airport.LGA, 0]]
+        assert segments[0].arrival_airport == [[Airport.LHR, 0]]
+
+    def test_list_of_destinations(self):
+        segments, _ = build_flight_segments(
+            origin=Airport.JFK,
+            destination=[Airport.LHR, Airport.CDG],
+            departure_date="2027-03-15",
+        )
+        assert segments[0].departure_airport == [[Airport.JFK, 0]]
+        assert segments[0].arrival_airport == [[Airport.LHR, 0], [Airport.CDG, 0]]
+
+    def test_lists_on_both_sides(self):
+        segments, _ = build_flight_segments(
+            origin=[Airport.JFK, Airport.LGA, Airport.EWR],
+            destination=[Airport.LHR, Airport.CDG],
+            departure_date="2027-03-15",
+        )
+        assert segments[0].departure_airport == [
+            [Airport.JFK, 0],
+            [Airport.LGA, 0],
+            [Airport.EWR, 0],
+        ]
+        assert segments[0].arrival_airport == [[Airport.LHR, 0], [Airport.CDG, 0]]
+
+    def test_round_trip_mirrors_multi_airport(self):
+        segments, trip_type = build_flight_segments(
+            origin=[Airport.JFK, Airport.LGA],
+            destination=[Airport.LHR, Airport.CDG],
+            departure_date="2027-03-15",
+            return_date="2027-03-22",
+        )
+        assert trip_type == TripType.ROUND_TRIP
+        assert segments[0].departure_airport == [[Airport.JFK, 0], [Airport.LGA, 0]]
+        assert segments[0].arrival_airport == [[Airport.LHR, 0], [Airport.CDG, 0]]
+        assert segments[1].departure_airport == [[Airport.LHR, 0], [Airport.CDG, 0]]
+        assert segments[1].arrival_airport == [[Airport.JFK, 0], [Airport.LGA, 0]]
+
+
+class TestBuildDateSearchSegmentsMultiAirport:
+    """Tests for multi-airport support in build_date_search_segments."""
+
+    def test_single_airport_wraps_to_list(self):
+        segments, _ = build_date_search_segments(
+            origin=Airport.JFK,
+            destination=Airport.LAX,
+            start_date="2027-03-15",
+        )
+        assert segments[0].departure_airport == [[Airport.JFK, 0]]
+        assert segments[0].arrival_airport == [[Airport.LAX, 0]]
+
+    def test_list_inputs_preserved(self):
+        segments, _ = build_date_search_segments(
+            origin=[Airport.JFK, Airport.LGA],
+            destination=[Airport.LHR, Airport.CDG],
+            start_date="2027-03-15",
+        )
+        assert segments[0].departure_airport == [[Airport.JFK, 0], [Airport.LGA, 0]]
+        assert segments[0].arrival_airport == [[Airport.LHR, 0], [Airport.CDG, 0]]
+
+    def test_round_trip_mirrors_multi_airport(self):
+        segments, trip_type = build_date_search_segments(
+            origin=[Airport.JFK, Airport.LGA],
+            destination=[Airport.LHR, Airport.CDG],
+            start_date="2027-03-15",
+            is_round_trip=True,
+            trip_duration=7,
+        )
+        assert trip_type == TripType.ROUND_TRIP
+        assert segments[0].departure_airport == [[Airport.JFK, 0], [Airport.LGA, 0]]
+        assert segments[0].arrival_airport == [[Airport.LHR, 0], [Airport.CDG, 0]]
+        assert segments[1].departure_airport == [[Airport.LHR, 0], [Airport.CDG, 0]]
+        assert segments[1].arrival_airport == [[Airport.JFK, 0], [Airport.LGA, 0]]

--- a/tests/mcp/test_multi_airport.py
+++ b/tests/mcp/test_multi_airport.py
@@ -1,0 +1,52 @@
+"""Tests for multi-airport support in MCP server helpers."""
+
+import pytest
+
+from fli.core.parsers import ParseError
+from fli.mcp.server import _resolve_airports
+from fli.models import Airport
+
+
+class TestResolveAirports:
+    """Tests for the comma-separated airport resolver."""
+
+    def test_single_code(self):
+        assert _resolve_airports("JFK") == [Airport.JFK]
+
+    def test_multiple_codes(self):
+        assert _resolve_airports("JFK,LGA") == [Airport.JFK, Airport.LGA]
+
+    def test_multiple_codes_with_whitespace(self):
+        assert _resolve_airports(" JFK , LGA ") == [Airport.JFK, Airport.LGA]
+
+    def test_lowercase_codes(self):
+        assert _resolve_airports("jfk,lga") == [Airport.JFK, Airport.LGA]
+
+    def test_mixed_case_codes(self):
+        assert _resolve_airports("jFk,Lga") == [Airport.JFK, Airport.LGA]
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ParseError):
+            _resolve_airports("")
+
+    def test_only_commas_raises(self):
+        with pytest.raises(ParseError):
+            _resolve_airports(",,,")
+
+    def test_only_whitespace_raises(self):
+        with pytest.raises(ParseError):
+            _resolve_airports("   ")
+
+    def test_invalid_code_raises(self):
+        with pytest.raises(ParseError):
+            _resolve_airports("INVALID")
+
+    def test_valid_followed_by_invalid_raises(self):
+        with pytest.raises(ParseError):
+            _resolve_airports("JFK,INVALID")
+
+    def test_preserves_order(self):
+        assert _resolve_airports("CDG,LHR,JFK") == [Airport.CDG, Airport.LHR, Airport.JFK]
+
+    def test_three_airports(self):
+        assert _resolve_airports("JFK,LGA,EWR") == [Airport.JFK, Airport.LGA, Airport.EWR]


### PR DESCRIPTION
## Summary

MCP `search_flights` and `search_dates` tools now accept comma-separated airport codes for origin and destination (e.g., `origin="JFK,LGA"` `destination="LHR,CDG"`). Single codes still work as before.

## Changes

- Updated `FlightSearchParams` and `DateSearchParams` field descriptions to document comma syntax
- Added `_resolve_airports()` helper in `fli/mcp/server.py` to parse comma-separated codes into Airport lists
- Updated `build_flight_segments()` and `build_date_search_segments()` in `fli/core/builders.py` to accept `Airport | list[Airport]` and build multi-airport `FlightSegment` entries
- The underlying `FlightSegment` model already supports `list[list[Airport | int]]` for multi-airport per leg, so no model changes were needed

## Testing

All 165 existing tests pass. Ruff format and lint clean. The Google Flights API accepts multi-airport segments at the protocol level, though response reliability for multi-airport queries may vary.

Closes #98

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the MCP `search_flights` and `search_dates` tools to accept comma-separated airport codes for multi-airport origin/destination searches (e.g., `origin="JFK,LGA"`), requiring no changes to the underlying `FlightSegment` model which already supports multiple airports per leg.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all 165 existing tests pass and the multi-airport logic is correct.

The only finding is a P2 edge case where an empty or all-comma input string silently returns an empty list and produces a less descriptive error than before. This is not a production-breaking issue and does not affect valid inputs.

fli/mcp/server.py — _resolve_airports empty-list guard

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/core/builders.py | Widens origin/destination parameters to Airport | list[Airport]; normalizes to list before building FlightSegment entries — straightforward and correct. |
| fli/mcp/server.py | Adds _resolve_airports() helper for comma-separated codes and updates both execute functions to use it; minor edge case with empty-input error messaging (P2). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as MCP Client
    participant Server as server.py
    participant Resolve as _resolve_airports()
    participant Builder as builders.py
    participant API as Google Flights API

    Client->>Server: search_flights(origin="JFK,LGA", destination="LHR,CDG")
    Server->>Resolve: _resolve_airports("JFK,LGA")
    Resolve-->>Server: [Airport.JFK, Airport.LGA]
    Server->>Resolve: _resolve_airports("LHR,CDG")
    Resolve-->>Server: [Airport.LHR, Airport.CDG]
    Server->>Builder: build_flight_segments(origins=[JFK,LGA], destinations=[LHR,CDG])
    Builder-->>Server: FlightSegment(departure=[[JFK,0],[LGA,0]], arrival=[[LHR,0],[CDG,0]])
    Server->>API: POST /search with multi-airport segment
    API-->>Server: flight results
    Server-->>Client: {success: true, flights: [...]}
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 366-368

Comment:
**Empty-list edge case in `_resolve_airports`**

If `codes` is an empty string or only commas/spaces (e.g., `","`), `_resolve_airports` returns `[]` after filtering. This empty list propagates into `build_flight_segments`, producing a `FlightSegment` with `departure_airport=[]`, which fails Pydantic's `validate_airports` and surfaces only as the generic `"Invalid parameter value"` response — a regression from pre-PR behavior where `resolve_airport("")` raised a descriptive `ParseError`. Adding a guard here restores actionable error messages.

```suggestion
def _resolve_airports(codes: str) -> list[Airport]:
    """Resolve one or more comma-separated airport codes."""
    airports = [resolve_airport(code.strip()) for code in codes.split(",") if code.strip()]
    if not airports:
        raise ParseError(f"No valid airport codes found in: '{codes}'")
    return airports
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: support multiple origin/destinatio..."](https://github.com/punitarani/fli/commit/06b09115b7e4f0bb635b9d25c30a466ff788a1f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27339102)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->