### PR TITLE
feat: add airport search by city name, airport name, or IATA code

### DIFF
--- a/fli/cli/commands/airports.py
+++ b/fli/cli/commands/airports.py
@@ -1,0 +1,51 @@
+"""Airport search command for looking up IATA codes."""
+
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from fli.core.airports import search_airports
+
+console = Console()
+
+
+def airports(
+    query: Annotated[
+        str,
+        typer.Argument(help="City name, airport name, or IATA code to search for"),
+    ],
+    limit: Annotated[int, typer.Option("--limit", "-n", help="Maximum results")] = 10,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+):
+    """Search for airports by city name, airport name, or IATA code.
+
+    Example:
+        fli airports "new york"
+        fli airports tokyo
+        fli airports JFK
+        fli airports heathrow
+
+    """
+    results = search_airports(query, limit=limit)
+
+    if not results:
+        console.print(f"[yellow]No airports found matching '{query}'[/yellow]")
+        raise typer.Exit(1)
+
+    if json_output:
+        import json
+
+        output = [{"code": r.code, "name": r.name, "match_type": r.match_type} for r in results]
+        console.print(json.dumps(output, indent=2))
+    else:
+        table = Table(title=f"Airports matching '{query}'")
+        table.add_column("Code", style="bold cyan", width=6)
+        table.add_column("Airport Name", style="white")
+        table.add_column("Match", style="dim")
+
+        for result in results:
+            table.add_row(result.code, result.name, result.match_type)
+
+        console.print(table)

--- a/fli/cli/main.py
+++ b/fli/cli/main.py
@@ -5,6 +5,7 @@ import sys
 
 import typer
 
+from fli.cli.commands.airports import airports
 from fli.cli.commands.dates import dates
 from fli.cli.commands.flights import flights
 
