### PR TITLE
fix: prevent cumulative travel date drift in chunked date search

### DIFF
--- a/fli/search/dates.py
+++ b/fli/search/dates.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from fli.core import extract_currency_from_price_token
 from fli.models import DateSearchFilters
-from fli.models.google_flights.base import TripType
+from fli.models.google_flights.base import FlightSegment, TripType
 from fli.search.client import get_client
 
 
@@ -68,22 +68,35 @@ class SearchDates:
         # Split into chunks of MAX_DAYS_PER_SEARCH
         all_results = []
         current_from = from_date
+        # Snapshot the original segment travel dates so each chunk can compute
+        # its own offset without accumulating mutations across iterations.
+        original_travel_dates = [seg.travel_date for seg in filters.flight_segments]
         while current_from <= to_date:
             current_to = min(current_from + timedelta(days=self.MAX_DAYS_PER_SEARCH - 1), to_date)
 
-            # Update the travel date for the flight segments
-            if current_from > from_date:
-                for segment in filters.flight_segments:
-                    segment.travel_date = (
-                        datetime.strptime(segment.travel_date, "%Y-%m-%d")
-                        + timedelta(days=self.MAX_DAYS_PER_SEARCH)
-                    ).strftime("%Y-%m-%d")
+            # Compute the travel date offset for this chunk relative to the
+            # original from_date, then build fresh FlightSegment copies so we
+            # never mutate the caller's filters object.
+            offset = current_from - from_date
+            chunk_segments = [
+                FlightSegment(
+                    departure_airport=seg.departure_airport,
+                    arrival_airport=seg.arrival_airport,
+                    travel_date=(
+                        datetime.strptime(original_date, "%Y-%m-%d") + offset
+                    ).strftime("%Y-%m-%d"),
+                    time_restrictions=seg.time_restrictions,
+                )
+                for seg, original_date in zip(
+                    filters.flight_segments, original_travel_dates
+                )
+            ]
 
             # Create new filters for this chunk
             chunk_filters = DateSearchFilters(
                 trip_type=filters.trip_type,
                 passenger_info=filters.passenger_info,
-                flight_segments=filters.flight_segments,
+                flight_segments=chunk_segments,
                 stops=filters.stops,
                 seat_type=filters.seat_type,
                 airlines=filters.airlines,

--- a/fli/search/dates.py
+++ b/fli/search/dates.py
@@ -87,21 +87,18 @@ class SearchDates:
                     }
                 )
                 for seg, original_date in zip(
-                    filters.flight_segments, original_travel_dates
+                    filters.flight_segments, original_travel_dates, strict=True
                 )
             ]
 
