### PR TITLE
Add HTTP transport tests and update MCP server configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ install-all:
 mcp:
 	uv run fli-mcp
 
+# Run the MCP server over HTTP
+mcp-http:
+	uv run fli-mcp-http
+
 # Build the docs
 docs:
 	uv run --extra dev mkdocs build
@@ -83,4 +87,4 @@ help:
 	@echo "  make devcontainer - Build dev container image"
 	@echo "  make requirements - Generate the requirements.txt file"
 # Declare the targets as phony
-.PHONY: help install install-dev install-all mcp docs format lint lint-fix test test-mcp test-fuzz test-all ci ci-docker devcontainer requirements
+.PHONY: help install install-dev install-all mcp mcp-http docs format lint lint-fix test test-mcp test-fuzz test-all ci ci-docker devcontainer requirements

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -829,7 +829,7 @@ def run():
     mcp.run(transport="stdio")
 
 
-def run_http(host: str = "127.0.0.1", port: int = 8000) -> None:
+def run_http(host: str = "0.0.0.0", port: int = 8000) -> None:
     """Run the MCP server over HTTP (streamable)."""
     env_host = os.getenv("HOST")
     env_port = os.getenv("PORT")

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -830,7 +830,13 @@ def run():
 
 
 def run_http(host: str = "0.0.0.0", port: int = 8000) -> None:
-    """Run the MCP server over HTTP (streamable)."""
+    """Run the MCP server over HTTP (streamable).
+
+    The default host is ``0.0.0.0`` so the server is reachable from outside the
+    container when deployed (e.g. Railway, Docker). When running locally this
+    exposes the server on every network interface — set ``HOST=127.0.0.1`` to
+    restrict it to loopback.
+    """
     env_host = os.getenv("HOST")
     env_port = os.getenv("PORT")
 

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,5 @@
 [build]
 builder = "NIXPACKS"
-nixpacksPlan = { "repo" = "punitarani/fli" }
 
 [deploy]
 numReplicas = 1

