### PR TITLE
feat: add locale support for regional pricing

### DIFF
--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -69,6 +69,14 @@ class FlightSearchConfig(BaseSettings):
         gt=0,
         description="Optional maximum number of results returned by each tool.",
     )
+    country: str | None = Field(
+        None,
+        description="ISO country code for locale-based pricing (e.g., 'BE', 'US', 'DE')",
+    )
+    language: str | None = Field(
+        None,
+        description="Language code (e.g., 'nl', 'en', 'de')",
+    )
 
 
 CONFIG = FlightSearchConfig()

--- a/fli/search/dates.py
+++ b/fli/search/dates.py
@@ -6,6 +6,7 @@ It is intended to be used for finding the cheapest dates to fly, not the cheapes
 """
 
 import json
+import os
 from datetime import datetime, timedelta
 
 from pydantic import BaseModel
@@ -40,6 +41,32 @@ class SearchDates:
     def __init__(self):
         """Initialize the search client for date-based searches."""
         self.client = get_client()
+
+    @staticmethod
+    def _build_url() -> str:
+        """Build the API URL with locale query parameters from environment variables.
+
+        Reads FLI_MCP_COUNTRY, FLI_MCP_LANGUAGE, and FLI_MCP_CURRENCY env vars
+        and appends them as gl=, hl=, and curr= query params respectively.
+
+        Returns:
+            The BASE_URL with any configured locale parameters appended.
+
+        """
+        url = SearchDates.BASE_URL
+        params = []
+        country = os.environ.get("FLI_MCP_COUNTRY")
+        if country:
+            params.append(f"gl={country}")
+        language = os.environ.get("FLI_MCP_LANGUAGE")
+        if language:
+            params.append(f"hl={language}")
+        currency = os.environ.get("FLI_MCP_CURRENCY")
+        if currency:
+            params.append(f"curr={currency}")
+        if params:
+            url = f"{url}?{'&'.join(params)}"
+        return url
 
     def search(self, filters: DateSearchFilters) -> list[DatePrice] | None:
         """Search for flight prices across a date range and search parameters.