@@ -16,6 +17,7 @@ app = typer.Typer(
 # Register commands
 app.command(name="flights")(flights)
 app.command(name="dates")(dates)
+app.command(name="airports")(airports)
 
 
 @app.callback(invoke_without_command=True)
@@ -37,7 +39,7 @@ def cli():
         args.append("--help")
 
     # If the first argument isn't a command, treat as flights search
-    if args[0] not in ["flights", "dates", "--help", "-h"]:
+    if args[0] not in ["flights", "dates", "airports", "--help", "-h"]:
         sys.argv.insert(1, "flights")
 
     app()

--- a/fli/core/__init__.py
+++ b/fli/core/__init__.py
@@ -4,6 +4,7 @@ This module provides shared parsing and building utilities used by both
 the CLI and MCP interfaces.
 """
 
+from .airports import search_airports
 from .builders import (
     build_date_search_segments,
     build_flight_segments,
@@ -37,6 +38,7 @@ __all__ = [
     "build_flight_segments",
     "build_multi_city_segments",
     "build_time_restrictions",
+    "search_airports",
     # Currency
     "extract_currency_from_price_token",
     "format_price",

--- a/fli/core/airports.py
+++ b/fli/core/airports.py
@@ -81,14 +81,14 @@ def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
 
     Args:
         query: Search string (e.g., "new york", "san fran", "JFK", "heathrow")
-        limit: Maximum results to return.
+        limit: Maximum results to return (must be >= 1).
 
     Returns:
         List of matching airports sorted by relevance (best match first).
 
     """
     query_lower = query.strip().lower()
-    if not query_lower:
+    if not query_lower or limit < 1:
         return []
 
     results: list[AirportMatch] = []
@@ -115,16 +115,17 @@ def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
                     pass
 
     # Priority 3: Partial city name match (handles "new yo" matching "new york")
-    for city, codes in CITY_AIRPORTS.items():
-        if city.startswith(query_lower) and query_lower not in CITY_AIRPORTS:
-            for code in codes:
-                if code not in seen_codes:
-                    try:
-                        airport = Airport[code]
-                        results.append(AirportMatch(code, airport.value, "city", 80.0))
-                        seen_codes.add(code)
-                    except KeyError:
-                        pass
+    if query_lower not in CITY_AIRPORTS:
+        for city, codes in CITY_AIRPORTS.items():
+            if city.startswith(query_lower):
+                for code in codes:
+                    if code not in seen_codes:
+                        try:
+                            airport = Airport[code]
+                            results.append(AirportMatch(code, airport.value, "city", 80.0))
+                            seen_codes.add(code)
+                        except KeyError:
+                            pass
 
     # Priority 4: Airport name substring match
     for airport in Airport:

--- a/fli/core/airports.py
+++ b/fli/core/airports.py
@@ -1,0 +1,152 @@
+"""Airport search utilities for looking up airports by city or name."""
+
+from fli.models import Airport
+
+# Mapping of city names to IATA codes for airports where the city name
+# is NOT in the airport name (e.g., JFK doesn't contain "New York")
+CITY_AIRPORTS: dict[str, list[str]] = {
+    "new york": ["JFK", "LGA", "EWR"],
+    "nyc": ["JFK", "LGA", "EWR"],
+    "chicago": ["ORD", "MDW"],
+    "washington": ["IAD", "DCA", "BWI"],
+    "washington dc": ["IAD", "DCA", "BWI"],
+    "london": ["LHR", "LGW", "STN", "LTN", "LCY"],
+    "paris": ["CDG", "ORY"],
+    "tokyo": ["NRT", "HND"],
+    "osaka": ["KIX", "ITM"],
+    "seoul": ["ICN", "GMP"],
+    "beijing": ["PEK", "PKX"],
+    "shanghai": ["PVG", "SHA"],
+    "bangkok": ["BKK", "DMK"],
+    "istanbul": ["IST", "SAW"],
+    "moscow": ["SVO", "DME", "VKO"],
+    "milan": ["MXP", "LIN"],
+    "rome": ["FCO", "CIA"],
+    "berlin": ["BER"],
+    "mumbai": ["BOM"],
+    "delhi": ["DEL"],
+    "sao paulo": ["GRU", "CGH"],
+    "rio": ["GIG", "SDU"],
+    "rio de janeiro": ["GIG", "SDU"],
+    "toronto": ["YYZ", "YTZ"],
+    "montreal": ["YUL"],
+    "mexico city": ["MEX"],
+    "buenos aires": ["EZE", "AEP"],
+    "dubai": ["DXB", "DWC"],
+    "singapore": ["SIN"],
+    "hong kong": ["HKG"],
+    "taipei": ["TPE", "TSA"],
+    "sydney": ["SYD"],
+    "melbourne": ["MEL"],
+    "san francisco": ["SFO", "OAK", "SJC"],
+    "sf": ["SFO", "OAK", "SJC"],
+    "bay area": ["SFO", "OAK", "SJC"],
+    "los angeles": ["LAX", "BUR", "SNA", "ONT", "LGB"],
+    "la": ["LAX", "BUR", "SNA", "ONT", "LGB"],
+    "dallas": ["DFW", "DAL"],
+    "houston": ["IAH", "HOU"],
+    "atlanta": ["ATL"],
+    "denver": ["DEN"],
+    "seattle": ["SEA"],
+    "boston": ["BOS"],
+    "miami": ["MIA", "FLL"],
+    "detroit": ["DTW"],
+    "minneapolis": ["MSP"],
+    "phoenix": ["PHX"],
+    "orlando": ["MCO"],
+    "las vegas": ["LAS"],
+    "honolulu": ["HNL"],
+}
+
+
+class AirportMatch:
+    """A matched airport from a search query."""
+
+    def __init__(self, code: str, name: str, match_type: str, score: float):
+        """Initialize a matched airport result."""
+        self.code = code
+        self.name = name
+        self.match_type = match_type  # "code", "city", "name"
+        self.score = score
+
+    def __repr__(self) -> str:
+        """Return a debug representation for the match."""
+        return (
+            f"AirportMatch(code={self.code!r}, name={self.name!r}, match_type={self.match_type!r})"
+        )
+
+
+def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
+    """Search airports by city name, airport name, or IATA code.
+
+    Args:
+        query: Search string (e.g., "new york", "san fran", "JFK", "heathrow")
+        limit: Maximum results to return.
+
+    Returns:
+        List of matching airports sorted by relevance (best match first).
+
+    """
+    query_lower = query.strip().lower()
+    if not query_lower:
+        return []
+
+    results: list[AirportMatch] = []
+    seen_codes: set[str] = set()
+
+    # Priority 1: Exact IATA code match
+    query_upper = query.strip().upper()
+    try:
+        airport = Airport[query_upper]
+        results.append(AirportMatch(query_upper, airport.value, "code", 100.0))
+        seen_codes.add(query_upper)
+    except KeyError:
+        pass
+
+    # Priority 2: City name lookup (handles "new york" -> JFK, LGA, EWR)
+    if query_lower in CITY_AIRPORTS:
+        for code in CITY_AIRPORTS[query_lower]:
+            if code not in seen_codes:
+                try:
+                    airport = Airport[code]
+                    results.append(AirportMatch(code, airport.value, "city", 90.0))
+                    seen_codes.add(code)
+                except KeyError:
+                    pass
+
+    # Priority 3: Partial city name match (handles "new yo" matching "new york")
+    for city, codes in CITY_AIRPORTS.items():
+        if city.startswith(query_lower) and query_lower not in CITY_AIRPORTS:
+            for code in codes:
+                if code not in seen_codes:
+                    try:
+                        airport = Airport[code]
+                        results.append(AirportMatch(code, airport.value, "city", 80.0))
+                        seen_codes.add(code)
+                    except KeyError:
+                        pass
+
+    # Priority 4: Airport name substring match
+    for airport in Airport:
+        if airport.name in seen_codes:
+            continue
+        airport_name_lower = airport.value.lower()
+        if query_lower in airport_name_lower:
+            # Score based on how early the match occurs.
+            pos = airport_name_lower.find(query_lower)
+            score = 70.0 - (pos * 0.1)  # Earlier matches score higher.
+            results.append(AirportMatch(airport.name, airport.value, "name", score))
+            seen_codes.add(airport.name)
+
+    # Priority 5: IATA code prefix match (handles "SF" matching "SFO")
+    if len(query_upper) <= 3:
+        for airport in Airport:
+            if airport.name in seen_codes:
+                continue
+            if airport.name.startswith(query_upper):
+                results.append(AirportMatch(airport.name, airport.value, "code", 60.0))
+                seen_codes.add(airport.name)
+
+    # Sort by score descending, then by code alphabetically
+    results.sort(key=lambda m: (-m.score, m.code))
+    return results[:limit]

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -24,8 +24,8 @@ from fli.core import (
     parse_max_stops,
     parse_sort_by,
     resolve_airport,
+    search_airports,
 )
-from fli.core.airports import search_airports
 from fli.core.parsers import ParseError
 from fli.models import (
     BagsFilter,
@@ -565,7 +565,7 @@ def find_airports(
         ),
     ],
     limit: Annotated[int, Field(description="Maximum results to return", ge=1, le=50)] = 10,
-) -> str:
+) -> dict[str, Any]:
     """Search for airports by city name, airport name, or IATA code.
 
     Use this tool to find airport IATA codes before searching for flights.
@@ -574,13 +574,11 @@ def find_airports(
     """
     results = search_airports(query, limit=limit)
 