-            # Create new filters for this chunk
-            chunk_filters = DateSearchFilters(
-                trip_type=filters.trip_type,
-                passenger_info=filters.passenger_info,
-                flight_segments=chunk_segments,
-                stops=filters.stops,
-                seat_type=filters.seat_type,
-                airlines=filters.airlines,
-                from_date=current_from.strftime("%Y-%m-%d"),
-                to_date=current_to.strftime("%Y-%m-%d"),
-                duration=filters.duration,
+            # Copy the original filters so optional constraints are preserved
+            # for each chunk, while updating only the fields that vary.
+            chunk_filters = filters.model_copy(
+                update={
+                    "flight_segments": chunk_segments,
+                    "from_date": current_from.strftime("%Y-%m-%d"),
+                    "to_date": current_to.strftime("%Y-%m-%d"),
+                }
             )
 
             chunk_results = self._search_chunk(chunk_filters)

--- a/fli/search/dates.py
+++ b/fli/search/dates.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 
 from fli.core import extract_currency_from_price_token
 from fli.models import DateSearchFilters
-from fli.models.google_flights.base import FlightSegment, TripType
+from fli.models.google_flights.base import TripType
 from fli.search.client import get_client
 
 
@@ -75,17 +75,16 @@ class SearchDates:
             current_to = min(current_from + timedelta(days=self.MAX_DAYS_PER_SEARCH - 1), to_date)
 
             # Compute the travel date offset for this chunk relative to the
-            # original from_date, then build fresh FlightSegment copies so we
-            # never mutate the caller's filters object.
+            # original from_date, then create shallow copies of each segment
+            # so we never mutate the caller's filters object.
             offset = current_from - from_date
             chunk_segments = [
-                FlightSegment(
-                    departure_airport=seg.departure_airport,
-                    arrival_airport=seg.arrival_airport,
-                    travel_date=(
-                        datetime.strptime(original_date, "%Y-%m-%d") + offset
-                    ).strftime("%Y-%m-%d"),
-                    time_restrictions=seg.time_restrictions,
+                seg.model_copy(
+                    update={
+                        "travel_date": (
+                            datetime.strptime(original_date, "%Y-%m-%d") + offset
+                        ).strftime("%Y-%m-%d"),
+                    }
                 )
                 for seg, original_date in zip(
                     filters.flight_segments, original_travel_dates

--- a/tests/search/test_search_dates.py
+++ b/tests/search/test_search_dates.py
@@ -5,13 +5,19 @@ from datetime import datetime, timedelta
 import pytest
 
 from fli.models import (
+    Airline,
     Airport,
+    BagsFilter,
     DateSearchFilters,
+    EmissionsFilter,
     FlightSegment,
+    LayoverRestrictions,
     MaxStops,
     PassengerInfo,
+    PriceLimit,
     SeatType,
     SortBy,
+    TimeRestrictions,
 )
 from fli.models.google_flights.base import TripType
 from fli.search import SearchDates
@@ -145,6 +151,103 @@ def complex_round_trip_params():
         from_date=(outbound_date - timedelta(days=30)).strftime("%Y-%m-%d"),
         to_date=(outbound_date + timedelta(days=30)).strftime("%Y-%m-%d"),
     )
+
+
+def test_chunked_search_does_not_mutate_caller_filters(monkeypatch):
+    """Chunked searches should not modify the caller's filter object."""
+    from_date = datetime.now() + timedelta(days=30)
+    to_date = from_date + timedelta(days=120)
+    filters = DateSearchFilters(
+        passenger_info=PassengerInfo(adults=1),
+        flight_segments=[
+            FlightSegment(
+                departure_airport=[[Airport.PHX, 0]],
+                arrival_airport=[[Airport.SFO, 0]],
+                travel_date=from_date.strftime("%Y-%m-%d"),
+            )
+        ],
+        from_date=from_date.strftime("%Y-%m-%d"),
+        to_date=to_date.strftime("%Y-%m-%d"),
+    )
+    original_segment_dates = [segment.travel_date for segment in filters.flight_segments]
+    captured_chunks = []
+
+    def fake_search_chunk(self, chunk_filters):
+        captured_chunks.append(chunk_filters)
+        return []
+
+    monkeypatch.setattr(SearchDates, "_search_chunk", fake_search_chunk)
+
+    search = SearchDates.__new__(SearchDates)
+    assert search.search(filters) is None
+
+    assert [segment.travel_date for segment in filters.flight_segments] == original_segment_dates
+    assert [chunk.flight_segments[0].travel_date for chunk in captured_chunks] == [
+        from_date.strftime("%Y-%m-%d"),
+        (from_date + timedelta(days=SearchDates.MAX_DAYS_PER_SEARCH)).strftime("%Y-%m-%d"),
+    ]
+
+
+def test_chunked_search_preserves_optional_filters(monkeypatch):
+    """Chunk filters should retain optional constraints from the caller's filters."""
+    from_date = datetime.now() + timedelta(days=30)
+    to_date = from_date + timedelta(days=130)
+    filters = DateSearchFilters(
+        passenger_info=PassengerInfo(adults=2, children=1),
+        flight_segments=[
+            FlightSegment(
+                departure_airport=[[Airport.PHX, 0]],
+                arrival_airport=[[Airport.SFO, 0]],
+                travel_date=from_date.strftime("%Y-%m-%d"),
+                time_restrictions=TimeRestrictions(
+                    earliest_departure=7,
+                    latest_departure=18,
+                    earliest_arrival=9,
+                    latest_arrival=22,
+                ),
+            )
+        ],
+        stops=MaxStops.ONE_STOP_OR_FEWER,
+        seat_type=SeatType.PREMIUM_ECONOMY,
+        price_limit=PriceLimit(max_price=500),
+        airlines=[Airline.AA, Airline.UA],
+        max_duration=480,
+        layover_restrictions=LayoverRestrictions(
+            airports=[Airport.LAX],
+            max_duration=180,
+        ),
+        emissions=EmissionsFilter.LESS,
+        bags=BagsFilter(checked_bags=1, carry_on=True),
+        from_date=from_date.strftime("%Y-%m-%d"),
+        to_date=to_date.strftime("%Y-%m-%d"),
+    )
+    captured_chunks = []
+
+    def fake_search_chunk(self, chunk_filters):
+        captured_chunks.append(chunk_filters)
+        return []
+
+    monkeypatch.setattr(SearchDates, "_search_chunk", fake_search_chunk)
+
+    search = SearchDates.__new__(SearchDates)
+    search.search(filters)
+
+    assert len(captured_chunks) == 3
+    for chunk in captured_chunks:
+        assert chunk is not filters
+        assert chunk.flight_segments[0] is not filters.flight_segments[0]
+        assert (
+            chunk.flight_segments[0].time_restrictions
+            == filters.flight_segments[0].time_restrictions
+        )
+        assert chunk.stops == filters.stops
+        assert chunk.seat_type == filters.seat_type
+        assert chunk.price_limit == filters.price_limit
+        assert chunk.airlines == filters.airlines
+        assert chunk.max_duration == filters.max_duration
+        assert chunk.layover_restrictions == filters.layover_restrictions
+        assert chunk.emissions == filters.emissions
+        assert chunk.bags == filters.bags
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Bug

`SearchDates.search()` splits date ranges longer than 61 days into multiple API chunks. The chunk loop used the caller's shared `filters` object while preparing per-chunk `FlightSegment` dates, so `filters.flight_segments[*].travel_date` was left advanced to the final chunk after `search()` returned.

The date sequence sent to each chunk still advanced by `MAX_DAYS_PER_SEARCH` (0, 61, 122, 183, ...). The defect fixed here is the side effect on the caller's filters object, which can corrupt subsequent reuse of the same `DateSearchFilters` instance.

## Fix

- Snapshot each original segment `travel_date` before chunking.
- Create per-chunk segment copies with `model_copy(update={"travel_date": ...})` so segment fields such as time restrictions and selected flights are preserved.
- Create per-chunk filters with `filters.model_copy(update={...})`, updating only `flight_segments`, `from_date`, and `to_date`. This preserves optional constraints such as price limit, max duration, layover restrictions, emissions, and bags.

## Tests

- [x] Added a unit test that forces chunking and verifies `SearchDates.search()` does not mutate the caller's `flight_segments[*].travel_date`.
- [x] Added a unit test that chunk filters preserve optional `DateSearchFilters` constraints.
- [x] Ran `pytest tests/search/test_search_dates.py -q -k 'chunked_search'`.
- [x] Ran `ruff check fli/search/dates.py tests/search/test_search_dates.py`.
- [x] Ran `ruff format --check fli/search/dates.py tests/search/test_search_dates.py`.