@@ -117,7 +144,7 @@ class SearchDates:
 
         try:
             response = self.client.post(
-                url=self.BASE_URL,
+                url=self._build_url(),
                 data=f"f.req={encoded_filters}",
                 impersonate="chrome",
                 allow_redirects=True,

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -5,6 +5,7 @@ with Google Flights' API to find available flights and their details.
 """
 
 import json
+import os
 from copy import deepcopy
 from datetime import datetime
 
@@ -36,6 +37,32 @@ class SearchFlights:
         """Initialize the search client for flight searches."""
         self.client = get_client()
 
+    @staticmethod
+    def _build_url() -> str:
+        """Build the API URL with locale query parameters from environment variables.
+
+        Reads FLI_MCP_COUNTRY, FLI_MCP_LANGUAGE, and FLI_MCP_CURRENCY env vars
+        and appends them as gl=, hl=, and curr= query params respectively.
+
+        Returns:
+            The BASE_URL with any configured locale parameters appended.
+
+        """
+        url = SearchFlights.BASE_URL
+        params = []
+        country = os.environ.get("FLI_MCP_COUNTRY")
+        if country:
+            params.append(f"gl={country}")
+        language = os.environ.get("FLI_MCP_LANGUAGE")
+        if language:
+            params.append(f"hl={language}")
+        currency = os.environ.get("FLI_MCP_CURRENCY")
+        if currency:
+            params.append(f"curr={currency}")
+        if params:
+            url = f"{url}?{'&'.join(params)}"
+        return url
+
     def search(
         self, filters: FlightSearchFilters, top_n: int = 5
     ) -> list[FlightResult | tuple[FlightResult, ...]] | None:
@@ -62,7 +89,7 @@ class SearchFlights:
 
         try:
             response = self.client.post(
-                url=self.BASE_URL,
+                url=self._build_url(),
                 data=f"f.req={encoded_filters}",
                 impersonate="chrome",
                 allow_redirects=True,


### PR DESCRIPTION
## Summary
- Adds `gl=`, `hl=`, and `curr=` query parameters to Google Flights API requests
- Controlled via `FLI_MCP_COUNTRY`, `FLI_MCP_LANGUAGE`, `FLI_MCP_CURRENCY` env vars
- Enables correct locale-based pricing (e.g., EUR prices when searching from Belgium)

## Problem
Google Flights API returns prices based on IP geolocation. Users outside the US get incorrect pricing — e.g., a Belgian user sees inflated USD prices instead of EUR prices matching google.com/travel.

## Solution
Added `_build_url()` static methods to `SearchFlights` and `SearchDates` that read environment variables and append locale query parameters to the API URL. This mirrors how the Google Flights web UI passes `gl=BE&hl=nl&curr=EUR` in its requests.

## Configuration
Set environment variables before starting the MCP server:
```
FLI_MCP_COUNTRY=BE    # ISO country code → gl= param
FLI_MCP_LANGUAGE=nl   # Language code → hl= param  
FLI_MCP_CURRENCY=EUR  # Currency code → curr= param
```

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR appends `gl=`, `hl=`, and `curr=` locale query parameters to the Google Flights API URL via new `_build_url()` static methods on `SearchFlights` and `SearchDates`, controlled by `FLI_MCP_COUNTRY`, `FLI_MCP_LANGUAGE`, and `FLI_MCP_CURRENCY` environment variables.

- The `country` and `language` fields added to `FlightSearchConfig` in `server.py` are dead code — `_build_url()` reads the env vars directly via `os.environ.get()`, bypassing the config entirely. `FLI_MCP_CURRENCY` is also absent from the config, making the new fields inconsistent and misleading.
- The `configuration_resource()` documentation is not updated to surface the three new env vars to MCP clients.
- `_build_url()` is copy-pasted identically into both search classes and should be extracted into a shared utility.

<h3>Confidence Score: 4/5</h3>

The core locale feature works correctly, but the config fields in server.py are dead code and the configuration resource is incomplete — both should be addressed before merge.

All findings are P2, but the unused country/language config fields create a genuine inconsistency: they appear in the config schema exposed to MCP clients but have no effect, while FLI_MCP_CURRENCY — which actually matters — is absent from the schema entirely. This misleads users about how to configure the feature.

fli/mcp/server.py — unused config fields and incomplete configuration resource documentation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| fli/mcp/server.py | Adds `country` and `language` fields to `FlightSearchConfig`, but neither is wired into the actual locale logic — `_build_url()` reads env vars directly, bypassing the config. `FLI_MCP_CURRENCY` is also absent from the config. The configuration resource is not updated with the new env vars. |
| fli/search/flights.py | Adds `_build_url()` static method that reads `FLI_MCP_COUNTRY`, `FLI_MCP_LANGUAGE`, and `FLI_MCP_CURRENCY` env vars and appends them as query params; method is identical to the one added in `dates.py`. |
| fli/search/dates.py | Adds identical `_build_url()` static method to `SearchDates`; logic and duplication concerns same as `flights.py`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant E as Env Vars<br/>(FLI_MCP_COUNTRY/LANGUAGE/CURRENCY)
    participant S as SearchFlights / SearchDates
    participant G as Google Flights API

    Note over E,S: _build_url() reads env vars directly<br/>(CONFIG fields country/language are unused)
    S->>E: os.environ.get("FLI_MCP_COUNTRY")
    S->>E: os.environ.get("FLI_MCP_LANGUAGE")
    S->>E: os.environ.get("FLI_MCP_CURRENCY")
    S->>S: Build URL with gl=, hl=, curr= params
    S->>G: POST BASE_URL?gl=BE&hl=nl&curr=EUR
    G-->>S: Locale-aware prices (e.g., EUR)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `fli/mcp/server.py`, line 622-639 ([link](https://github.com/punitarani/fli/blob/40759edf226c223b05d4b31005494bfeb975b83c/fli/mcp/server.py#L622-L639)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **New env vars missing from configuration resource**

   The `configuration_resource()` exposes a hardcoded list of env vars for documentation, but `FLI_MCP_COUNTRY`, `FLI_MCP_LANGUAGE`, and `FLI_MCP_CURRENCY` are not included. Users querying the resource via MCP will have no indication these locale parameters exist.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: fli/mcp/server.py
   Line: 622-639

   Comment:
   **New env vars missing from configuration resource**

   The `configuration_resource()` exposes a hardcoded list of env vars for documentation, but `FLI_MCP_COUNTRY`, `FLI_MCP_LANGUAGE`, and `FLI_MCP_CURRENCY` are not included. Users querying the resource via MCP will have no indication these locale parameters exist.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20fli%2Fmcp%2Fserver.py%0ALine%3A%20622-639%0A%0AComment%3A%0A**New%20env%20vars%20missing%20from%20configuration%20resource**%0A%0AThe%20%60configuration_resource%28%29%60%20exposes%20a%20hardcoded%20list%20of%20env%20vars%20for%20documentation%2C%20but%20%60FLI_MCP_COUNTRY%60%2C%20%60FLI_MCP_LANGUAGE%60%2C%20and%20%60FLI_MCP_CURRENCY%60%20are%20not%20included.%20Users%20querying%20the%20resource%20via%20MCP%20will%20have%20no%20indication%20these%20locale%20parameters%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22environment%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22prefix%22%3A%20%22FLI_MCP_%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22variables%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_PASSENGERS%22%3A%20%22Adjust%20the%20default%20passenger%20count.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CURRENCY%22%3A%20%22Override%20the%20fallback%20currency%20code%20for%20results.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CABIN_CLASS%22%3A%20%22Set%20a%20default%20cabin%20class.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_SORT_BY%22%3A%20%22Set%20the%20default%20result%20sorting%20strategy.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_DEPARTURE_WINDOW%22%3A%20%22Provide%20a%20default%20departure%20window%20%28HH-HH%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_MAX_RESULTS%22%3A%20%22Limit%20the%20maximum%20number%20of%20results%20returned%20by%20tools.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_COUNTRY%22%3A%20%22ISO%20country%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'BE'%2C%20'US'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_LANGUAGE%22%3A%20%22Language%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'nl'%2C%20'en'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_CURRENCY%22%3A%20%22Currency%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'EUR'%2C%20'USD'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20fli%2Fmcp%2Fserver.py%0ALine%3A%20622-639%0A%0AComment%3A%0A**New%20env%20vars%20missing%20from%20configuration%20resource**%0A%0AThe%20%60configuration_resource%28%29%60%20exposes%20a%20hardcoded%20list%20of%20env%20vars%20for%20documentation%2C%20but%20%60FLI_MCP_COUNTRY%60%2C%20%60FLI_MCP_LANGUAGE%60%2C%20and%20%60FLI_MCP_CURRENCY%60%20are%20not%20included.%20Users%20querying%20the%20resource%20via%20MCP%20will%20have%20no%20indication%20these%20locale%20parameters%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22environment%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22prefix%22%3A%20%22FLI_MCP_%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22variables%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_PASSENGERS%22%3A%20%22Adjust%20the%20default%20passenger%20count.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CURRENCY%22%3A%20%22Override%20the%20fallback%20currency%20code%20for%20results.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CABIN_CLASS%22%3A%20%22Set%20a%20default%20cabin%20class.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_SORT_BY%22%3A%20%22Set%20the%20default%20result%20sorting%20strategy.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_DEPARTURE_WINDOW%22%3A%20%22Provide%20a%20default%20departure%20window%20%28HH-HH%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_MAX_RESULTS%22%3A%20%22Limit%20the%20maximum%20number%20of%20results%20returned%20by%20tools.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_COUNTRY%22%3A%20%22ISO%20country%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'BE'%2C%20'US'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_LANGUAGE%22%3A%20%22Language%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'nl'%2C%20'en'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_CURRENCY%22%3A%20%22Currency%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'EUR'%2C%20'USD'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=punitarani%2Ffli&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22feature%2Flocale-support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Flocale-support%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20fli%2Fmcp%2Fserver.py%0ALine%3A%20622-639%0A%0AComment%3A%0A**New%20env%20vars%20missing%20from%20configuration%20resource**%0A%0AThe%20%60configuration_resource%28%29%60%20exposes%20a%20hardcoded%20list%20of%20env%20vars%20for%20documentation%2C%20but%20%60FLI_MCP_COUNTRY%60%2C%20%60FLI_MCP_LANGUAGE%60%2C%20and%20%60FLI_MCP_CURRENCY%60%20are%20not%20included.%20Users%20querying%20the%20resource%20via%20MCP%20will%20have%20no%20indication%20these%20locale%20parameters%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22environment%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22prefix%22%3A%20%22FLI_MCP_%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22variables%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_PASSENGERS%22%3A%20%22Adjust%20the%20default%20passenger%20count.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CURRENCY%22%3A%20%22Override%20the%20fallback%20currency%20code%20for%20results.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CABIN_CLASS%22%3A%20%22Set%20a%20default%20cabin%20class.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_SORT_BY%22%3A%20%22Set%20the%20default%20result%20sorting%20strategy.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_DEPARTURE_WINDOW%22%3A%20%22Provide%20a%20default%20departure%20window%20%28HH-HH%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_MAX_RESULTS%22%3A%20%22Limit%20the%20maximum%20number%20of%20results%20returned%20by%20tools.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_COUNTRY%22%3A%20%22ISO%20country%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'BE'%2C%20'US'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_LANGUAGE%22%3A%20%22Language%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'nl'%2C%20'en'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_CURRENCY%22%3A%20%22Currency%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'EUR'%2C%20'USD'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fmcp%2Fserver.py%3A72-79%0A**Unused%20config%20fields%20%E2%80%94%20dead%20code**%0A%0A%60country%60%20and%20%60language%60%20are%20added%20to%20%60FlightSearchConfig%60%20%28so%20they%20appear%20in%20the%20config%20schema%20resource%20and%20receive%20%60FLI_MCP_COUNTRY%60%2F%60FLI_MCP_LANGUAGE%60%20via%20pydantic-settings%29%2C%20but%20neither%20%60CONFIG.country%60%20nor%20%60CONFIG.language%60%20is%20referenced%20anywhere.%20The%20actual%20locale%20parameters%20are%20read%20independently%20by%20%60os.environ.get%28%29%60%20inside%20each%20%60_build_url%28%29%60%20method%2C%20completely%20bypassing%20the%20config.%20The%20%60FLI_MCP_CURRENCY%60%20field%20is%20not%20in%20the%20config%20at%20all%2C%20making%20the%20pattern%20inconsistent.%20Either%20wire%20the%20config%20values%20into%20%60_build_url%28%29%60%2C%20or%20remove%20these%20fields%20to%20avoid%20confusing%20users%20who%20inspect%20the%20config%20schema.%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fmcp%2Fserver.py%3A622-639%0A**New%20env%20vars%20missing%20from%20configuration%20resource**%0A%0AThe%20%60configuration_resource%28%29%60%20exposes%20a%20hardcoded%20list%20of%20env%20vars%20for%20documentation%2C%20but%20%60FLI_MCP_COUNTRY%60%2C%20%60FLI_MCP_LANGUAGE%60%2C%20and%20%60FLI_MCP_CURRENCY%60%20are%20not%20included.%20Users%20querying%20the%20resource%20via%20MCP%20will%20have%20no%20indication%20these%20locale%20parameters%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22environment%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22prefix%22%3A%20%22FLI_MCP_%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22variables%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_PASSENGERS%22%3A%20%22Adjust%20the%20default%20passenger%20count.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CURRENCY%22%3A%20%22Override%20the%20fallback%20currency%20code%20for%20results.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CABIN_CLASS%22%3A%20%22Set%20a%20default%20cabin%20class.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_SORT_BY%22%3A%20%22Set%20the%20default%20result%20sorting%20strategy.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_DEPARTURE_WINDOW%22%3A%20%22Provide%20a%20default%20departure%20window%20%28HH-HH%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_MAX_RESULTS%22%3A%20%22Limit%20the%20maximum%20number%20of%20results%20returned%20by%20tools.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_COUNTRY%22%3A%20%22ISO%20country%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'BE'%2C%20'US'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_LANGUAGE%22%3A%20%22Language%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'nl'%2C%20'en'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_CURRENCY%22%3A%20%22Currency%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'EUR'%2C%20'USD'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fflights.py%3A40-65%0A**Duplicated%20%60_build_url%28%29%60%20logic**%0A%0A%60_build_url%28%29%60%20in%20%60SearchFlights%60%20and%20%60SearchDates%60%20is%20byte-for-byte%20identical.%20Since%20both%20classes%20live%20in%20the%20same%20%60fli%2Fsearch%2F%60%20package%2C%20this%20should%20be%20extracted%20into%20a%20shared%20module-level%20helper%20%28e.g.%2C%20in%20%60client.py%60%20or%20a%20new%20%60fli%2Fsearch%2Futils.py%60%29%20to%20avoid%20drift%20if%20the%20URL-building%20logic%20needs%20to%20change.%0A%0A&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fmcp%2Fserver.py%3A72-79%0A**Unused%20config%20fields%20%E2%80%94%20dead%20code**%0A%0A%60country%60%20and%20%60language%60%20are%20added%20to%20%60FlightSearchConfig%60%20%28so%20they%20appear%20in%20the%20config%20schema%20resource%20and%20receive%20%60FLI_MCP_COUNTRY%60%2F%60FLI_MCP_LANGUAGE%60%20via%20pydantic-settings%29%2C%20but%20neither%20%60CONFIG.country%60%20nor%20%60CONFIG.language%60%20is%20referenced%20anywhere.%20The%20actual%20locale%20parameters%20are%20read%20independently%20by%20%60os.environ.get%28%29%60%20inside%20each%20%60_build_url%28%29%60%20method%2C%20completely%20bypassing%20the%20config.%20The%20%60FLI_MCP_CURRENCY%60%20field%20is%20not%20in%20the%20config%20at%20all%2C%20making%20the%20pattern%20inconsistent.%20Either%20wire%20the%20config%20values%20into%20%60_build_url%28%29%60%2C%20or%20remove%20these%20fields%20to%20avoid%20confusing%20users%20who%20inspect%20the%20config%20schema.%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fmcp%2Fserver.py%3A622-639%0A**New%20env%20vars%20missing%20from%20configuration%20resource**%0A%0AThe%20%60configuration_resource%28%29%60%20exposes%20a%20hardcoded%20list%20of%20env%20vars%20for%20documentation%2C%20but%20%60FLI_MCP_COUNTRY%60%2C%20%60FLI_MCP_LANGUAGE%60%2C%20and%20%60FLI_MCP_CURRENCY%60%20are%20not%20included.%20Users%20querying%20the%20resource%20via%20MCP%20will%20have%20no%20indication%20these%20locale%20parameters%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22environment%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22prefix%22%3A%20%22FLI_MCP_%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22variables%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_PASSENGERS%22%3A%20%22Adjust%20the%20default%20passenger%20count.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CURRENCY%22%3A%20%22Override%20the%20fallback%20currency%20code%20for%20results.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CABIN_CLASS%22%3A%20%22Set%20a%20default%20cabin%20class.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_SORT_BY%22%3A%20%22Set%20the%20default%20result%20sorting%20strategy.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_DEPARTURE_WINDOW%22%3A%20%22Provide%20a%20default%20departure%20window%20%28HH-HH%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_MAX_RESULTS%22%3A%20%22Limit%20the%20maximum%20number%20of%20results%20returned%20by%20tools.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_COUNTRY%22%3A%20%22ISO%20country%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'BE'%2C%20'US'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_LANGUAGE%22%3A%20%22Language%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'nl'%2C%20'en'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_CURRENCY%22%3A%20%22Currency%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'EUR'%2C%20'USD'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fflights.py%3A40-65%0A**Duplicated%20%60_build_url%28%29%60%20logic**%0A%0A%60_build_url%28%29%60%20in%20%60SearchFlights%60%20and%20%60SearchDates%60%20is%20byte-for-byte%20identical.%20Since%20both%20classes%20live%20in%20the%20same%20%60fli%2Fsearch%2F%60%20package%2C%20this%20should%20be%20extracted%20into%20a%20shared%20module-level%20helper%20%28e.g.%2C%20in%20%60client.py%60%20or%20a%20new%20%60fli%2Fsearch%2Futils.py%60%29%20to%20avoid%20drift%20if%20the%20URL-building%20logic%20needs%20to%20change.%0A%0A&repo=punitarani%2Ffli&pr=139&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22feature%2Flocale-support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Flocale-support%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fmcp%2Fserver.py%3A72-79%0A**Unused%20config%20fields%20%E2%80%94%20dead%20code**%0A%0A%60country%60%20and%20%60language%60%20are%20added%20to%20%60FlightSearchConfig%60%20%28so%20they%20appear%20in%20the%20config%20schema%20resource%20and%20receive%20%60FLI_MCP_COUNTRY%60%2F%60FLI_MCP_LANGUAGE%60%20via%20pydantic-settings%29%2C%20but%20neither%20%60CONFIG.country%60%20nor%20%60CONFIG.language%60%20is%20referenced%20anywhere.%20The%20actual%20locale%20parameters%20are%20read%20independently%20by%20%60os.environ.get%28%29%60%20inside%20each%20%60_build_url%28%29%60%20method%2C%20completely%20bypassing%20the%20config.%20The%20%60FLI_MCP_CURRENCY%60%20field%20is%20not%20in%20the%20config%20at%20all%2C%20making%20the%20pattern%20inconsistent.%20Either%20wire%20the%20config%20values%20into%20%60_build_url%28%29%60%2C%20or%20remove%20these%20fields%20to%20avoid%20confusing%20users%20who%20inspect%20the%20config%20schema.%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fmcp%2Fserver.py%3A622-639%0A**New%20env%20vars%20missing%20from%20configuration%20resource**%0A%0AThe%20%60configuration_resource%28%29%60%20exposes%20a%20hardcoded%20list%20of%20env%20vars%20for%20documentation%2C%20but%20%60FLI_MCP_COUNTRY%60%2C%20%60FLI_MCP_LANGUAGE%60%2C%20and%20%60FLI_MCP_CURRENCY%60%20are%20not%20included.%20Users%20querying%20the%20resource%20via%20MCP%20will%20have%20no%20indication%20these%20locale%20parameters%20exist.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22environment%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22prefix%22%3A%20%22FLI_MCP_%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22variables%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_PASSENGERS%22%3A%20%22Adjust%20the%20default%20passenger%20count.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CURRENCY%22%3A%20%22Override%20the%20fallback%20currency%20code%20for%20results.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_CABIN_CLASS%22%3A%20%22Set%20a%20default%20cabin%20class.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_SORT_BY%22%3A%20%22Set%20the%20default%20result%20sorting%20strategy.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_DEFAULT_DEPARTURE_WINDOW%22%3A%20%22Provide%20a%20default%20departure%20window%20%28HH-HH%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_MAX_RESULTS%22%3A%20%22Limit%20the%20maximum%20number%20of%20results%20returned%20by%20tools.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_COUNTRY%22%3A%20%22ISO%20country%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'BE'%2C%20'US'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_LANGUAGE%22%3A%20%22Language%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'nl'%2C%20'en'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22FLI_MCP_CURRENCY%22%3A%20%22Currency%20code%20for%20locale-based%20pricing%20%28e.g.%2C%20'EUR'%2C%20'USD'%29.%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fflights.py%3A40-65%0A**Duplicated%20%60_build_url%28%29%60%20logic**%0A%0A%60_build_url%28%29%60%20in%20%60SearchFlights%60%20and%20%60SearchDates%60%20is%20byte-for-byte%20identical.%20Since%20both%20classes%20live%20in%20the%20same%20%60fli%2Fsearch%2F%60%20package%2C%20this%20should%20be%20extracted%20into%20a%20shared%20module-level%20helper%20%28e.g.%2C%20in%20%60client.py%60%20or%20a%20new%20%60fli%2Fsearch%2Futils.py%60%29%20to%20avoid%20drift%20if%20the%20URL-building%20logic%20needs%20to%20change.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 72-79

Comment:
**Unused config fields — dead code**

`country` and `language` are added to `FlightSearchConfig` (so they appear in the config schema resource and receive `FLI_MCP_COUNTRY`/`FLI_MCP_LANGUAGE` via pydantic-settings), but neither `CONFIG.country` nor `CONFIG.language` is referenced anywhere. The actual locale parameters are read independently by `os.environ.get()` inside each `_build_url()` method, completely bypassing the config. The `FLI_MCP_CURRENCY` field is not in the config at all, making the pattern inconsistent. Either wire the config values into `_build_url()`, or remove these fields to avoid confusing users who inspect the config schema.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/mcp/server.py
Line: 622-639

Comment:
**New env vars missing from configuration resource**

The `configuration_resource()` exposes a hardcoded list of env vars for documentation, but `FLI_MCP_COUNTRY`, `FLI_MCP_LANGUAGE`, and `FLI_MCP_CURRENCY` are not included. Users querying the resource via MCP will have no indication these locale parameters exist.

```suggestion
                "environment": {
                    "prefix": "FLI_MCP_",
                    "variables": {
                        "FLI_MCP_DEFAULT_PASSENGERS": "Adjust the default passenger count.",
                        "FLI_MCP_DEFAULT_CURRENCY": "Override the fallback currency code for results.",
                        "FLI_MCP_DEFAULT_CABIN_CLASS": "Set a default cabin class.",
                        "FLI_MCP_DEFAULT_SORT_BY": "Set the default result sorting strategy.",
                        "FLI_MCP_DEFAULT_DEPARTURE_WINDOW": "Provide a default departure window (HH-HH).",
                        "FLI_MCP_MAX_RESULTS": "Limit the maximum number of results returned by tools.",
                        "FLI_MCP_COUNTRY": "ISO country code for locale-based pricing (e.g., 'BE', 'US').",
                        "FLI_MCP_LANGUAGE": "Language code for locale-based pricing (e.g., 'nl', 'en').",
                        "FLI_MCP_CURRENCY": "Currency code for locale-based pricing (e.g., 'EUR', 'USD').",
                    },
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/search/flights.py
Line: 40-65

Comment:
**Duplicated `_build_url()` logic**

`_build_url()` in `SearchFlights` and `SearchDates` is byte-for-byte identical. Since both classes live in the same `fli/search/` package, this should be extracted into a shared module-level helper (e.g., in `client.py` or a new `fli/search/utils.py`) to avoid drift if the URL-building logic needs to change.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add locale support (gl, hl, curr) ..."](https://github.com/punitarani/fli/commit/40759edf226c223b05d4b31005494bfeb975b83c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28993106)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->