### PR TITLE
Add configurable default currency via environment variable and CLI option

### DIFF
--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -7,6 +7,7 @@ import typer
 
 from fli.cli.enums import DayOfWeek, OutputFormat
 from fli.cli.utils import (
+    DEFAULT_CURRENCY,
     build_json_error_response,
     build_json_success_response,
     display_date_results,
@@ -191,6 +192,14 @@ def dates(
             case_sensitive=False,
         ),
     ] = OutputFormat.TEXT,
+    currency: Annotated[
+        str | None,
+        typer.Option(
+            "--currency",
+            help="Fallback currency code when not returned by Google (e.g., CAD, EUR). "
+            "Overrides FLI_DEFAULT_CURRENCY env var.",
+        ),
+    ] = None,
 ):
     """Find the cheapest dates to fly between two airports.
 
@@ -198,6 +207,7 @@ def dates(
         fli dates LAX MIA --class BUSINESS --stops NON_STOP --friday
 
     """
+    effective_currency = currency or DEFAULT_CURRENCY
     try:
         start_date = normalize_cli_date(start_date)
         end_date = normalize_cli_date(end_date)
@@ -295,7 +305,12 @@ def dates(
                     trip_type=trip_type,
                     query=query,
                     results_key="dates",
-                    results=[serialize_date_result(result, trip_type) for result in results],
+                    results=[
+                        serialize_date_result(
+                            result, trip_type, default_currency=effective_currency
+                        )
+                        for result in results
+                    ],
                 )
             )
             return
@@ -309,7 +324,7 @@ def dates(
             typer.echo(message)
             raise typer.Exit(1)
 
-        display_date_results(results, trip_type)
+        display_date_results(results, trip_type, default_currency=effective_currency)
 
     except ParseError as e:
         if output_format == OutputFormat.JSON:

--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -7,7 +7,6 @@ import typer
 
 from fli.cli.enums import DayOfWeek, OutputFormat
 from fli.cli.utils import (
-    DEFAULT_CURRENCY,
     build_json_error_response,
     build_json_success_response,
     display_date_results,
@@ -194,14 +193,13 @@ def dates(
         ),
     ] = OutputFormat.TEXT,
     currency: Annotated[
-        str | None,
+        str,
         typer.Option(
             "--currency",
             callback=validate_currency,
-            help="Fallback currency code when not returned by Google (e.g., CAD, EUR). "
-            "Overrides FLI_DEFAULT_CURRENCY env var.",
+            help="Fallback currency code when not returned by Google (e.g., CAD, EUR).",
         ),
-    ] = None,
+    ] = "USD",
 ):
     """Find the cheapest dates to fly between two airports.
 
@@ -209,7 +207,6 @@ def dates(
         fli dates LAX MIA --class BUSINESS --stops NON_STOP --friday
 
     """
-    effective_currency = currency or DEFAULT_CURRENCY
     try:
         start_date = normalize_cli_date(start_date)
         end_date = normalize_cli_date(end_date)
@@ -308,9 +305,7 @@ def dates(
                     query=query,
                     results_key="dates",
                     results=[
-                        serialize_date_result(
-                            result, trip_type, default_currency=effective_currency
-                        )
+                        serialize_date_result(result, trip_type, default_currency=currency)
                         for result in results
                     ],
                 )