-    if not results:
-        return f"No airports found matching '{query}'."
-
-    lines = [f"Airports matching '{query}':\n"]
-    for r in results:
-        lines.append(f"  {r.code} - {r.name}")
-    return "\n".join(lines)
+    return {
+        "query": query,
+        "count": len(results),
+        "airports": [{"code": r.code, "name": r.name, "match_type": r.match_type} for r in results],
+    }
 
 
 

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -25,6 +25,7 @@ from fli.core import (
     parse_sort_by,
     resolve_airport,
 )
+from fli.core.airports import search_airports
 from fli.core.parsers import ParseError
 from fli.models import (
     BagsFilter,
@@ -545,6 +546,42 @@ def search_dates(
 def _search_dates_from_params(params: DateSearchParams) -> dict[str, Any]:
     """Entry point for tests that call the tool via a params object."""
     return _execute_date_search(params)
+
+
+@mcp.tool(
+    annotations={
+        "title": "Search Airports",
+        "readOnlyHint": True,
+        "idempotentHint": True,
+    },
+)
+def find_airports(
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "City name, airport name, or IATA code (e.g., 'new york', 'heathrow', 'JFK')"
+            )
+        ),
+    ],
+    limit: Annotated[int, Field(description="Maximum results to return", ge=1, le=50)] = 10,
+) -> str:
+    """Search for airports by city name, airport name, or IATA code.
+
+    Use this tool to find airport IATA codes before searching for flights.
+    Supports city names (e.g., "new york" returns JFK, LGA, EWR),
+    airport names (e.g., "heathrow" returns LHR), and IATA codes.
+    """
+    results = search_airports(query, limit=limit)
+
+    if not results:
+        return f"No airports found matching '{query}'."
+
+    lines = [f"Airports matching '{query}':\n"]
+    for r in results:
+        lines.append(f"  {r.code} - {r.name}")
+    return "\n".join(lines)
+
 
 
 # =============================================================================

