### PR TITLE
New: Add HTTP streamable MCP server docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,54 @@
-.venv/
-**/__pycache__/
-*.pyc
-*.pyo
-.pytest_cache/
-.ruff_cache/
-.mypy_cache/
+# Version control
+.git/
+.gitignore
+
+# Python artifacts
+__pycache__/
+*.py[cod]
 *.egg-info/
+*.egg
+.eggs/
 dist/
 build/
+wheels/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test & coverage
+tests/
+.pytest_cache/
 .coverage
+.coverage.*
 htmlcov/
+coverage.xml
 junit.xml
+
+# Dev tooling
+.ruff_cache/
+.mypy_cache/
+
+# Docs
+docs/
 site/
+
+# IDE / OS
+.idea/
+.vscode/
+*.DS_Store
+
+# Docker itself
+Dockerfile
+.dockerignore
+
+# CI / devcontainer
+.github/
+.devcontainer/
+
+# Misc
+*.log
+.env
+examples/
+scripts/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,12 +41,12 @@ jobs:
             type=sha,prefix=sha-,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,10 @@
-name: Build secret.provid.gg (DEV)
+name: Build & Push Docker Image
 
 on:
   push:
-    branches: ["development"]
+    branches: ["main"]
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -19,6 +21,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -32,8 +37,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=dev
-            type=raw,value=dev-{{sha}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=sha-,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -42,3 +49,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Build secret.provid.gg (DEV)
+
+on:
+  push:
+    branches: ["development"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=dev
+            type=raw,value=dev-{{sha}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=builder /app/fli /app/fli
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV VIRTUAL_ENV="/app/.venv"
+ENV PYTHONUNBUFFERED=1
 ENV HOST="0.0.0.0"
 ENV PORT="8000"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: dependency resolver
 FROM python:3.12-slim AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.6.0 /uv /bin/uv
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: dependency resolver
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock README.md ./
+COPY fli/ ./fli/
+
+RUN uv sync --frozen --no-dev --no-cache
+
+
+# Stage 2: minimal runtime
+FROM python:3.12-slim AS runtime
+
+WORKDIR /app
+
+# Copy only the installed venv and source from the builder
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/fli /app/fli
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV VIRTUAL_ENV="/app/.venv"
+ENV HOST="0.0.0.0"
+ENV PORT="8000"
+
+EXPOSE 8000
+
+# Run as non-root
+RUN useradd --no-create-home --shell /bin/false appuser
+USER appuser
+
+CMD ["fli-mcp-http"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       HOST: "0.0.0.0"
       PORT: "8000"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  fli-mcp:
+    image: ghcr.io/nicolaeser/fli:latest
+    ports:
+      - "8000:8000"
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "8000"
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fli-mcp:
-    image: ghcr.io/nicolaeser/fli:latest
+    image: ghcr.io/punitarani/fli:latest
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
Added:
- Docker Container build workflow
- docker-compose file
- Dockerfile


Builded Container is pushed to ghcr.io

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Docker containerization for the HTTP MCP server, including a multi-stage Dockerfile, a docker-compose service definition, a GHCR publishing workflow, and an expanded `.dockerignore`. All previously flagged issues (unpinned `uv` version, missing `PYTHONUNBUFFERED`, missing multi-arch support, missing healthcheck) have been addressed in this revision. The healthcheck probing `http://localhost:8000/health` is valid — FastMCP 2.x exposes this endpoint by default on its HTTP transport.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all prior findings resolved, no new issues found

All previously flagged P1/P2 issues (unpinned uv, PYTHONUNBUFFERED, multi-platform, healthcheck) have been addressed. The FastMCP /health endpoint exists by default in 2.x, so the docker-compose healthcheck is correct. No remaining blocking issues.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .dockerignore | Expanded with comprehensive ignore rules for git, IDE, docs, and CI artifacts |
| .github/workflows/docker.yml | New CI workflow builds and pushes multi-platform image to GHCR on main push and release events |
| Dockerfile | Multi-stage build with pinned uv 0.6.0, non-root user, PYTHONUNBUFFERED set, and correct env wiring |
| docker-compose.yml | Service definition with healthcheck probing FastMCP's built-in /health endpoint |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer / CI
    participant GHA as GitHub Actions
    participant GHCR as ghcr.io
    participant Host as Container Host

    Dev->>GHA: Push to main / publish release
    GHA->>GHA: Checkout + setup Buildx
    GHA->>GHCR: docker login (GITHUB_TOKEN)
    GHA->>GHA: Extract metadata (tags, labels)
    GHA->>GHCR: Build & push (linux/amd64 + linux/arm64)
    Host->>GHCR: docker pull ghcr.io/punitarani/fli:latest
    Host->>Host: docker compose up
    Host->>Host: healthcheck GET /health → 200 OK
```

<sub>**[Greploops](https://www.greptile.com/docs/mcp-v2/skills#greploop)** — Automatically fix all review issues by running `/greploops` in [Claude Code](https://claude.ai/download). It iterates: fix, push, re-review, repeat until 5/5 confidence.<br>Use the **[Greptile plugin for Claude Code](https://www.greptile.com/docs/integrations/claude-code#claude-code-plugin)** to query reviews, search comments, and manage custom context directly from your terminal.</sub>

<sub>Reviews (2): Last reviewed commit: ["Pin uv"](https://github.com/punitarani/fli/commit/33c5cc2dfb0fbb4bcb4275f291970fab028f761d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27393422)</sub>

<!-- /greptile_comment -->