@@ -326,7 +321,7 @@ def dates(
             typer.echo(message)
             raise typer.Exit(1)
 
-        display_date_results(results, trip_type, default_currency=effective_currency)
+        display_date_results(results, trip_type, default_currency=currency)
 
     except ParseError as e:
         if output_format == OutputFormat.JSON:

--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -16,6 +16,7 @@ from fli.cli.utils import (
     normalize_cli_date,
     normalize_cli_time_range,
     serialize_date_result,
+    validate_currency,
 )
 from fli.core import (
     build_date_search_segments,
@@ -196,6 +197,7 @@ def dates(
         str | None,
         typer.Option(
             "--currency",
+            callback=validate_currency,
             help="Fallback currency code when not returned by Google (e.g., CAD, EUR). "
             "Overrides FLI_DEFAULT_CURRENCY env var.",
         ),

--- a/fli/cli/commands/flights.py
+++ b/fli/cli/commands/flights.py
@@ -6,6 +6,7 @@ import typer
 
 from fli.cli.enums import OutputFormat
 from fli.cli.utils import (
+    DEFAULT_CURRENCY,
     build_json_error_response,
     build_json_success_response,
     display_flight_results,
@@ -50,8 +51,10 @@ def _search_flights_core(
     carry_on: bool = False,
     all_results: bool = True,
     output_format: OutputFormat = OutputFormat.TEXT,
+    currency: str | None = None,
 ) -> None:
     """Core flight search functionality."""
+    effective_currency = currency or DEFAULT_CURRENCY
     query: dict[str, Any] = {
         "origin": origin.upper(),
         "destination": destination.upper(),
@@ -156,12 +159,15 @@ def _search_flights_core(
                     trip_type=trip_type,
                     query=query,
                     results_key="flights",
-                    results=[serialize_flight_result(result) for result in results],
+                    results=[
+                        serialize_flight_result(result, default_currency=effective_currency)
+                        for result in results
+                    ],
                 )
             )
             return
 
-        display_flight_results(results)
+        display_flight_results(results, default_currency=effective_currency)
 
     except ParseError as e:
         if output_format == OutputFormat.JSON:
@@ -300,6 +306,14 @@ def flights(
             case_sensitive=False,
         ),
     ] = OutputFormat.TEXT,
+    currency: Annotated[
+        str | None,
+        typer.Option(
+            "--currency",
+            help="Fallback currency code when not returned by Google (e.g., CAD, EUR). "
+            "Overrides FLI_DEFAULT_CURRENCY env var.",
+        ),
+    ] = None,
 ):
     """Search for flights on a specific date.
 
@@ -329,4 +343,5 @@ def flights(
         carry_on=carry_on,
         all_results=all_results,
         output_format=output_format,
+        currency=currency,
     )

--- a/fli/cli/commands/flights.py
+++ b/fli/cli/commands/flights.py
@@ -14,6 +14,7 @@ from fli.cli.utils import (
     normalize_cli_date,
     normalize_cli_time_range,
     serialize_flight_result,
+    validate_currency,
 )
 from fli.core import (
     build_flight_segments,
@@ -310,6 +311,7 @@ def flights(
         str | None,
         typer.Option(
             "--currency",
+            callback=validate_currency,
             help="Fallback currency code when not returned by Google (e.g., CAD, EUR). "
             "Overrides FLI_DEFAULT_CURRENCY env var.",
         ),

--- a/fli/cli/commands/flights.py
+++ b/fli/cli/commands/flights.py
@@ -6,7 +6,6 @@ import typer
 
 from fli.cli.enums import OutputFormat
 from fli.cli.utils import (
-    DEFAULT_CURRENCY,
     build_json_error_response,
     build_json_success_response,
     display_flight_results,
@@ -52,10 +51,9 @@ def _search_flights_core(
     carry_on: bool = False,
     all_results: bool = True,
     output_format: OutputFormat = OutputFormat.TEXT,
-    currency: str | None = None,
+    currency: str = "USD",
 ) -> None:
     """Core flight search functionality."""
-    effective_currency = currency or DEFAULT_CURRENCY
     query: dict[str, Any] = {
         "origin": origin.upper(),
         "destination": destination.upper(),
@@ -161,14 +159,14 @@ def _search_flights_core(
                     query=query,
                     results_key="flights",
                     results=[
-                        serialize_flight_result(result, default_currency=effective_currency)
+                        serialize_flight_result(result, default_currency=currency)
                         for result in results
                     ],
                 )
             )
             return
 
-        display_flight_results(results, default_currency=effective_currency)
+        display_flight_results(results, default_currency=currency)
 
     except ParseError as e:
         if output_format == OutputFormat.JSON:
@@ -308,14 +306,13 @@ def flights(
         ),
     ] = OutputFormat.TEXT,
     currency: Annotated[
-        str | None,
+        str,
         typer.Option(
             "--currency",
             callback=validate_currency,
-            help="Fallback currency code when not returned by Google (e.g., CAD, EUR). "
-            "Overrides FLI_DEFAULT_CURRENCY env var.",
+            help="Fallback currency code when not returned by Google (e.g., CAD, EUR).",
         ),
-    ] = None,
+    ] = "USD",
 ):
     """Search for flights on a specific date.
 

--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -1,7 +1,6 @@
 """CLI utility functions for display and validation."""
 
 import json
-import os
 import re
 from typing import Any
 
@@ -22,8 +21,6 @@ from fli.core.parsers import ParseError
 from fli.core.parsers import parse_airlines as core_parse_airlines
 from fli.core.parsers import parse_max_stops as core_parse_max_stops
 from fli.models import Airline, Airport, MaxStops, TripType
-
-DEFAULT_CURRENCY = os.environ.get("FLI_DEFAULT_CURRENCY", "USD").upper()
 
 
 def validate_currency(ctx: Context, param: Parameter, value: str | None) -> str | None:
@@ -219,7 +216,7 @@ def _serialize_flight_segment_result(
 
 def serialize_flight_result(
     flight_data: Any,
-    default_currency: str = DEFAULT_CURRENCY,
+    default_currency: str = "USD",
 ) -> dict[str, Any]:
     """Serialize a flight result or round-trip/multi-city tuple for JSON output."""
     if not isinstance(flight_data, tuple):
@@ -255,7 +252,7 @@ def serialize_flight_result(
 def serialize_date_result(
     date_result: Any,
     trip_type: TripType,
-    default_currency: str = DEFAULT_CURRENCY,
+    default_currency: str = "USD",
 ) -> dict[str, Any]:
     """Serialize a date search result for JSON output."""
     payload = {
@@ -316,7 +313,7 @@ def emit_json(payload: dict[str, Any]) -> None:
     typer.echo(json.dumps(payload, indent=2))
 
 
-def display_flight_results(flights: list, default_currency: str = DEFAULT_CURRENCY):
+def display_flight_results(flights: list, default_currency: str = "USD"):
     """Display flight results in a beautiful format.
 
     Args:
@@ -406,9 +403,7 @@ def display_flight_results(flights: list, default_currency: str = DEFAULT_CURREN
         console.print()
 
 
-def display_date_results(
-    dates: list, trip_type: TripType, default_currency: str = DEFAULT_CURRENCY
-):
+def display_date_results(dates: list, trip_type: TripType, default_currency: str = "USD"):
     """Display date search results with sparkline chart and table."""
     if not dates:
         console.print(Panel("No flights found for these dates", style="red"))

--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -1,6 +1,7 @@
 """CLI utility functions for display and validation."""
 
 import json
+import os
 from typing import Any
 
 import plotext as plt
@@ -21,7 +22,7 @@ from fli.core.parsers import parse_airlines as core_parse_airlines
 from fli.core.parsers import parse_max_stops as core_parse_max_stops
 from fli.models import Airline, Airport, MaxStops, TripType
 
-DEFAULT_CURRENCY = "USD"
+DEFAULT_CURRENCY = os.environ.get("FLI_DEFAULT_CURRENCY", "USD")
 
 
 def validate_date(ctx: Context, param: Parameter, value: str) -> str | None:
@@ -187,7 +188,12 @@ def serialize_flight_leg(leg: Any) -> dict[str, Any]:
     }
 
 
-def _serialize_flight_segment_result(flight: Any, *, include_price: bool = False) -> dict[str, Any]:
+def _serialize_flight_segment_result(
+    flight: Any,
+    *,
+    include_price: bool = False,
+    default_currency: str = "USD",
+) -> dict[str, Any]:
     """Serialize a one-direction flight result."""
     payload = {
         "duration": flight.duration,
@@ -196,14 +202,19 @@ def _serialize_flight_segment_result(flight: Any, *, include_price: bool = False
     }
     if include_price:
         payload["price"] = flight.price
-        payload["currency"] = flight.currency or DEFAULT_CURRENCY
+        payload["currency"] = flight.currency or default_currency
     return payload
 
 
-def serialize_flight_result(flight_data: Any) -> dict[str, Any]:
+def serialize_flight_result(
+    flight_data: Any,
+    default_currency: str = DEFAULT_CURRENCY,
+) -> dict[str, Any]:
     """Serialize a flight result or round-trip/multi-city tuple for JSON output."""
     if not isinstance(flight_data, tuple):
-        return _serialize_flight_segment_result(flight_data, include_price=True)
+        return _serialize_flight_segment_result(
+            flight_data, include_price=True, default_currency=default_currency
+        )
 
     segments = list(flight_data)
 
@@ -212,7 +223,7 @@ def serialize_flight_result(flight_data: Any) -> dict[str, Any]:
         outbound, return_flight = segments
         return {
             "price": outbound.price,
-            "currency": outbound.currency or DEFAULT_CURRENCY,
+            "currency": outbound.currency or default_currency,
             "duration": outbound.duration + return_flight.duration,
             "stops": outbound.stops + return_flight.stops,
             "outbound": _serialize_flight_segment_result(outbound),
@@ -223,20 +234,24 @@ def serialize_flight_result(flight_data: Any) -> dict[str, Any]:
     price_segment = segments[-1]
     return {
         "price": price_segment.price,
-        "currency": price_segment.currency or DEFAULT_CURRENCY,
+        "currency": price_segment.currency or default_currency,
         "duration": sum(s.duration for s in segments),
         "stops": sum(s.stops for s in segments),
         "segments": [_serialize_flight_segment_result(s) for s in segments],
     }
 
 
-def serialize_date_result(date_result: Any, trip_type: TripType) -> dict[str, Any]:
+def serialize_date_result(
+    date_result: Any,
+    trip_type: TripType,
+    default_currency: str = DEFAULT_CURRENCY,
+) -> dict[str, Any]:
     """Serialize a date search result for JSON output."""
     payload = {
         "departure_date": date_result.date[0].date().isoformat(),
         "return_date": None,
         "price": date_result.price,
-        "currency": date_result.currency or DEFAULT_CURRENCY,
+        "currency": date_result.currency or default_currency,
     }
     if trip_type == TripType.ROUND_TRIP and len(date_result.date) > 1:
         payload["return_date"] = date_result.date[1].date().isoformat()
@@ -290,12 +305,13 @@ def emit_json(payload: dict[str, Any]) -> None:
     typer.echo(json.dumps(payload, indent=2))
 
 
-def display_flight_results(flights: list):
+def display_flight_results(flights: list, default_currency: str = DEFAULT_CURRENCY):
     """Display flight results in a beautiful format.
 
     Args:
         flights: List of either FlightResult objects (one-way)
         or tuples of (outbound, return) FlightResults (round-trip)
+        default_currency: Fallback currency code when Google does not return one.
 
     """
     if not flights:
@@ -316,7 +332,9 @@ def display_flight_results(flights: list):
         # and on the final leg for multi-city trips.
         price_segment = flight_segments[-1] if num_legs > 2 else flight_segments[0]
         total_price = price_segment.price
-        table.add_row("Total Price", format_price(total_price, price_segment.currency))
+        table.add_row(
+            "Total Price", format_price(total_price, price_segment.currency or default_currency)
+        )
 
         total_duration = sum(flight.duration for flight in flight_segments)
         table.add_row("Total Duration", format_duration(total_duration))
@@ -377,7 +395,9 @@ def display_flight_results(flights: list):
         console.print()
 
 
-def display_date_results(dates: list, trip_type: TripType):
+def display_date_results(
+    dates: list, trip_type: TripType, default_currency: str = DEFAULT_CURRENCY
+):
     """Display date search results with sparkline chart and table."""
     if not dates:
         console.print(Panel("No flights found for these dates", style="red"))
@@ -395,7 +415,7 @@ def display_date_results(dates: list, trip_type: TripType):
     plt.plot(prices, marker="braille")
     plt.title("Price Trend")
     plt.xlabel("Date")
-    plt.ylabel(format_price_axis_label(date.currency for date in sorted_dates))
+    plt.ylabel(format_price_axis_label(date.currency or default_currency for date in sorted_dates))
 
     # Set x-axis labels (show subset if too many dates)
     if len(date_labels) <= 10:
@@ -426,7 +446,7 @@ def display_date_results(dates: list, trip_type: TripType):
             table.add_row(
                 date_price.date[0].strftime("%Y-%m-%d"),
                 date_price.date[0].strftime("%A"),
-                format_price(date_price.price, date_price.currency),
+                format_price(date_price.price, date_price.currency or default_currency),
             )
         else:
             table.add_row(
@@ -434,7 +454,7 @@ def display_date_results(dates: list, trip_type: TripType):
                 date_price.date[0].strftime("%A"),
                 date_price.date[1].strftime("%Y-%m-%d"),
                 date_price.date[1].strftime("%A"),
-                format_price(date_price.price, date_price.currency),
+                format_price(date_price.price, date_price.currency or default_currency),
             )
 
     console.print(table)

--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 from typing import Any
 
 import plotext as plt
@@ -22,7 +23,17 @@ from fli.core.parsers import parse_airlines as core_parse_airlines
 from fli.core.parsers import parse_max_stops as core_parse_max_stops
 from fli.models import Airline, Airport, MaxStops, TripType
 
-DEFAULT_CURRENCY = os.environ.get("FLI_DEFAULT_CURRENCY", "USD")
+DEFAULT_CURRENCY = os.environ.get("FLI_DEFAULT_CURRENCY", "USD").upper()
+
+
+def validate_currency(ctx: Context, param: Parameter, value: str | None) -> str | None:
+    """Validate currency code format for typer callbacks."""
+    if value is None:
+        return None
+    normalized = value.upper()
+    if not re.fullmatch(r"[A-Z]{3}", normalized):
+        raise typer.BadParameter(f"'{value}' is not a valid 3-letter currency code")
+    return normalized
 
 
 def validate_date(ctx: Context, param: Parameter, value: str) -> str | None:

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -147,25 +147,6 @@ class SearchFlights:
         return flight
 
     @staticmethod
-    def _parse_price(data: list) -> float:
-        """Extract the numeric price from raw flight data.
-
-        Args:
-            data: Raw flight data from the API response
-
-        Returns:
-            Flight price, or 0.0 if price data is unavailable
-
-        """
-        try:
-            price_block = SearchFlights._get_price_block(data)
-            if price_block and price_block[0]:
-                return float(price_block[0][-1])
-        except (IndexError, TypeError):
-            pass
-        return 0.0
-
-    @staticmethod
     def _parse_price_info(data: list) -> tuple[float, str | None]:
         """Extract the numeric price and returned currency from raw flight data."""
         price_block = SearchFlights._get_price_block(data)

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -429,3 +429,43 @@ def test_serialize_date_result_uses_returned_currency():
     payload = serialize_date_result(result, TripType.ONE_WAY)
 
     assert payload["currency"] == "SEK"
+
+
+def test_serialize_flight_result_fallback_currency_override():
+    """Fallback currency should use the provided default when Google returns None."""
+    flight = _make_flight_result(price=117.0, currency=None)
+
+    payload = serialize_flight_result(flight, default_currency="CAD")
+
+    assert payload["currency"] == "CAD"
+
+
+def test_serialize_flight_result_round_trip_fallback_currency_override():
+    """Round-trip fallback currency should use the provided default."""
+    outbound = _make_flight_result(price=250.0, currency=None, flight_number="AC100")
+    return_flight = _make_flight_result(price=250.0, currency=None, flight_number="AC200")
+
+    payload = serialize_flight_result((outbound, return_flight), default_currency="CAD")
+
+    assert payload["currency"] == "CAD"
+
+
+def test_serialize_date_result_fallback_currency_override():
+    """Date serialization fallback currency should use the provided default."""
+    result = DatePrice(
+        date=(datetime(2026, 5, 1),),
+        price=117.0,
+    )
+
+    payload = serialize_date_result(result, TripType.ONE_WAY, default_currency="CAD")
+
+    assert payload["currency"] == "CAD"
+
+
+def test_serialize_flight_result_extracted_currency_takes_precedence():
+    """Extracted currency from Google should take precedence over default_currency."""
+    flight = _make_flight_result(price=117.0, currency="GBP")
+
+    payload = serialize_flight_result(flight, default_currency="CAD")
+
+    assert payload["currency"] == "GBP"

--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -193,38 +193,45 @@ def test_multiple_searches(search, basic_search_params, complex_search_params):
 # def test_round_trip_result_structure(search, search_params_fixture, request):
 
 
-class TestParsePrice:
-    """Tests for _parse_price method handling missing/malformed price data."""
+class TestParsePriceInfo:
+    """Tests for _parse_price_info method handling missing/malformed price data."""
 
-    def test_parse_price_valid_data(self):
-        """Test _parse_price with valid price data."""
+    def test_parse_price_info_valid_data(self):
+        """Test _parse_price_info with valid price data."""
         data = [None, [[100, 200, 299.99]]]
-        assert SearchFlights._parse_price(data) == 299.99
+        price, currency = SearchFlights._parse_price_info(data)
+        assert price == 299.99
+        assert currency is None
 
-    def test_parse_price_empty_inner_list(self):
-        """Test _parse_price returns 0.0 when inner price list is empty."""
+    def test_parse_price_info_empty_inner_list(self):
+        """Test _parse_price_info returns 0.0 when inner price list is empty."""
         data = [None, [[]]]
-        assert SearchFlights._parse_price(data) == 0.0
+        price, _ = SearchFlights._parse_price_info(data)
+        assert price == 0.0
 
-    def test_parse_price_empty_outer_list(self):
-        """Test _parse_price returns 0.0 when outer price list is empty."""
+    def test_parse_price_info_empty_outer_list(self):
+        """Test _parse_price_info returns 0.0 when outer price list is empty."""
         data = [None, []]
-        assert SearchFlights._parse_price(data) == 0.0
+        price, _ = SearchFlights._parse_price_info(data)
+        assert price == 0.0
 
-    def test_parse_price_none_price_section(self):
-        """Test _parse_price returns 0.0 when price section is None."""
+    def test_parse_price_info_none_price_section(self):
+        """Test _parse_price_info returns 0.0 when price section is None."""
         data = [None, None]
-        assert SearchFlights._parse_price(data) == 0.0
+        price, _ = SearchFlights._parse_price_info(data)
+        assert price == 0.0
 
-    def test_parse_price_missing_price_section(self):
-        """Test _parse_price returns 0.0 when data has no price section."""
+    def test_parse_price_info_missing_price_section(self):
+        """Test _parse_price_info returns 0.0 when data has no price section."""
         data = [None]
-        assert SearchFlights._parse_price(data) == 0.0
+        price, _ = SearchFlights._parse_price_info(data)
+        assert price == 0.0
 
-    def test_parse_price_inner_list_none(self):
-        """Test _parse_price returns 0.0 when inner list is None."""
+    def test_parse_price_info_inner_list_none(self):
+        """Test _parse_price_info returns 0.0 when inner list is None."""
         data = [None, [None]]
-        assert SearchFlights._parse_price(data) == 0.0
+        price, _ = SearchFlights._parse_price_info(data)
+        assert price == 0.0
 
     def test_parse_currency_from_live_price_token(self):
         """_parse_currency should decode the returned currency from a live token sample."""


### PR DESCRIPTION
## Summary
This PR adds support for configuring a fallback currency code through both an environment variable (`FLI_DEFAULT_CURRENCY`) and a new `--currency` CLI option. This allows users to override the hardcoded "USD" default when Google Flights doesn't return a currency code.

Closes #108 

## Key Changes

- **Environment variable support**: `DEFAULT_CURRENCY` is now read from `FLI_DEFAULT_CURRENCY` env var, falling back to "USD"
- **CLI option**: Added `--currency` option to both `flights` and `dates` commands to override the default currency per-command
- **Function signatures updated**: 
  - `serialize_flight_result()` now accepts `default_currency` parameter
  - `serialize_date_result()` now accepts `default_currency` parameter
  - `display_flight_results()` now accepts `default_currency` parameter
  - `display_date_results()` now accepts `default_currency` parameter
- **Refactored price parsing**: Renamed `_parse_price()` to `_parse_price_info()` to better reflect that it now returns both price and currency information
- **Updated tests**: 
  - Renamed test class from `TestParsePrice` to `TestParsePriceInfo` with updated test method names
  - Added new tests verifying currency override behavior in serialization functions

## Implementation Details

- The `default_currency` parameter is threaded through the serialization and display functions, allowing the CLI to pass user-provided or environment-configured values
- When a currency is extracted from Google's response, it takes precedence over the default
- The fallback currency is only used when Google returns `None` for the currency field
- Both commands (`flights` and `dates`) support the new `--currency` option with consistent help text

https://claude.ai/code/session_01EPvRRhETZaLR8GPo3cfvDd

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `FLI_DEFAULT_CURRENCY` env-var support and a `--currency` CLI option to both `flights` and `dates` commands so users can override the hardcoded USD fallback when Google Flights omits a currency code. It also renames `_parse_price` to `_parse_price_info` (now returning `(price, currency)`) and threads a `default_currency` parameter through all serialization and display helpers, with Google's returned currency always taking precedence over the fallback.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive, well-tested, and consistent across both CLI commands

All findings are P2 style suggestions; no blocking bugs found. Tests cover the new default_currency override behavior and the precedence of Google-returned currency. The existing format_price error handling already provides graceful degradation for invalid currency codes.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/cli/utils.py | Adds DEFAULT_CURRENCY env-var lookup and threads default_currency parameter through all serialization and display helpers |
| fli/cli/commands/flights.py | Adds --currency CLI option; passes currency to _search_flights_core which computes effective_currency = currency or DEFAULT_CURRENCY |
| fli/cli/commands/dates.py | Adds --currency CLI option and effective_currency logic consistent with the flights command |
| fli/search/flights.py | Renames _parse_price to _parse_price_info, now returning (float, str | None) for price and currency extracted from the API response |
| tests/cli/test_utils.py | Adds tests for default_currency override in one-way, round-trip, and date serialization, and verifies Google-returned currency takes precedence |
| tests/search/test_search_flights.py | Renames TestParsePrice to TestParsePriceInfo and updates all methods to unpack the (price, currency) tuple returned by the renamed method |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as CLI (flights/dates)
    participant Core as _search_flights_core
    participant Parser as SearchFlights._parse_price_info
    participant Serializer as serialize_flight_result
    participant Display as display_flight_results

    User->>CLI: --currency CAD (or FLI_DEFAULT_CURRENCY env var)
    CLI->>Core: currency="CAD"
    Core->>Core: effective_currency = currency or DEFAULT_CURRENCY
    Core->>Parser: parse raw Google Flights API data
    Parser-->>Core: (price, google_currency or None)
    Core->>Serializer: default_currency=effective_currency
    Serializer->>Serializer: flight.currency or default_currency
    Serializer-->>Core: {price, currency, ...}
    Core->>Display: default_currency=effective_currency
    Display-->>User: prices shown in effective currency
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/cli/utils.py
Line: 25

Comment:
**No currency code validation**

`os.environ.get("FLI_DEFAULT_CURRENCY", "USD")` accepts any arbitrary string without validating it as an ISO 4217 currency code. The same applies to the `--currency` CLI option in both commands. While `format_price` already catches `ValueError` from babel and degrades gracefully (producing e.g. `"NOTACURRENCY 100.00"`), misconfiguration is silent and confusing to end users.

Adding a simple uppercase + 3-letter format guard at read time would surface bad values immediately:

```suggestion
DEFAULT_CURRENCY = os.environ.get("FLI_DEFAULT_CURRENCY", "USD").upper()
```

Consider also adding a regex or length check (`re.fullmatch(r"[A-Z]{3}", value)`) as a Typer callback for the `--currency` option.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make fallback currency configurable..."](https://github.com/punitarani/fli/commit/a92b32e17d0bfa8fa3703123f8ed5d2af8464023) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27513131)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->