### PR TITLE
Fix crash on unknown airport/airline codes in flight results

### DIFF
--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -5,6 +5,7 @@ with Google Flights' API to find available flights and their details.
 """
 
 import json
+import logging
 from copy import deepcopy
 from datetime import datetime
 
@@ -80,7 +81,16 @@ class SearchFlights:
                 if isinstance(encoded_filters[i], list)
                 for item in encoded_filters[i][0]
             ]
-            flights = [self._parse_flights_data(flight) for flight in flights_data]
+            flights = []
+            for flight in flights_data:
+                try:
+                    flights.append(self._parse_flights_data(flight))
+                except (AttributeError, KeyError, ValueError) as e:
+                    logging.debug("Skipping flight with unparseable data: %s", e)
+                    continue
+
+            if not flights:
+                return None
 
             if filters.trip_type == TripType.ONE_WAY:
                 return flights


### PR DESCRIPTION
## Summary
- Flights routing through airports not in the `Airport` enum (e.g., `IMR`) cause `_parse_airport` to raise `AttributeError`, crashing the entire search
- This affects routes like OTP→YUL where connecting flights may route through smaller regional airports
- Fix: skip individual flights with unrecognized codes instead of crashing, so all other valid results are still returned

## Test plan
- [x] Verified `fli flights OTP YUL 2026-07-12` now returns 101 results (was crashing before)
- [x] Verified existing routes (e.g., `fli flights YUL CDG 2026-06-24`) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash caused by connecting airports or airlines missing from the `Airport`/`Airline` enums by wrapping per-flight parsing in a `try/except (AttributeError, KeyError, ValueError)` and skipping unrecognised entries. The approach is correct and targeted, but two minor issues are worth noting: dropped flights are silently discarded with no log output, and when every flight in a batch fails the method returns `[]` rather than `None`, diverging from the existing `return None` early-exit path at line 74.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix resolves a real crash with no functional regressions on covered routes; only minor observability and consistency concerns remain.

Only P2 findings (missing log on skip, None vs empty-list inconsistency). No security implications. Core happy path and round-trip recursive logic are unaffected.

fli/search/flights.py — specifically the empty-list vs None return value when all flights fail to parse.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/search/flights.py | Wraps `_parse_flights_data` in a per-flight try/except to skip flights with unrecognised airport or airline enum codes instead of crashing; no logging on skip and subtle None-vs-empty-list divergence from the existing early-return path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[flights_data list] --> B{For each flight}
    B --> C[_parse_flights_data]
    C -->|success| D[Append to flights list]
    C -->|AttributeError / KeyError / ValueError| E[Skip — continue]
    D --> B
    E --> B
    B -->|done| F{flights empty?}
    F -->|No| G[Return flights list]
    F -->|Yes| H[Return empty list
⚠️ diverges from None early-exit]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afli%2Fsearch%2Fflights.py%3A83-88%0A**Silent%20flight%20drops%20are%20invisible%20to%20callers**%0A%0AWhen%20a%20flight%20is%20skipped%20due%20to%20an%20unrecognised%20airport%20or%20airline%20code%2C%20no%20warning%20is%20emitted.%20A%20user%20who%20searches%20a%20route%20where%20every%20result%20routes%20through%20an%20unknown%20airport%20will%20receive%20an%20empty%20list%20with%20no%20indication%20that%20anything%20was%20dropped.%20Adding%20a%20%60logging.warning%60%20%28or%20at%20minimum%20a%20%60logging.debug%60%29%20call%20inside%20the%20%60except%60%20block%20would%20make%20it%20easy%20to%20diagnose%20unexpected%20drops%20without%20changing%20observable%20behaviour.%0A%0A%23%23%23%20Issue%202%20of%202%0Afli%2Fsearch%2Fflights.py%3A83-91%0A**Empty%20list%20returned%20instead%20of%20%60None%60%20when%20all%20flights%20fail**%0A%0AIf%20every%20entry%20in%20%60flights_data%60%20raises%20a%20parse%20error%2C%20%60flights%60%20ends%20up%20as%20%60%5B%5D%60.%20The%20existing%20%60return%20None%60%20path%20%28line%2074%29%20signals%20%22no%20results%20found%22%20to%20callers%2C%20but%20this%20new%20path%20returns%20%60%5B%5D%60%20instead.%20The%20recursive%20call%20at%20line%20110%20guards%20with%20%60if%20next_results%20is%20not%20None%3A%60%2C%20so%20an%20empty%20list%20passes%20that%20guard%20and%20produces%20an%20empty%20%60flight_combos%60%20%E2%80%94%20harmless%20here%2C%20but%20callers%20that%20distinguish%20%60None%60%20from%20%60%5B%5D%60%20%28e.g.%2C%20CLI%20output%20or%20future%20callers%29%20may%20behave%20differently%20for%20the%20two%20cases.%20Consider%20returning%20%60None%60%20%28or%20an%20empty%20list%20consistently%29%20when%20%60flights%60%20ends%20up%20empty%20after%20the%20loop.%0A%0A&pr=143&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afli%2Fsearch%2Fflights.py%3A83-88%0A**Silent%20flight%20drops%20are%20invisible%20to%20callers**%0A%0AWhen%20a%20flight%20is%20skipped%20due%20to%20an%20unrecognised%20airport%20or%20airline%20code%2C%20no%20warning%20is%20emitted.%20A%20user%20who%20searches%20a%20route%20where%20every%20result%20routes%20through%20an%20unknown%20airport%20will%20receive%20an%20empty%20list%20with%20no%20indication%20that%20anything%20was%20dropped.%20Adding%20a%20%60logging.warning%60%20%28or%20at%20minimum%20a%20%60logging.debug%60%29%20call%20inside%20the%20%60except%60%20block%20would%20make%20it%20easy%20to%20diagnose%20unexpected%20drops%20without%20changing%20observable%20behaviour.%0A%0A%23%23%23%20Issue%202%20of%202%0Afli%2Fsearch%2Fflights.py%3A83-91%0A**Empty%20list%20returned%20instead%20of%20%60None%60%20when%20all%20flights%20fail**%0A%0AIf%20every%20entry%20in%20%60flights_data%60%20raises%20a%20parse%20error%2C%20%60flights%60%20ends%20up%20as%20%60%5B%5D%60.%20The%20existing%20%60return%20None%60%20path%20%28line%2074%29%20signals%20%22no%20results%20found%22%20to%20callers%2C%20but%20this%20new%20path%20returns%20%60%5B%5D%60%20instead.%20The%20recursive%20call%20at%20line%20110%20guards%20with%20%60if%20next_results%20is%20not%20None%3A%60%2C%20so%20an%20empty%20list%20passes%20that%20guard%20and%20produces%20an%20empty%20%60flight_combos%60%20%E2%80%94%20harmless%20here%2C%20but%20callers%20that%20distinguish%20%60None%60%20from%20%60%5B%5D%60%20%28e.g.%2C%20CLI%20output%20or%20future%20callers%29%20may%20behave%20differently%20for%20the%20two%20cases.%20Consider%20returning%20%60None%60%20%28or%20an%20empty%20list%20consistently%29%20when%20%60flights%60%20ends%20up%20empty%20after%20the%20loop.%0A%0A&repo=punitarani%2Ffli&pr=143&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Fskip-unknown-airports%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fskip-unknown-airports%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afli%2Fsearch%2Fflights.py%3A83-88%0A**Silent%20flight%20drops%20are%20invisible%20to%20callers**%0A%0AWhen%20a%20flight%20is%20skipped%20due%20to%20an%20unrecognised%20airport%20or%20airline%20code%2C%20no%20warning%20is%20emitted.%20A%20user%20who%20searches%20a%20route%20where%20every%20result%20routes%20through%20an%20unknown%20airport%20will%20receive%20an%20empty%20list%20with%20no%20indication%20that%20anything%20was%20dropped.%20Adding%20a%20%60logging.warning%60%20%28or%20at%20minimum%20a%20%60logging.debug%60%29%20call%20inside%20the%20%60except%60%20block%20would%20make%20it%20easy%20to%20diagnose%20unexpected%20drops%20without%20changing%20observable%20behaviour.%0A%0A%23%23%23%20Issue%202%20of%202%0Afli%2Fsearch%2Fflights.py%3A83-91%0A**Empty%20list%20returned%20instead%20of%20%60None%60%20when%20all%20flights%20fail**%0A%0AIf%20every%20entry%20in%20%60flights_data%60%20raises%20a%20parse%20error%2C%20%60flights%60%20ends%20up%20as%20%60%5B%5D%60.%20The%20existing%20%60return%20None%60%20path%20%28line%2074%29%20signals%20%22no%20results%20found%22%20to%20callers%2C%20but%20this%20new%20path%20returns%20%60%5B%5D%60%20instead.%20The%20recursive%20call%20at%20line%20110%20guards%20with%20%60if%20next_results%20is%20not%20None%3A%60%2C%20so%20an%20empty%20list%20passes%20that%20guard%20and%20produces%20an%20empty%20%60flight_combos%60%20%E2%80%94%20harmless%20here%2C%20but%20callers%20that%20distinguish%20%60None%60%20from%20%60%5B%5D%60%20%28e.g.%2C%20CLI%20output%20or%20future%20callers%29%20may%20behave%20differently%20for%20the%20two%20cases.%20Consider%20returning%20%60None%60%20%28or%20an%20empty%20list%20consistently%29%20when%20%60flights%60%20ends%20up%20empty%20after%20the%20loop.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: fli/search/flights.py
Line: 83-88

Comment:
**Silent flight drops are invisible to callers**

When a flight is skipped due to an unrecognised airport or airline code, no warning is emitted. A user who searches a route where every result routes through an unknown airport will receive an empty list with no indication that anything was dropped. Adding a `logging.warning` (or at minimum a `logging.debug`) call inside the `except` block would make it easy to diagnose unexpected drops without changing observable behaviour.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: fli/search/flights.py
Line: 83-91

Comment:
**Empty list returned instead of `None` when all flights fail**

If every entry in `flights_data` raises a parse error, `flights` ends up as `[]`. The existing `return None` path (line 74) signals "no results found" to callers, but this new path returns `[]` instead. The recursive call at line 110 guards with `if next_results is not None:`, so an empty list passes that guard and produces an empty `flight_combos` — harmless here, but callers that distinguish `None` from `[]` (e.g., CLI output or future callers) may behave differently for the two cases. Consider returning `None` (or an empty list consistently) when `flights` ends up empty after the loop.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix crash on unknown airport/airline cod..."](https://github.com/punitarani/fli/commit/a1cafcef5ecefbef7660a9857b161cff3a5a264d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29723769)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->