### PR TITLE
Add booking link field to FlightResult from API response

### DIFF
--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -211,6 +211,7 @@ def _serialize_flight_segment_result(
     if include_price:
         payload["price"] = flight.price
         payload["currency"] = flight.currency or default_currency
+        payload["booking_link"] = flight.booking_link
     return payload
 
 
@@ -232,6 +233,7 @@ def serialize_flight_result(
         return {
             "price": outbound.price,
             "currency": outbound.currency or default_currency,
+            "booking_link": outbound.booking_link,
             "duration": outbound.duration + return_flight.duration,
             "stops": outbound.stops + return_flight.stops,
             "outbound": _serialize_flight_segment_result(outbound),
@@ -243,6 +245,7 @@ def serialize_flight_result(
     return {
         "price": price_segment.price,
         "currency": price_segment.currency or default_currency,
+        "booking_link": price_segment.booking_link,
         "duration": sum(s.duration for s in segments),
         "stops": sum(s.stops for s in segments),
         "segments": [_serialize_flight_segment_result(s) for s in segments],
@@ -348,6 +351,10 @@ def display_flight_results(flights: list, default_currency: str = "USD"):
         table.add_row("Total Duration", format_duration(total_duration))
         total_stops = sum(flight.stops for flight in flight_segments)
         table.add_row("Total Stops", str(total_stops))
+
+        # Add booking link if available (from the price-bearing segment)
+        if price_segment.booking_link:
+            table.add_row("Book on Google", price_segment.booking_link)
 
         # Create segments tables for each direction
         all_segments = []

--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -347,14 +347,14 @@ def display_flight_results(flights: list, default_currency: str = "USD"):
             "Total Price", format_price(total_price, price_segment.currency or default_currency)
         )
 
+        # Add booking link immediately after price (from the price-bearing segment)
+        if price_segment.booking_link:
+            table.add_row("Book on Google", price_segment.booking_link)
+
         total_duration = sum(flight.duration for flight in flight_segments)
         table.add_row("Total Duration", format_duration(total_duration))
         total_stops = sum(flight.stops for flight in flight_segments)
         table.add_row("Total Stops", str(total_stops))
-
-        # Add booking link if available (from the price-bearing segment)
-        if price_segment.booking_link:
-            table.add_row("Book on Google", price_segment.booking_link)
 
         # Create segments tables for each direction
         all_segments = []

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -184,6 +184,7 @@ def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[s
         return {
             "price": flight.price,
             "currency": flight.currency or CONFIG.default_currency,
+            "booking_link": flight.booking_link,
             "legs": [_serialize_flight_leg(leg) for leg in flight.legs],
         }
 
@@ -195,6 +196,7 @@ def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[s
         return {
             "price": outbound.price,
             "currency": outbound.currency or CONFIG.default_currency,
+            "booking_link": outbound.booking_link,
             "legs": [
                 *[_serialize_flight_leg(leg) for leg in outbound.legs],
                 *[_serialize_flight_leg(leg) for leg in return_flight.legs],
@@ -207,6 +209,7 @@ def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[s
     return {
         "price": price_segment.price,
         "currency": price_segment.currency or CONFIG.default_currency,
+        "booking_link": price_segment.booking_link,
         "legs": [_serialize_flight_leg(leg) for segment in segments for leg in segment.legs],
     }
 

--- a/fli/models/google_flights/base.py
+++ b/fli/models/google_flights/base.py
@@ -165,6 +165,7 @@ class FlightResult(BaseModel):
     currency: str | None = None
     duration: PositiveInt  # total duration in minutes
     stops: NonNegativeInt
+    booking_link: str | None = None
 
 
 class FlightSegment(BaseModel):

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -31,6 +31,10 @@ class SearchFlights:
     DEFAULT_HEADERS = {
         "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
     }
+    BOOKING_URL = "https://www.google.com/travel/flights?tfs={token}"
+    FALLBACK_SEARCH_URL = (
+        "https://www.google.com/travel/flights?q=Flights+from+{origin}+to+{dest}+on+{date}"
+    )
 
     def __init__(self):
         """Initialize the search client for flight searches."""
@@ -114,8 +118,6 @@ class SearchFlights:
         except Exception as e:
             raise Exception(f"Search failed: {str(e)}") from e
 
-    BOOKING_URL = "https://www.google.com/travel/flights?tfs={token}"
-
     @staticmethod
     def _parse_booking_link(data: list) -> str | None:
         """Extract the booking link from raw flight data.
@@ -147,26 +149,35 @@ class SearchFlights:
 
         """
         price, currency = SearchFlights._parse_price_info(data)
-        flight = FlightResult(
+        legs = [
+            FlightLeg(
+                airline=SearchFlights._parse_airline(fl[22][0]),
+                flight_number=fl[22][1],
+                departure_airport=SearchFlights._parse_airport(fl[3]),
+                arrival_airport=SearchFlights._parse_airport(fl[6]),
+                departure_datetime=SearchFlights._parse_datetime(fl[20], fl[8]),
+                arrival_datetime=SearchFlights._parse_datetime(fl[21], fl[10]),
+                duration=fl[11],
+            )
+            for fl in data[0][2]
+        ]
+
+        booking_link = SearchFlights._parse_booking_link(data)
+        if not booking_link and legs:
+            booking_link = SearchFlights.FALLBACK_SEARCH_URL.format(
+                origin=legs[0].departure_airport.name,
+                dest=legs[-1].arrival_airport.name,
+                date=legs[0].departure_datetime.strftime("%Y-%m-%d"),
+            )
+
+        return FlightResult(
             price=price,
             currency=currency,
             duration=data[0][9],
             stops=len(data[0][2]) - 1,
-            booking_link=SearchFlights._parse_booking_link(data),
-            legs=[
-                FlightLeg(
-                    airline=SearchFlights._parse_airline(fl[22][0]),
-                    flight_number=fl[22][1],
-                    departure_airport=SearchFlights._parse_airport(fl[3]),
-                    arrival_airport=SearchFlights._parse_airport(fl[6]),
-                    departure_datetime=SearchFlights._parse_datetime(fl[20], fl[8]),
-                    arrival_datetime=SearchFlights._parse_datetime(fl[21], fl[10]),
-                    duration=fl[11],
-                )
-                for fl in data[0][2]
-            ],
+            booking_link=booking_link,
+            legs=legs,
         )
-        return flight
 
     @staticmethod
     def _parse_price_info(data: list) -> tuple[float, str | None]:

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -114,6 +114,27 @@ class SearchFlights:
         except Exception as e:
             raise Exception(f"Search failed: {str(e)}") from e
 
+    BOOKING_URL = "https://www.google.com/travel/flights?tfs={token}"
+
+    @staticmethod
+    def _parse_booking_link(data: list) -> str | None:
+        """Extract the booking link from raw flight data.
+
+        Args:
+            data: Raw flight data from the API response
+
+        Returns:
+            Google Flights booking URL, or None if unavailable
+
+        """
+        try:
+            token = data[0][0]
+            if isinstance(token, str) and token:
+                return SearchFlights.BOOKING_URL.format(token=token)
+        except (IndexError, TypeError):
+            pass
+        return None
+
     @staticmethod
     def _parse_flights_data(data: list) -> FlightResult:
         """Parse raw flight data into a structured FlightResult.
@@ -131,6 +152,7 @@ class SearchFlights:
             currency=currency,
             duration=data[0][9],
             stops=len(data[0][2]) - 1,
+            booking_link=SearchFlights._parse_booking_link(data),
             legs=[
                 FlightLeg(
                     airline=SearchFlights._parse_airline(fl[22][0]),

--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -256,3 +256,35 @@ class TestParsePriceInfo:
             ],
         ]
         assert SearchFlights._parse_price_info(data) == (118.0, "USD")
+
+
+class TestParseBookingLink:
+    """Tests for _parse_booking_link method."""
+
+    def test_parse_booking_link_with_valid_token(self):
+        """_parse_booking_link should return a Google Flights URL when a token is present."""
+        token = "SampleBookingToken123"
+        data = [[token]]
+        link = SearchFlights._parse_booking_link(data)
+        assert link == f"https://www.google.com/travel/flights?tfs={token}"
+
+    def test_parse_booking_link_with_empty_token(self):
+        """_parse_booking_link should return None when the token is an empty string."""
+        data = [[""]]
+        assert SearchFlights._parse_booking_link(data) is None
+
+    def test_parse_booking_link_with_none_token(self):
+        """_parse_booking_link should return None when the token is None."""
+        data = [[None]]
+        assert SearchFlights._parse_booking_link(data) is None
+
+    def test_parse_booking_link_missing_inner_list(self):
+        """_parse_booking_link should return None when data[0] is missing or too short."""
+        assert SearchFlights._parse_booking_link([[]]) is None
+        assert SearchFlights._parse_booking_link([None]) is None
+        assert SearchFlights._parse_booking_link([]) is None
+
+    def test_parse_booking_link_non_string_token(self):
+        """_parse_booking_link should return None when the token is not a string."""
+        data = [[42]]
+        assert SearchFlights._parse_booking_link(data) is None

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "flights"
-version = "0.8.2"
+version = "0.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
This pull request adds support for Google Flights booking links throughout the flight search and display pipeline. The main changes include parsing the booking link from raw flight data, updating data models and serialization methods to include the booking link, displaying the booking link in CLI output, and adding comprehensive tests for the new parsing logic.

**Booking Link Extraction and Parsing**
* Added a new static method `_parse_booking_link` to `SearchFlights` that extracts a booking token from raw flight data and constructs a Google Flights booking URL.
* Updated `_parse_flights_data` in `SearchFlights` to include the parsed `booking_link` in the returned `FlightResult`.

**Model and Serialization Updates**
* Added a new optional `booking_link` field to the `FlightResult` model in `fli/models/google_flights/base.py`.
* Updated all relevant serialization methods in `fli/cli/utils.py` and `fli/mcp/server.py` to include the `booking_link` in their output dictionaries. [[1]](diffhunk://#diff-341342c70585f8f14023c52ca12d2bf13d0394e8288bc9db836161e0a7d3ee8bR214) [[2]](diffhunk://#diff-341342c70585f8f14023c52ca12d2bf13d0394e8288bc9db836161e0a7d3ee8bR236) [[3]](diffhunk://#diff-341342c70585f8f14023c52ca12d2bf13d0394e8288bc9db836161e0a7d3ee8bR248) [[4]](diffhunk://#diff-2bc2f0c16d51d82fe01bc9dc0393d0949719a749bc5889e4c5010baa8fc871baR187) [[5]](diffhunk://#diff-2bc2f0c16d51d82fe01bc9dc0393d0949719a749bc5889e4c5010baa8fc871baR199) [[6]](diffhunk://#diff-2bc2f0c16d51d82fe01bc9dc0393d0949719a749bc5889e4c5010baa8fc871baR212)

**CLI Display Enhancements**
* Modified `display_flight_results` to show a "Book on Google" row with the booking link if available.

**Testing**
* Added a new test class `TestParseBookingLink` with multiple test cases to ensure robust extraction of booking links under various scenarios.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `booking_link` field to `FlightResult` by extracting a booking token from `data[0][0]` in the Google Flights API response and constructing a `https://www.google.com/travel/flights?tfs={token}` URL. The field is propagated consistently through CLI serialization, MCP output, and the Rich display layer, with unit tests covering token extraction edge cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are non-blocking P2 style suggestions.

The implementation is correct and consistent across all trip types (one-way, round-trip, multi-city) in both CLI and MCP paths. The three findings are style issues: constant placement mid-class, missing defensive URL encoding, and nullable-field serialization.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/search/flights.py | Adds `_parse_booking_link` static method and `BOOKING_URL` constant; minor style issues with constant placement mid-class and missing URL encoding. |
| fli/models/google_flights/base.py | Adds optional `booking_link: str | None = None` to `FlightResult`; clean non-breaking change. |
| fli/cli/utils.py | Propagates `booking_link` through CLI serialization and Rich display; `null` always emitted in JSON when field is absent (style). |
| fli/mcp/server.py | Adds `booking_link` to all MCP serialization paths (one-way, round-trip, multi-city) consistently. |
| tests/search/test_search_flights.py | Adds `TestParseBookingLink` with five unit tests covering valid token, empty string, None, missing list, and non-string token. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant API as Google Flights API
    participant SF as SearchFlights
    participant FR as FlightResult
    participant CLI as CLI utils.py
    participant MCP as MCP server.py

    API->>SF: Raw JSON response
    SF->>SF: _parse_flights_data(data)
    SF->>SF: _parse_booking_link(data)
    Note over SF: token = data[0][0]
    SF->>FR: FlightResult(booking_link=URL)
    FR->>CLI: serialize_flight_result()
    Note over CLI: payload[booking_link]=flight.booking_link
    CLI-->>CLI: display_flight_results() → Book on Google row
    FR->>MCP: _serialize_flight_result()
    Note over MCP: {booking_link: flight.booking_link}
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/search/flights.py
Line: 117

Comment:
**`BOOKING_URL` constant out of place**

This constant is defined mid-class after the `search()` method, while the other class-level constants `BASE_URL` and `DEFAULT_HEADERS` are at the top of the class (lines 30–31). Moving it there keeps the layout consistent and makes it easy to find all URL constants at a glance.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/search/flights.py
Line: 133

Comment:
**URL-encode the booking token**

The token is interpolated into the URL without percent-encoding. Google's tokens appear to use URL-safe base64, but defensive encoding prevents silent breakage if the token format ever includes characters like `+` or `/`:

```python
from urllib.parse import quote
return SearchFlights.BOOKING_URL.format(token=quote(token, safe=""))
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/cli/utils.py
Line: 214

Comment:
**`booking_link` always serialized even when `None`**

This unconditionally adds `"booking_link": null` to the JSON output for every flight that has no token. The same pattern appears on lines 236 and 248 in the same file. If consumers don't expect a nullable key, consider guarding the assignment:

```python
if flight.booking_link is not None:
    payload["booking_link"] = flight.booking_link
```
Apply consistently across all three call sites.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #1 from felixvk1234/c..."](https://github.com/punitarani/fli/commit/19696d44cd800292a4948cc1d33bc90aba3a7aad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27622895)</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->