--- a/tests/core/test_airports.py
+++ b/tests/core/test_airports.py
@@ -1,0 +1,99 @@
+"""Tests for airport search functionality."""
+
+from fli.core.airports import search_airports
+
+
+class TestSearchAirports:
+    """Tests for the search_airports function."""
+
+    def test_exact_iata_code(self):
+        """Exact IATA code returns the airport."""
+        results = search_airports("JFK")
+        assert len(results) >= 1
+        assert results[0].code == "JFK"
+        assert results[0].match_type == "code"
+
+    def test_iata_code_case_insensitive(self):
+        """IATA code search is case-insensitive."""
+        results = search_airports("jfk")
+        assert len(results) >= 1
+        assert results[0].code == "JFK"
+
+    def test_city_name_new_york(self):
+        """City name 'new york' returns NYC airports."""
+        results = search_airports("new york")
+        codes = [r.code for r in results]
+        assert "JFK" in codes
+        assert "LGA" in codes
+        assert "EWR" in codes
+
+    def test_city_name_tokyo(self):
+        """City name 'tokyo' returns Tokyo airports."""
+        results = search_airports("tokyo")
+        codes = [r.code for r in results]
+        assert "NRT" in codes
+        assert "HND" in codes
+
+    def test_city_name_london(self):
+        """City name 'london' returns London airports."""
+        results = search_airports("london")
+        codes = [r.code for r in results]
+        assert "LHR" in codes
+        assert "LGW" in codes
+
+    def test_airport_name_substring(self):
+        """Searching by airport name substring works."""
+        results = search_airports("heathrow")
+        assert len(results) >= 1
+        assert results[0].code == "LHR"
+
+    def test_airport_name_san_francisco(self):
+        """Searching 'san francisco' matches via both city map and name."""
+        results = search_airports("san francisco")
+        codes = [r.code for r in results]
+        assert "SFO" in codes
+
+    def test_partial_city_name(self):
+        """Partial city name matches."""
+        results = search_airports("new yo")
+        codes = [r.code for r in results]
+        assert "JFK" in codes
+
+    def test_iata_prefix(self):
+        """Partial IATA code prefix matches."""
+        results = search_airports("SF")
+        codes = [r.code for r in results]
+        assert "SFO" in codes
+
+    def test_empty_query(self):
+        """Empty query returns empty list."""
+        assert search_airports("") == []
+        assert search_airports("   ") == []
+
+    def test_no_results(self):
+        """Query with no matches returns empty list."""
+        results = search_airports("xyznonexistent")
+        assert results == []
+
+    def test_limit(self):
+        """Limit parameter caps results."""
+        results = search_airports("international", limit=3)
+        assert len(results) <= 3
+
+    def test_code_match_highest_priority(self):
+        """Exact code match scores higher than name match."""
+        results = search_airports("LAX")
+        assert results[0].code == "LAX"
+        assert results[0].match_type == "code"
+
+    def test_city_abbreviation(self):
+        """City abbreviations work."""
+        results = search_airports("sf")
+        codes = [r.code for r in results]
+        assert "SFO" in codes
+
+    def test_nyc_abbreviation(self):
+        """NYC abbreviation works."""
+        results = search_airports("nyc")
+        codes = [r.code for r in results]
+        assert "JFK" in codes