--- a/tests/mcp/test_mcp_http.py
+++ b/tests/mcp/test_mcp_http.py
@@ -1,0 +1,131 @@
+"""Tests that the MCP HTTP server boots and exposes the expected tools.
+
+Covers:
+  1. In-process client test — verifies tool listing without networking.
+  2. HTTP transport test — starts the server on a free port and connects over HTTP.
+"""
+
+import socket
+import threading
+import time
+
+import pytest
+import uvicorn
+from fastmcp import Client
+
+from fli.mcp.server import mcp
+
+EXPECTED_TOOLS = {"search_flights", "search_dates"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    """Return an available TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Test A: In-process (no network)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPInProcess:
+    """Verify MCP tool listing via the in-process FastMCP client."""
+
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_expected_names(self):
+        """list_tools() must return search_flights and search_dates."""
+        client = Client(mcp)
+        async with client:
+            tools = await client.list_tools()
+        names = {t.name for t in tools}
+        assert names == EXPECTED_TOOLS
+
+    @pytest.mark.asyncio
+    async def test_tools_have_description_and_schema(self):
+        """Each tool must have a non-empty description and an inputSchema."""
+        client = Client(mcp)
+        async with client:
+            tools = await client.list_tools()
+        for tool in tools:
+            assert tool.description, f"{tool.name} is missing a description"
+            assert tool.inputSchema, f"{tool.name} is missing inputSchema"
+
+
+# ---------------------------------------------------------------------------
+# Test B: HTTP transport (full integration)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPHTTP:
+    """Start the MCP server over HTTP and verify tools via a real connection."""
+
+    @pytest.mark.asyncio
+    async def test_http_list_tools(self):
+        """Boot the HTTP server, connect, and verify tool names."""
+        port = _free_port()
+
+        app = mcp.http_app()
+        config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+        server = uvicorn.Server(config)
+
+        thread = threading.Thread(target=server.run, daemon=True)
+        thread.start()
+
+        # Wait for the server to accept connections.
+        for _ in range(40):
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+                    break
+            except OSError:
+                time.sleep(0.25)
+        else:
+            pytest.fail("MCP HTTP server did not start in time")
+
+        try:
+            client = Client(f"http://127.0.0.1:{port}/mcp/")
+            async with client:
+                tools = await client.list_tools()
+            names = {t.name for t in tools}
+            assert names == EXPECTED_TOOLS
+        finally:
+            server.should_exit = True
+            thread.join(timeout=5)
+
+    @pytest.mark.asyncio
+    async def test_http_tools_have_description_and_schema(self):
+        """Boot the HTTP server and verify each tool has description + schema."""
+        port = _free_port()
+
+        app = mcp.http_app()
+        config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+        server = uvicorn.Server(config)
+
+        thread = threading.Thread(target=server.run, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+                    break
+            except OSError:
+                time.sleep(0.25)
+        else:
+            pytest.fail("MCP HTTP server did not start in time")
+
+        try:
+            client = Client(f"http://127.0.0.1:{port}/mcp/")
+            async with client:
+                tools = await client.list_tools()
+            for tool in tools:
+                assert tool.description, f"{tool.name} is missing a description"
+                assert tool.inputSchema, f"{tool.name} is missing inputSchema"
+        finally:
+            server.should_exit = True
+            thread.join(timeout=5)

--- a/tests/mcp/test_mcp_http.py
+++ b/tests/mcp/test_mcp_http.py
@@ -5,7 +5,6 @@ Covers:
   2. HTTP transport test — starts the server on a free port and connects over HTTP.
 """
 
-import socket
 import threading
 import time
 
@@ -19,15 +18,38 @@ EXPECTED_TOOLS = {"search_flights", "search_dates"}
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures
 # ---------------------------------------------------------------------------
 
 
-def _free_port() -> int:
-    """Return an available TCP port on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+@pytest.fixture
+def http_mcp_url():
+    """Boot the MCP server in a background thread and yield its base URL.
+
+    Uses uvicorn port=0 so the OS assigns a free port at bind time, then reads
+    the actual port back from the bound socket. This avoids the TOCTOU race of
+    pre-allocating a port and hoping nothing else claims it before uvicorn binds.
+    """
+    app = mcp.http_app()
+    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10
+    while not server.started:
+        if time.monotonic() > deadline:
+            server.should_exit = True
+            thread.join(timeout=5)
+            pytest.fail("MCP HTTP server did not start in time")
+        time.sleep(0.05)
+
+    port = server.servers[0].sockets[0].getsockname()[1]
+    try:
+        yield f"http://127.0.0.1:{port}/mcp/"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
 
 
 # ---------------------------------------------------------------------------
@@ -67,65 +89,20 @@ class TestMCPHTTP:
     """Start the MCP server over HTTP and verify tools via a real connection."""
 
     @pytest.mark.asyncio
-    async def test_http_list_tools(self):
+    async def test_http_list_tools(self, http_mcp_url):
         """Boot the HTTP server, connect, and verify tool names."""
-        port = _free_port()
-
-        app = mcp.http_app()
-        config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
-        server = uvicorn.Server(config)
-
-        thread = threading.Thread(target=server.run, daemon=True)
-        thread.start()
-
-        # Wait for the server to accept connections.
-        for _ in range(40):
-            try:
-                with socket.create_connection(("127.0.0.1", port), timeout=0.25):
-                    break
-            except OSError:
-                time.sleep(0.25)
-        else:
-            pytest.fail("MCP HTTP server did not start in time")
-
-        try:
-            client = Client(f"http://127.0.0.1:{port}/mcp/")
-            async with client:
-                tools = await client.list_tools()
-            names = {t.name for t in tools}
-            assert names == EXPECTED_TOOLS
-        finally:
-            server.should_exit = True
-            thread.join(timeout=5)
+        client = Client(http_mcp_url)
+        async with client:
+            tools = await client.list_tools()
+        names = {t.name for t in tools}
+        assert names == EXPECTED_TOOLS
 
     @pytest.mark.asyncio
-    async def test_http_tools_have_description_and_schema(self):
+    async def test_http_tools_have_description_and_schema(self, http_mcp_url):
         """Boot the HTTP server and verify each tool has description + schema."""
-        port = _free_port()
-
-        app = mcp.http_app()
-        config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
-        server = uvicorn.Server(config)
-
-        thread = threading.Thread(target=server.run, daemon=True)
-        thread.start()
-
-        for _ in range(40):
-            try:
-                with socket.create_connection(("127.0.0.1", port), timeout=0.25):
-                    break
-            except OSError:
-                time.sleep(0.25)
-        else:
-            pytest.fail("MCP HTTP server did not start in time")
-
-        try:
-            client = Client(f"http://127.0.0.1:{port}/mcp/")
-            async with client:
-                tools = await client.list_tools()
-            for tool in tools:
-                assert tool.description, f"{tool.name} is missing a description"
-                assert tool.inputSchema, f"{tool.name} is missing inputSchema"
-        finally:
-            server.should_exit = True
-            thread.join(timeout=5)
+        client = Client(http_mcp_url)
+        async with client:
+            tools = await client.list_tools()
+        for tool in tools:
+            assert tool.description, f"{tool.name} is missing a description"
+            assert tool.inputSchema, f"{tool.name} is missing inputSchema"

--- a/tests/mcp/test_mcp_http.py
+++ b/tests/mcp/test_mcp_http.py
@@ -14,7 +14,7 @@ from fastmcp import Client
 
 from fli.mcp.server import mcp
 
-EXPECTED_TOOLS = {"search_flights", "search_dates"}
+EXPECTED_TOOLS = {"search_flights", "search_dates", "find_airports"}
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +62,7 @@ class TestMCPInProcess:
 
     @pytest.mark.asyncio
     async def test_list_tools_returns_expected_names(self):
-        """list_tools() must return search_flights and search_dates."""
+        """list_tools() must return the expected MCP tools."""
         client = Client(mcp)
         async with client:
             tools = await client.list_tools()


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for the MCP HTTP server and updates the server configuration to support HTTP transport testing and deployment.

## Key Changes

- **New test suite** (`tests/mcp/test_mcp_http.py`): Added 4 test cases covering both in-process and HTTP transport scenarios:
  - In-process client tests verify tool listing without networking overhead
  - HTTP transport tests start the server on a free port and validate tool exposure over HTTP
  - All tests verify that expected tools (`search_flights`, `search_dates`) are present with proper descriptions and input schemas

- **MCP server configuration**: Updated `run_http()` default host from `127.0.0.1` to `0.0.0.0` to allow external connections, enabling proper HTTP server deployment

- **Build tooling**: Added `mcp-http` Makefile target to run the HTTP server variant and updated `.PHONY` declarations

- **Deployment config**: Removed hardcoded nixpacksPlan reference from `railway.toml` to allow dynamic configuration

## Implementation Details

The HTTP tests use a helper function to find available TCP ports and implement proper server lifecycle management:
- Server startup with connection retry logic (40 attempts with 0.25s intervals)
- Graceful shutdown via `server.should_exit` flag
- Thread-based server execution to avoid blocking async test execution
- Proper resource cleanup in finally blocks

https://claude.ai/code/session_01MkjS2kP1d43DGvqr818MkJ

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds HTTP transport test coverage for the MCP server (in-process + real uvicorn), updates the default bind host to `0.0.0.0` for Railway deployment, adds a `mcp-http` Makefile target, and cleans up `railway.toml`. All findings are style/quality suggestions with no blocking issues.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style suggestions with no blocking correctness or security issues.

The `_free_port()` race is a well-known test-flakiness pattern mitigated by the existing retry loop, and the 0.0.0.0 change is intentional and documented in the PR description. No P0/P1 issues were found.

tests/mcp/test_mcp_http.py — minor race condition and duplication worth cleaning up in a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/mcp/test_mcp_http.py | New test file with solid structure; contains a TOCTOU race in _free_port() and duplicated server-lifecycle boilerplate across two HTTP test methods. |
| fli/mcp/server.py | Default bind host changed from 127.0.0.1 to 0.0.0.0; intentional for deployment but may surprise local users — rest of the function is unchanged. |
| Makefile | Added mcp-http target and updated .PHONY declaration; straightforward and correct. |
| railway.toml | Removed hardcoded nixpacksPlan line to allow dynamic Railway configuration; change is intentional and safe. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as pytest test
    participant FP as _free_port()
    participant UV as uvicorn.Server
    participant MCP as FastMCP app
    participant Client as FastMCP Client

    Test->>FP: bind & release port
    FP-->>Test: port number
    Test->>UV: Config(host, port)
    Test->>UV: server.run() [daemon thread]
    loop up to 40 × 0.25 s
        Test->>UV: socket.create_connection()
        UV-->>Test: connected / OSError
    end
    Test->>Client: Client(http://127.0.0.1:{port}/mcp/)
    Client->>MCP: list_tools()
    MCP-->>Client: [search_flights, search_dates]
    Client-->>Test: tools list
    Test->>Test: assert names == EXPECTED_TOOLS
    Test->>UV: server.should_exit = True
    UV-->>Test: thread exits

```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/mcp/test_mcp_http.py
Line: 26-30

Comment:
**TOCTOU race in `_free_port()`**

The socket is closed when the `with` block exits, releasing the port before uvicorn binds to it. Another process or thread can claim that port in the gap, causing a flaky "server did not start in time" failure. The retry loop (lines 82–89) reduces the chance but doesn't eliminate it. A more robust pattern is to let uvicorn bind to port `0` and read the OS-assigned port after startup:

```python
# Instead of _free_port(), pass port=0 to uvicorn.Config and
# retrieve the actual port after the server is ready:
config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
server = uvicorn.Server(config)
thread = threading.Thread(target=server.run, daemon=True)
thread.start()
# Poll until server.started, then:
port = server.servers[0].sockets[0].getsockname()[1]
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/mcp/test_mcp_http.py
Line: 69-131

Comment:
**Duplicated server lifecycle setup**

`test_http_list_tools` and `test_http_tools_have_description_and_schema` share identical server start / wait-for-ready / shutdown boilerplate. Extracting this into an `asyncio`-compatible pytest fixture would remove ~25 duplicated lines and make future HTTP tests easier to add:

```python
import asyncio
import contextlib

@pytest.fixture()
async def http_mcp_server():
    port = _free_port()
    app = mcp.http_app()
    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
    server = uvicorn.Server(config)
    thread = threading.Thread(target=server.run, daemon=True)
    thread.start()
    for _ in range(40):
        try:
            with socket.create_connection(("127.0.0.1", port), timeout=0.25):
                break
        except OSError:
            time.sleep(0.25)
    else:
        pytest.fail("MCP HTTP server did not start in time")
    yield port
    server.should_exit = True
    thread.join(timeout=5)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 832

Comment:
**Default host `0.0.0.0` exposes all interfaces locally**

Changing from `127.0.0.1` to `0.0.0.0` makes sense for Railway (where binding all interfaces is required), but users running `fli-mcp-http` directly on their machine will now have the server reachable on every network interface without any warning. Consider documenting this in the help text or `README`, or prompting users to set the `HOST` env var when they need loopback-only behavior.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Setup Railway HTTP MCP deployment and ad..."](https://github.com/punitarani/fli/commit/1380e8fb02bfd429db5a5cd1eb46e60b98d0c6c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27339321)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=90a8ba16-9510-4f10-b2ad-cb22d0733792))

<!-- /greptile_comment -->