### PR TITLE
feat: preserve Google Flights booking tokens

### DIFF
--- a/fli/cli/utils.py
+++ b/fli/cli/utils.py
@@ -211,6 +211,16 @@ def _serialize_flight_segment_result(
     if include_price:
         payload["price"] = flight.price
         payload["currency"] = flight.currency or default_currency
+    _attach_google_flights_tokens(payload, flight)
+    return payload
+
+
+def _attach_google_flights_tokens(payload: dict[str, Any], flight: Any) -> dict[str, Any]:
+    """Attach raw Google Flights booking tokens when they are available."""
+    if getattr(flight, "google_flights_tfu_inner_token", None):
+        payload["google_flights_tfu_inner_token"] = flight.google_flights_tfu_inner_token
+    if getattr(flight, "google_flights_tfs_tokens", None):
+        payload["google_flights_tfs_tokens"] = flight.google_flights_tfs_tokens
     return payload
 
 
@@ -229,7 +239,7 @@ def serialize_flight_result(
     if len(segments) == 2:
         # Round-trip: Google Flights returns the full RT price on the outbound leg.
         outbound, return_flight = segments
-        return {
+        payload = {
             "price": outbound.price,
             "currency": outbound.currency or default_currency,
             "duration": outbound.duration + return_flight.duration,
@@ -237,16 +247,18 @@ def serialize_flight_result(
             "outbound": _serialize_flight_segment_result(outbound),
             "return": _serialize_flight_segment_result(return_flight),
         }
+        return _attach_google_flights_tokens(payload, outbound)
 
     # Multi-city (3+ legs): combined price is on the final leg.
     price_segment = segments[-1]
-    return {
+    payload = {
         "price": price_segment.price,
         "currency": price_segment.currency or default_currency,
         "duration": sum(s.duration for s in segments),
         "stops": sum(s.stops for s in segments),
         "segments": [_serialize_flight_segment_result(s) for s in segments],
     }
+    return _attach_google_flights_tokens(payload, price_segment)
 
 
 def serialize_date_result(

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -181,18 +181,19 @@ def _serialize_flight_leg(leg: Any) -> dict[str, Any]:
 def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[str, Any]:
     """Serialize a flight result (or round-trip/multi-city tuple) to a dictionary."""
     if not isinstance(flight, tuple):
-        return {
+        payload = {
             "price": flight.price,
             "currency": flight.currency or CONFIG.default_currency,
             "legs": [_serialize_flight_leg(leg) for leg in flight.legs],
         }
+        return _attach_google_flights_tokens(payload, flight)
 
     segments = list(flight)
 
     if len(segments) == 2 and is_round_trip:
         # Google Flights returns the full round-trip price on the outbound leg
         outbound, return_flight = segments
-        return {
+        payload = {
             "price": outbound.price,
             "currency": outbound.currency or CONFIG.default_currency,
             "legs": [
@@ -200,15 +201,26 @@ def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[s
                 *[_serialize_flight_leg(leg) for leg in return_flight.legs],
             ],
         }
+        return _attach_google_flights_tokens(payload, outbound)
 
     # Multi-city (3+ legs) or 2-leg non-round-trip: combined price on the
     # final leg (matches Google Flights pricing and the CLI display logic).
     price_segment = segments[-1] if len(segments) > 2 else segments[0]
-    return {
+    payload = {
         "price": price_segment.price,
         "currency": price_segment.currency or CONFIG.default_currency,
         "legs": [_serialize_flight_leg(leg) for segment in segments for leg in segment.legs],
     }
+    return _attach_google_flights_tokens(payload, price_segment)
+
+
+def _attach_google_flights_tokens(payload: dict[str, Any], flight: Any) -> dict[str, Any]:
+    """Attach raw Google Flights booking tokens when they are available."""
+    if getattr(flight, "google_flights_tfu_inner_token", None):
+        payload["google_flights_tfu_inner_token"] = flight.google_flights_tfu_inner_token
+    if getattr(flight, "google_flights_tfs_tokens", None):
+        payload["google_flights_tfs_tokens"] = flight.google_flights_tfs_tokens
+    return payload
 
 
 def _serialize_date_result(date_result: Any) -> dict[str, Any]:

--- a/fli/models/google_flights/base.py
+++ b/fli/models/google_flights/base.py
@@ -165,6 +165,8 @@ class FlightResult(BaseModel):
     currency: str | None = None
     duration: PositiveInt  # total duration in minutes
     stops: NonNegativeInt
+    google_flights_tfu_inner_token: str | None = None
+    google_flights_tfs_tokens: list[str] | None = None
 
 
 class FlightSegment(BaseModel):

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -131,6 +131,8 @@ class SearchFlights:
             currency=currency,
             duration=data[0][9],
             stops=len(data[0][2]) - 1,
+            google_flights_tfu_inner_token=SearchFlights._parse_tfu_inner_token(data),
+            google_flights_tfs_tokens=SearchFlights._parse_tfs_tokens(data),
             legs=[
                 FlightLeg(
                     airline=SearchFlights._parse_airline(fl[22][0]),
@@ -145,6 +147,39 @@ class SearchFlights:
             ],
         )
         return flight
+
+    @staticmethod
+    def _parse_tfu_inner_token(data: list) -> str | None:
+        """Extract the opaque Google Flights booking token from a result row."""
+        try:
+            token = data[1][1]
+        except (IndexError, TypeError):
+            return None
+        return token if isinstance(token, str) and token else None
+
+    @staticmethod
+    def _parse_tfs_tokens(data: list) -> list[str] | None:
+        """Extract candidate itinerary tokens from a result row."""
+        try:
+            raw_value = data[8]
+        except (IndexError, TypeError):
+            return None
+        if not raw_value:
+            return None
+
+        parsed = raw_value
+        if isinstance(raw_value, str):
+            try:
+                parsed = json.loads(raw_value)
+            except json.JSONDecodeError:
+                parsed = raw_value
+
+        if isinstance(parsed, list):
+            tokens = [item for item in parsed if isinstance(item, str) and item]
+            return tokens or None
+        if isinstance(parsed, str):
+            return [parsed]
+        return None
 
     @staticmethod
     def _parse_price_info(data: list) -> tuple[float, str | None]:

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -331,6 +331,8 @@ def test_serialize_airline_normal_code():
 def test_serialize_flight_result_one_way():
     """JSON flight serialization should use machine-readable nested fields."""
     flight = _make_flight_result(price=159.0)
+    flight.google_flights_tfu_inner_token = "inner-token"
+    flight.google_flights_tfs_tokens = ["token-a", "token-b"]
 
     payload = serialize_flight_result(flight)
 
@@ -338,6 +340,21 @@ def test_serialize_flight_result_one_way():
     assert payload["currency"] == "USD"
     assert payload["legs"][0]["departure_airport"]["code"] == "JFK"
     assert payload["legs"][0]["airline"]["code"] == "DL"
+    assert payload["google_flights_tfu_inner_token"] == "inner-token"
+    assert payload["google_flights_tfs_tokens"] == ["token-a", "token-b"]
+
+
+def test_serialize_flight_result_round_trip_uses_outbound_tokens():
+    """Round-trip serialization should preserve the outbound booking tokens."""
+    outbound = _make_flight_result(price=317.0, flight_number="DL100")
+    return_flight = _make_flight_result(price=317.0, flight_number="DL200")
+    outbound.google_flights_tfu_inner_token = "rt-inner-token"
+    outbound.google_flights_tfs_tokens = ["rt-token-a", "rt-token-b"]
+
+    payload = serialize_flight_result((outbound, return_flight))
+
+    assert payload["google_flights_tfu_inner_token"] == "rt-inner-token"
+    assert payload["google_flights_tfs_tokens"] == ["rt-token-a", "rt-token-b"]
 
 
 def test_serialize_flight_result_numeric_prefix_airline():

--- a/tests/mcp/test_mcp_server_fixes.py
+++ b/tests/mcp/test_mcp_server_fixes.py
@@ -107,14 +107,20 @@ class TestSerializeFlightResult:
     def test_one_way_price_unchanged(self):
         """One-way flight price should pass through unchanged."""
         flight = _make_flight(price=250.0)
+        flight.google_flights_tfu_inner_token = "inner-token"
+        flight.google_flights_tfs_tokens = ["token-a", "token-b"]
         result = _serialize_flight_result(flight, is_round_trip=False)
         assert result["price"] == 250.0
         assert result["currency"] == "USD"
+        assert result["google_flights_tfu_inner_token"] == "inner-token"
+        assert result["google_flights_tfs_tokens"] == ["token-a", "token-b"]
 
     def test_round_trip_uses_outbound_price_only(self):
         """Round-trip price must equal outbound.price (Google already includes full RT price)."""
         outbound = _make_flight(price=454.0, legs=[_make_leg("TLV", "ATH")])
         return_flight = _make_flight(price=454.0, legs=[_make_leg("ATH", "TLV")])
+        outbound.google_flights_tfu_inner_token = "rt-inner-token"
+        outbound.google_flights_tfs_tokens = ["rt-token-a", "rt-token-b"]
 
         result = _serialize_flight_result((outbound, return_flight), is_round_trip=True)
 
@@ -123,6 +129,8 @@ class TestSerializeFlightResult:
             f"Expected 454.0 (outbound price only), got {result['price']}. "
             "Google Flights already includes the full RT price on the outbound leg."
         )
+        assert result["google_flights_tfu_inner_token"] == "rt-inner-token"
+        assert result["google_flights_tfs_tokens"] == ["rt-token-a", "rt-token-b"]
 
     def test_round_trip_price_not_doubled(self):
         """Explicit check that the price is not the sum of both legs."""

--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -256,3 +256,39 @@ class TestParsePriceInfo:
             ],
         ]
         assert SearchFlights._parse_price_info(data) == (118.0, "USD")
+
+
+class TestParseGoogleFlightsTokens:
+    """Tests for preserving raw Google Flights booking tokens."""
+
+    def _make_leg(self):
+        leg = [None] * 23
+        leg[3] = "JFK"
+        leg[6] = "LAX"
+        leg[8] = [10, 30]
+        leg[10] = [13, 45]
+        leg[11] = 195
+        leg[20] = [2026, 5, 1]
+        leg[21] = [2026, 5, 1]
+        leg[22] = ["DL", "123"]
+        return leg
+
+    def test_parse_tfu_inner_token(self):
+        data = [None, [[100, 200, 299.99], "inner-token"]]
+        assert SearchFlights._parse_tfu_inner_token(data) == "inner-token"
+
+    def test_parse_tfs_tokens(self):
+        data = [None, None, None, None, None, None, None, None, '["token-a","token-b"]']
+        assert SearchFlights._parse_tfs_tokens(data) == ["token-a", "token-b"]
+
+    def test_parse_flights_data_preserves_google_tokens(self):
+        data = [[None] * 25, [[100, 200, 299.99], "inner-token"]]
+        data[0][2] = [self._make_leg()]
+        data[0][9] = 195
+        data.extend([None] * 7)
+        data[8] = '["token-a","token-b"]'
+
+        result = SearchFlights._parse_flights_data(data)
+
+        assert result.google_flights_tfu_inner_token == "inner-token"
+        assert result.google_flights_tfs_tokens == ["token-a", "token-b"]


### PR DESCRIPTION
## Summary
- preserve the opaque Google Flights booking tokens on `FlightResult`
- expose the canonical token fields in CLI and MCP JSON output
- add focused unit coverage for parsing plus one-way and round-trip serialization

## Why
These tokens are useful for downstream tooling that needs to keep a stable handle on the raw Google Flights itinerary data without reparsing the response.

## Testing
- `uv run python -m pytest tests/search/test_search_flights.py::TestParsePriceInfo tests/search/test_search_flights.py::TestParseGoogleFlightsTokens tests/cli/test_utils.py tests/mcp/test_mcp_server_fixes.py`
- `uv run ruff check fli/models/google_flights/base.py fli/search/flights.py fli/cli/utils.py fli/mcp/server.py tests/search/test_search_flights.py tests/cli/test_utils.py tests/mcp/test_mcp_server_fixes.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves two opaque Google Flights booking tokens (`google_flights_tfu_inner_token` and `google_flights_tfs_tokens`) on `FlightResult` and surfaces them in both CLI and MCP JSON output. The model change is backward-compatible and all three serialization paths (one-way, round-trip, multi-city) are covered by focused unit tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/clarity suggestions that do not affect correctness.

No P0 or P1 issues found. The model addition is non-breaking, error handling in the new parsers is defensive, and the serialization changes are covered by unit tests across all trip-type paths. The two P2 notes (helper duplication and the tfu/currency token overlap clarification) are improvements for maintainability but do not affect runtime behavior.

fli/search/flights.py — worth adding a comment clarifying that `data[1][1]` is the same slot used for currency extraction.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The token fields are opaque strings read from the API response and passed through without evaluation or execution.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/models/google_flights/base.py | Adds two optional fields to `FlightResult`: `google_flights_tfu_inner_token` and `google_flights_tfs_tokens`; clean Pydantic additions with no breaking changes. |
| fli/search/flights.py | Adds `_parse_tfu_inner_token` and `_parse_tfs_tokens` static methods and wires them into `_parse_flights_data`; `tfu_inner_token` reads `data[1][1]`, which is the same slot already decoded as the currency token by `extract_currency_from_price_token`. |
| fli/cli/utils.py | Introduces `_attach_google_flights_tokens` and calls it from all three serialization paths; logic is correct but the helper is duplicated identically in `fli/mcp/server.py`. |
| fli/mcp/server.py | Same `_attach_google_flights_tokens` helper and call-sites as CLI; duplicate of the function in `cli/utils.py` — should be shared via `fli/core/`. |
| tests/search/test_search_flights.py | Adds `TestParseGoogleFlightsTokens` class covering `_parse_tfu_inner_token`, `_parse_tfs_tokens`, and the full `_parse_flights_data` round-trip; good coverage of the new parsing paths. |
| tests/cli/test_utils.py | Extends existing one-way and adds a new round-trip token-preservation test; straightforward and correct. |
| tests/mcp/test_mcp_server_fixes.py | Extends `TestSerializeFlightResult` to assert token fields appear for both one-way and round-trip serialization; adequate coverage. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Google Flights API response\nraw flight data row"] --> B["_parse_flights_data(data)"]
    B --> C["_parse_tfu_inner_token(data)\ndata[1][1]"]
    B --> D["_parse_tfs_tokens(data)\ndata[8]  (JSON-decoded list)"]
    B --> E["_parse_price_info(data)\ndata[1][0] → price\ndata[1][1] → currency token"]
    C -->|"same slot as currency token"| E
    C --> F["FlightResult.google_flights_tfu_inner_token"]
    D --> G["FlightResult.google_flights_tfs_tokens"]
    F --> H["_attach_google_flights_tokens(payload, flight)"]
    G --> H
    H --> I["CLI serialize_flight_result"]
    H --> J["MCP _serialize_flight_result"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/cli/utils.py
Line: 218-224

Comment:
**Duplicate helper across CLI and MCP**

`_attach_google_flights_tokens` is copy-pasted verbatim into `fli/mcp/server.py` (lines 217-223). Any future change to the serialisation logic (e.g. renaming a field, adding a third token) must be applied in both files. Moving the helper to `fli/core/` (alongside `parsers.py` / `builders.py`) would keep both layers in sync automatically, following the existing pattern of sharing utilities.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/search/flights.py
Line: 151-158

Comment:
**`tfu_inner_token` overlaps with the currency-token field**

`_parse_tfu_inner_token` reads `data[1][1]`, which is the exact same field already passed to `extract_currency_from_price_token` in `_parse_price_info` (via `price_block[1]`). The value is a base64-encoded protobuf blob whose primary purpose is to carry the currency code.

If `data[1][1]` is genuinely a stable booking handle in addition to being the currency token, a comment explaining this dual role would help future maintainers — and consumers of the field — understand what they can rely on. If it is *only* the currency token, labelling it as a "booking token" in the model and output could mislead downstream tooling.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: preserve Google Flights booking to..."](https://github.com/punitarani/fli/commit/717d6e0824ffd706ff8d32cdc0751ec50fb80835) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27724156)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->