### PR DESCRIPTION
## Summary

Add `search_airports()` utility that looks up IATA codes from city names, airport names, or partial codes. Exposed as CLI command (`fli airports`), MCP tool (`find_airports`), and Python API (`from fli.core import search_airports`).

## Why this matters

Users must know IATA codes to use any fli command. When using fli through MCP with an AI assistant, the assistant needs to map "San Francisco" to "SFO" but fli provides no way to do this lookup. The competitor library [fast-flights](https://github.com/AWeirdDev/flights) had an [abandoned PR #66](https://github.com/AWeirdDev/flights/pull/66) for the same gap ("Enhance airport search to support multiple search criteria").

For MCP-powered travel agents, this is a prerequisite. You can't search flights if you don't know the airport code.

## Demo

![Airport Search Demo](https://vhs.charm.sh/vhs-49aVyEqoWHvu6DjVLBomfK.gif)

## Changes

- **`fli/core/airports.py`** (NEW, 152 lines) - Search function with 5-priority matching: exact IATA code, city name lookup (50+ major cities), partial city match, airport name substring, IATA prefix. City mapping covers cases where the city name isn't in the airport name (e.g., "new york" returns JFK, LGA, EWR since "John F Kennedy International Airport" doesn't contain "New York").

- **`fli/cli/commands/airports.py`** (NEW, 51 lines) - CLI command with rich table output and `--json` flag.

- **`fli/mcp/server.py`** (+36 lines) - `find_airports` MCP tool so AI assistants can resolve city names to codes before calling `search_flights`.

- **`tests/core/test_airports.py`** (NEW, 99 lines) - 15 tests covering exact codes, city names, partial matches, edge cases.

## Testing

```bash
uv run pytest -vv tests/core/test_airports.py  # 15 passed
uv run ruff check .                             # all checks passed
uv run fli airports "new york"                  # JFK, LGA, EWR
uv run fli airports heathrow                    # LHR
uv run fli airports sf                          # SFO, OAK, SJC
```

This contribution was developed with AI assistance (Codex + Claude Code).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `search_airports()` as a core utility, CLI command (`fli airports`), and MCP tool (`find_airports`) to let users (and AI agents) resolve city names or partial strings to IATA codes before calling flight search. The 5-priority matching algorithm (exact code → city map → partial city → airport name substring → IATA prefix) is well-structured and the test coverage is solid.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style suggestions with no correctness or runtime impact.

No P0 or P1 issues found. The logic is correct, tests cover all priority levels and edge cases, and the CLI/MCP wiring is done properly. Remaining comments are minor: a redundant condition placement, missing lower-bound validation on a parameter, an inconsistent return type on one MCP tool, and an import style mismatch.

fli/core/airports.py (minor loop guard) and fli/mcp/server.py (return type inconsistency) are the only files worth a second look, but neither blocks merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/core/airports.py | New 5-priority search function; well-structured but Priority 3 guard is checked inside the loop and limit parameter accepts negative values silently |
| fli/cli/commands/airports.py | Clean CLI command with rich table output and --json flag; no issues |
| fli/mcp/server.py | find_airports MCP tool added correctly but returns plain str while other tools return dict; search_airports imported from submodule instead of fli.core |
| fli/cli/main.py | airports command registered and added to CLI dispatch guard correctly |
| fli/core/__init__.py | search_airports correctly re-exported in __all__ |
| tests/core/test_airports.py | 15 tests covering all priority levels, edge cases, and abbreviations; good coverage |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[search_airports query] --> B{query empty?}
    B -- yes --> Z[return empty list]
    B -- no --> C[Priority 1: Exact IATA code match]
    C --> D{Airport enum match?}
    D -- yes --> E[Add with score 100]
    D -- no --> F[Priority 2: Exact city name lookup in CITY_AIRPORTS]
    E --> F
    F --> G{Exact city match?}
    G -- yes --> H[Add mapped airports with score 90]
    G -- no --> I[Priority 3: Partial city name match]
    H --> I
    I --> J{Any city starts with query AND query not in map?}
    J -- yes --> K[Add airports with score 80]
    J -- no --> L[Priority 4: Airport name substring scan]
    K --> L
    L --> M{query substring of any Airport.value?}
    M -- yes --> N[Add with score 70 minus position offset]
    M -- no --> O[Priority 5: IATA prefix scan]
    N --> O
    O --> P{len query <= 3?}
    P -- yes --> Q{Any IATA code starts with query?}
    Q -- yes --> R[Add with score 60]
    P -- no --> S[Sort by score desc then code asc]
    R --> S
    S --> T[Return results up to limit]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/core/airports.py
Line: 118-127

Comment:
**Priority 3 condition is re-evaluated on every loop iteration**

The guard `query_lower not in CITY_AIRPORTS` is constant across all iterations of the `CITY_AIRPORTS` loop. When the query has an exact city match, the loop still executes but immediately short-circuits on every entry — O(N) wasted evaluations. Hoist the check outside the loop for clarity and efficiency.

```suggestion
    # Priority 3: Partial city name match (handles "new yo" matching "new york")
    if query_lower not in CITY_AIRPORTS:
        for city, codes in CITY_AIRPORTS.items():
            if city.startswith(query_lower):
                for code in codes:
                    if code not in seen_codes:
                        try:
                            airport = Airport[code]
                            results.append(AirportMatch(code, airport.value, "city", 80.0))
                            seen_codes.add(code)
                        except KeyError:
                            pass
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/core/airports.py
Line: 79

Comment:
**`limit` not validated against non-positive values**

`results[:limit]` with `limit=0` silently returns an empty list; with `limit=-1` it drops the last result. The MCP tool enforces `ge=1`, but the public `search_airports` function has no guard, so callers using the Python API directly can trigger this silently incorrect behaviour.

```suggestion
def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
    if limit < 1:
        raise ValueError(f"limit must be >= 1, got {limit}")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 692-717

Comment:
**`find_airports` returns a plain string; other tools return structured dicts**

`search_flights` and `search_dates` both return `dict[str, Any]`, which AI agents can consume directly. `find_airports` returns a pre-formatted string, forcing any downstream caller (human or agent) to parse text to extract codes. Returning a structured response like `{"airports": [{"code": ..., "name": ...}]}` would be consistent with the rest of the API and easier to integrate.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 41

Comment:
**`search_airports` imported directly from submodule, not from `fli.core`**

All other utilities (`build_flight_segments`, `parse_airlines`, etc.) are imported from the `fli.core` package, which already re-exports `search_airports` in its `__all__`. Importing directly from `fli.core.airports` here is inconsistent with the established pattern.

```suggestion
from fli.core import (
    build_date_search_segments,
    build_flight_segments,
    build_time_restrictions,
    parse_airlines,
    parse_cabin_class,
    parse_emissions,
    parse_max_stops,
    parse_sort_by,
    resolve_airport,
    search_airports,
)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add airport search by city name, a..."](https://github.com/punitarani/fli/commit/96829f5654e8775f1a457c2690bc1dc0c08bf039) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27340886)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->