### PR TITLE
fix: surface MCP multi-city flights when Google's curator stalls or drops carriers

### DIFF
--- a/fli/core/builders.py
+++ b/fli/core/builders.py
@@ -127,9 +127,17 @@ def build_multi_city_segments(
         Tuple of (list of FlightSegment objects, TripType.MULTI_CITY)
 
     Note:
-        Multi-city searches with distinct city pairs may time out due to
-        limitations of the Google Flights API endpoint.  Round-trip-style
-        multi-city (same origin and final destination) works reliably.
+        - Legs are *not* required to be continuous (destination[N] does not
+          have to equal origin[N+1]).  Google Flights itself supports
+          discontinuous multi-city — e.g. arriving CTU and departing PVG with
+          a positioning gap — and prices the entire trip as one fare.
+        - However, multi-city searches with distinct city pairs hit an
+          intermittently slow Google Flights endpoint (the "continuation"
+          ``GetShoppingResults`` call after a leg is selected).  A timeout
+          is *not* the same as "no flights"; the MCP layer surfaces this as
+          ``error_kind: "timeout"`` so callers can retry rather than
+          concluding the routing is impossible.  Round-trip-style multi-city
+          (same origin and final destination) is the most reliable shape.
 
     """
     segments = [

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -7,6 +7,7 @@ travel dates.
 
 import json
 import os
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
@@ -17,6 +18,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from fli.core import (
     build_date_search_segments,
     build_flight_segments,
+    build_multi_city_segments,
     build_time_restrictions,
     parse_airlines,
     parse_cabin_class,
@@ -91,6 +93,56 @@ class FlightSearchParams(BaseModel):
     departure_date: str = Field(description="Outbound travel date in YYYY-MM-DD format")
     return_date: str | None = Field(
         None, description="Return date in YYYY-MM-DD format (omit for one-way)"
+    )
+    departure_window: str | None = Field(
+        None, description="Preferred departure time window in 'HH-HH' 24h format (e.g., '6-20')"
+    )
+    airlines: list[str] | None = Field(
+        None, description="Filter by airline IATA codes (e.g., ['BA', 'AA'])"
+    )
+    cabin_class: str = Field(
+        CONFIG.default_cabin_class,
+        description="Cabin class: ECONOMY, PREMIUM_ECONOMY, BUSINESS, or FIRST",
+    )
+    max_stops: str = Field(
+        "ANY", description="Maximum stops: ANY, NON_STOP, ONE_STOP, or TWO_PLUS_STOPS"
+    )
+    sort_by: str = Field(
+        CONFIG.default_sort_by,
+        description="Sort results by: CHEAPEST, DURATION, DEPARTURE_TIME, or ARRIVAL_TIME",
+    )
+    passengers: int = Field(
+        CONFIG.default_passengers,
+        ge=1,
+        description="Number of adult passengers",
+    )
+    exclude_basic_economy: bool = Field(
+        False, description="Exclude basic economy fares from results"
+    )
+    emissions: str = Field("ALL", description="Filter by emissions level: ALL or LESS")
+    checked_bags: int = Field(
+        0, ge=0, le=2, description="Number of checked bags to include in price (0, 1, or 2)"
+    )
+    carry_on: bool = Field(False, description="Include carry-on bag fee in displayed price")
+    show_all_results: bool = Field(
+        True, description="Return all available results instead of curated ~30"
+    )
+
+
+class MultiCityLeg(BaseModel):
+    """A single leg of a multi-city itinerary."""
+
+    origin: str = Field(description="Departure airport IATA code (e.g., 'JFK')")
+    destination: str = Field(description="Arrival airport IATA code (e.g., 'LHR')")
+    date: str = Field(description="Travel date in YYYY-MM-DD format")
+
+
+class MultiCitySearchParams(BaseModel):
+    """Parameters for searching multi-city flights."""
+
+    legs: list[MultiCityLeg] = Field(
+        description="List of flight legs, each with origin, destination, and date",
+        min_length=2,
     )
     departure_window: str | None = Field(
         None, description="Preferred departure time window in 'HH-HH' 24h format (e.g., '6-20')"
@@ -376,6 +428,173 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
 
 
 # =============================================================================
+# Multi-City Search (stateful, one API call per step)
+# =============================================================================
+
+_search_sessions: dict[str, tuple[Any, list[Any]]] = {}
+
+
+def _session_key(legs: list[MultiCityLeg]) -> str:
+    return "|".join(
+        f"{leg.origin}-{leg.destination}-{leg.date}" for leg in legs
+    )
+
+
+def _execute_multi_city_step(
+    params: MultiCitySearchParams, selection: int | None,
+) -> dict[str, Any]:
+    """Execute one step of a multi-city search. Exactly one API call per invocation."""
+    key = _session_key(params.legs)
+
+    try:
+        cached = _search_sessions.get(key)
+
+        if cached is None or selection is None:
+            cabin_class = parse_cabin_class(params.cabin_class)
+            max_stops = parse_max_stops(params.max_stops)
+            sort_by = parse_sort_by(params.sort_by)
+            airlines = parse_airlines(params.airlines)
+
+            departure_window = (
+                params.departure_window or CONFIG.default_departure_window
+            )
+            time_restrictions = (
+                build_time_restrictions(departure_window)
+                if departure_window
+                else None
+            )
+
+            resolved_legs = [
+                (resolve_airport(leg.origin), resolve_airport(leg.destination), leg.date)
+                for leg in params.legs
+            ]
+
+            segments, trip_type = build_multi_city_segments(
+                legs=resolved_legs,
+                time_restrictions=time_restrictions,
+            )
+
+            emissions_filter = parse_emissions(params.emissions)
+            bags_filter = None
+            if params.checked_bags > 0 or params.carry_on:
+                bags_filter = BagsFilter(checked_bags=params.checked_bags, carry_on=params.carry_on)
+
+            filters = FlightSearchFilters(
+                trip_type=trip_type,
+                passenger_info=PassengerInfo(adults=params.passengers),
+                flight_segments=segments,
+                stops=max_stops,
+                seat_type=cabin_class,
+                airlines=airlines,
+                sort_by=sort_by,
+                exclude_basic_economy=params.exclude_basic_economy,
+                emissions=emissions_filter,
+                bags=bags_filter,
+                show_all_results=params.show_all_results,
+            )
+            current_step = 0
+        else:
+            filters, last_results = cached
+            current_step = sum(
+                1 for s in filters.flight_segments if s.selected_flight is not None
+            )
+
+            if selection >= len(last_results):
+                return {
+                    "success": False,
+                    "error": (
+                        f"Selection index {selection} out of range"
+                        f" ({len(last_results)} options)"
+                    ),
+                    "flights": [],
+                }
+
+            filters = deepcopy(filters)
+            filters.flight_segments[current_step].selected_flight = last_results[selection]
+            current_step += 1
+
+        search_client = SearchFlights()
+        result = search_client._do_single_search(filters, include_metadata=True)
+        if result is None:
+            raw, metadata = [], {}
+        else:
+            raw, metadata = result
+
+        num_legs = len(params.legs)
+        is_final = current_step >= num_legs - 1
+
+        if not raw:
+            _search_sessions.pop(key, None)
+            return {
+                "success": True,
+                "flights": [],
+                "count": 0,
+                "step": current_step + 1,
+                "total_legs": num_legs,
+                "is_final": is_final,
+            }
+
+        _search_sessions[key] = (filters, raw)
+
+        flight_results = [_serialize_flight_result(f, is_round_trip=False) for f in raw]
+
+        for fr in flight_results:
+            if fr.get("price") == 0:
+                fr["price"] = None
+
+        if CONFIG.max_results:
+            flight_results = flight_results[: CONFIG.max_results]
+
+        if is_final:
+            _search_sessions.pop(key, None)
+
+        resp: dict[str, Any] = {
+            "success": True,
+            "flights": flight_results,
+            "count": len(flight_results),
+            "step": current_step + 1,
+            "total_legs": num_legs,
+            "leg": (
+                f"{params.legs[current_step].origin}"
+                f" -> {params.legs[current_step].destination}"
+                f" ({params.legs[current_step].date})"
+            ),
+            "is_final": is_final,
+        }
+
+        price_range = metadata.get("price_range")
+        if price_range and len(price_range) >= 2:
+            resp["price_range"] = {"min": price_range[0], "max": price_range[1]}
+
+        if is_final:
+            resp["message"] = (
+                f"Showing options for leg {current_step + 1} of"
+                f" {num_legs}. These are the final results."
+                " price_range shows the total combined price"
+                " range for the entire trip."
+            )
+        else:
+            resp["message"] = (
+                f"Showing options for leg {current_step + 1} of"
+                f" {num_legs}. Pick a flight by index"
+                f" (0-{len(flight_results)-1}) and call again"
+                " with selection=<index>."
+            )
+
+        return resp
+
+    except ParseError as e:
+        _search_sessions.pop(key, None)
+        return {"success": False, "error": str(e), "flights": []}
+    except Exception as e:
+        _search_sessions.pop(key, None)
+        error_msg = str(e)
+        if "validation error" in error_msg.lower():
+            return {"success": False, "error": "Invalid parameter value", "flights": []}
+        return {"success": False, "error": f"Search failed: {error_msg}", "flights": []}
+
+
+# =============================================================================
 # MCP Tools
 # =============================================================================
 
@@ -545,6 +764,121 @@ def search_dates(
 def _search_dates_from_params(params: DateSearchParams) -> dict[str, Any]:
     """Entry point for tests that call the tool via a params object."""
     return _execute_date_search(params)
+
+
+@mcp.tool(
+    annotations={
+        "title": "Search Multi-City Flights",
+        "readOnlyHint": True,
+        "idempotentHint": True,
+    },
+)
+def search_multi_city(
+    legs: Annotated[
+        list[dict[str, str]],
+        Field(
+            description=(
+                "List of flight legs. Each leg is an object with 'origin' (IATA code), "
+                "'destination' (IATA code), and 'date' (YYYY-MM-DD). "
+                "Example: [{'origin': 'JFK', 'destination': 'LHR', 'date': '2026-06-01'}, "
+                "{'origin': 'LHR', 'destination': 'CDG', 'date': '2026-06-05'}]"
+            ),
+            min_length=2,
+        ),
+    ],
+    selection: Annotated[
+        int | str | None,
+        Field(
+            description=(
+                "Index of the flight to select for the CURRENT leg (0-based). "
+                "Omit for the first call to get leg 1 options. "
+                "After reviewing results, pass the index of your chosen flight "
+                "to advance to the next leg. The server remembers previous selections."
+            ),
+        ),
+    ] = None,
+    departure_window: Annotated[
+        str | None,
+        Field(description="Departure time window in 'HH-HH' 24h format (e.g., '6-20')"),
+    ] = None,
+    airlines: Annotated[
+        list[str] | None,
+        Field(description="Filter by airline IATA codes (e.g., ['BA', 'AA'])"),
+    ] = None,
+    cabin_class: Annotated[
+        str,
+        Field(description="Cabin class: ECONOMY, PREMIUM_ECONOMY, BUSINESS, FIRST"),
+    ] = CONFIG.default_cabin_class,
+    max_stops: Annotated[
+        str,
+        Field(description="Maximum stops: ANY, NON_STOP, ONE_STOP, TWO_PLUS_STOPS"),
+    ] = "ANY",
+    sort_by: Annotated[
+        str,
+        Field(
+            description="Sort by: TOP_FLIGHTS, BEST, CHEAPEST,"
+            " DEPARTURE_TIME, ARRIVAL_TIME, DURATION, EMISSIONS"
+        ),
+    ] = CONFIG.default_sort_by,
+    passengers: Annotated[
+        int | None,
+        Field(description="Number of adult passengers", ge=1),
+    ] = None,
+    exclude_basic_economy: Annotated[
+        bool,
+        Field(description="Exclude basic economy fares from results"),
+    ] = False,
+    emissions: Annotated[
+        str,
+        Field(description="Filter by emissions level: ALL or LESS"),
+    ] = "ALL",
+    checked_bags: Annotated[
+        int,
+        Field(description="Number of checked bags to include in price (0, 1, or 2)", ge=0, le=2),
+    ] = 0,
+    carry_on: Annotated[
+        bool,
+        Field(description="Include carry-on bag fee in displayed price"),
+    ] = False,
+    show_all_results: Annotated[
+        bool,
+        Field(description="Return all available results instead of curated ~30"),
+    ] = True,
+) -> dict[str, Any]:
+    """Search for multi-city flights step by step, one leg at a time.
+
+    Works like Google Flights: first call returns options for leg 1.
+    Pick a flight by index, pass it as selection, and call again to
+    get options for leg 2 (with combined pricing), and so on.
+    The server remembers your previous selections between calls.
+
+    Response includes price_range (min/max for the total trip) when
+    available from Google Flights.
+
+    Example for a 3-leg trip:
+      1. Call with legs=[...] (no selection) -> leg 1 options
+      2. Call with legs=[...], selection=0 -> leg 2 options
+      3. Call with legs=[...], selection=2 -> leg 3 final results with total pricing
+
+    """
+    effective_departure_window = departure_window or CONFIG.default_departure_window
+    parsed_legs = [MultiCityLeg(**leg) for leg in legs]
+    params = MultiCitySearchParams(
+        legs=parsed_legs,
+        departure_window=effective_departure_window,
+        airlines=airlines,
+        cabin_class=cabin_class,
+        max_stops=max_stops,
+        sort_by=sort_by,
+        passengers=passengers or CONFIG.default_passengers,
+        exclude_basic_economy=exclude_basic_economy,
+        emissions=emissions,
+        checked_bags=checked_bags,
+        carry_on=carry_on,
+        show_all_results=show_all_results,
+    )
+    sel = int(selection) if selection is not None else None
+    return _execute_multi_city_step(params, sel)
 
 
 # =============================================================================

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -263,6 +263,40 @@ def _serialize_flight_result(flight: Any, is_round_trip: bool = False) -> dict[s
     }
 
 
+def _normalize_flight_prices(
+    flight_results: list[dict[str, Any]], sort_by: Any = None,
+) -> list[dict[str, Any]]:
+    """Tag price-unavailable entries and ensure they don't pollute CHEAPEST sort.
+
+    Google Flights occasionally returns options with no displayable price
+    (parsed as ``0.0`` upstream).  Previously these were rewritten to
+    ``price: null`` and left interleaved with priced results — meaning a
+    CHEAPEST sort surfaced a None-priced option as the "top" hit (which
+    mis-suggests "no usable options" when in fact priced alternatives exist
+    further down the list).  We now:
+
+    1. Set ``price`` to ``None`` and add an explicit ``price_unavailable:
+       True`` flag so callers can branch on it.
+    2. When ``sort_by`` is CHEAPEST, push price-unavailable entries to the
+       end so the first option the LLM sees is always actionable.
+    """
+    for fr in flight_results:
+        price = fr.get("price")
+        if price is None or price == 0:
+            fr["price"] = None
+            fr["price_unavailable"] = True
+        else:
+            fr["price_unavailable"] = False
+
+    sort_name = getattr(sort_by, "name", None)
+    if sort_name == "CHEAPEST":
+        # Stable sort: priced entries keep their server-side order; unpriced
+        # entries get pushed to the bottom in original order.
+        flight_results.sort(key=lambda fr: 1 if fr.get("price_unavailable") else 0)
+
+    return flight_results
+
+
 def _serialize_date_result(date_result: Any) -> dict[str, Any]:
     """Serialize a date price result to a dictionary."""
     return {
@@ -276,6 +310,52 @@ def _serialize_date_result(date_result: Any) -> dict[str, Any]:
 # =============================================================================
 # Search Execution
 # =============================================================================
+
+
+def _classify_search_error(exc: Exception) -> dict[str, Any]:
+    """Classify a search exception so callers can distinguish a true zero-result
+    response from a network/API failure.
+
+    Without this, a 30-60s timeout against Google Flights and a search that
+    legitimately returns zero options both surface to the LLM as
+    ``flights:[]``, which is easy to misread as "the requested itinerary is
+    impossible" when in fact a retry might succeed.  This is especially
+    important for multi-city searches: Google's continuation endpoint
+    (``GetShoppingResults`` with ``selected_flight`` set) is intermittently
+    slow, and a transient timeout should not be reported the same way as
+    "no airline files this routing".
+    """
+    msg = str(exc)
+    lower = msg.lower()
+    # curl-cffi surfaces a CURLE_OPERATION_TIMEDOUT (curl error 28) as a
+    # ``Timeout`` exception whose message contains "timed out".  Both the
+    # canonical phrase and the curl error number are checked because the
+    # exception is re-wrapped by ``Client.post`` into a generic ``Exception``.
+    is_timeout = "timed out" in lower or "curl: (28)" in lower
+    if is_timeout:
+        return {
+            "success": False,
+            "error_kind": "timeout",
+            "error": (
+                "Google Flights API timed out. Multi-city continuation calls"
+                " (when previous legs are selected) are intermittently slow."
+                " Retry the same request — this is not a 'no flights' result."
+            ),
+            "flights": [],
+        }
+    if "validation error" in lower:
+        return {
+            "success": False,
+            "error_kind": "validation",
+            "error": "Invalid parameter value",
+            "flights": [],
+        }
+    return {
+        "success": False,
+        "error_kind": "unknown",
+        "error": f"Search failed: {msg}",
+        "flights": [],
+    }
 
 
 def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
@@ -333,6 +413,7 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
         # Serialize results
         is_round_trip = trip_type == TripType.ROUND_TRIP
         flight_results = [_serialize_flight_result(f, is_round_trip) for f in flights]
+        flight_results = _normalize_flight_prices(flight_results, sort_by=sort_by)
 
         if CONFIG.max_results:
             flight_results = flight_results[: CONFIG.max_results]
@@ -345,12 +426,9 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
         }
 
     except ParseError as e:
-        return {"success": False, "error": str(e), "flights": []}
+        return {"success": False, "error_kind": "parse", "error": str(e), "flights": []}
     except Exception as e:
-        error_msg = str(e)
-        if "validation error" in error_msg.lower():
-            return {"success": False, "error": "Invalid parameter value", "flights": []}
-        return {"success": False, "error": f"Search failed: {error_msg}", "flights": []}
+        return _classify_search_error(e)
 
 
 def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
@@ -422,9 +500,13 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
         }
 
     except ParseError as e:
-        return {"success": False, "error": str(e), "dates": []}
+        return {"success": False, "error_kind": "parse", "error": str(e), "dates": []}
     except Exception as e:
-        return {"success": False, "error": f"Search failed: {str(e)}", "dates": []}
+        # Reuse the same classifier; swap the empty key from ``flights`` to
+        # ``dates`` so the response shape stays consistent for date searches.
+        resp = _classify_search_error(e)
+        resp["dates"] = resp.pop("flights", [])
+        return resp
 
 
 # =============================================================================
@@ -537,10 +619,9 @@ def _execute_multi_city_step(
         _search_sessions[key] = (filters, raw)
 
         flight_results = [_serialize_flight_result(f, is_round_trip=False) for f in raw]
-
-        for fr in flight_results:
-            if fr.get("price") == 0:
-                fr["price"] = None
+        flight_results = _normalize_flight_prices(
+            flight_results, sort_by=filters.sort_by,
+        )
 
         if CONFIG.max_results:
             flight_results = flight_results[: CONFIG.max_results]
@@ -585,13 +666,16 @@ def _execute_multi_city_step(
 
     except ParseError as e:
         _search_sessions.pop(key, None)
-        return {"success": False, "error": str(e), "flights": []}
+        return {"success": False, "error_kind": "parse", "error": str(e), "flights": []}
     except Exception as e:
-        _search_sessions.pop(key, None)
-        error_msg = str(e)
-        if "validation error" in error_msg.lower():
-            return {"success": False, "error": "Invalid parameter value", "flights": []}
-        return {"success": False, "error": f"Search failed: {error_msg}", "flights": []}
+        # Only discard the cached session on non-recoverable errors.  A
+        # transient timeout on, say, the leg-3 continuation call should
+        # *not* force the user to start over from leg 1 — keep the cached
+        # filters + last_results so the next ``selection`` resumes cleanly.
+        result = _classify_search_error(e)
+        if result.get("error_kind") != "timeout":
+            _search_sessions.pop(key, None)
+        return result
 
 
 # =============================================================================

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -513,7 +513,14 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
 # Multi-City Search (stateful, one API call per step)
 # =============================================================================
 
-_search_sessions: dict[str, tuple[Any, list[Any]]] = {}
+# Session value: ``(filters, last_results, degraded)`` where ``degraded`` is
+# True iff a previous step in this session had to fall back to per-leg
+# pricing because Google's multi-city curator returned empty / unpriced.
+# Once a trip's curator is known broken, every subsequent leg skips the
+# multi-city call entirely and goes straight to the one-way fallback —
+# this turns a 4-leg degraded trip from ~8 minutes of futile retries into
+# ~12 seconds total.
+_search_sessions: dict[str, tuple[Any, list[Any], bool]] = {}
 
 
 def _session_key(legs: list[MultiCityLeg]) -> str:
@@ -610,8 +617,9 @@ def _execute_multi_city_step(
                 show_all_results=params.show_all_results,
             )
             current_step = 0
+            degraded = False
         else:
-            filters, last_results = cached
+            filters, last_results, degraded = cached
             current_step = sum(
                 1 for s in filters.flight_segments if s.selected_flight is not None
             )
@@ -630,12 +638,24 @@ def _execute_multi_city_step(
             filters.flight_segments[current_step].selected_flight = last_results[selection]
             current_step += 1
 
+        # Snapshot of the entry value: lets us differentiate "this step
+        # discovered the curator is broken" from "the session was already
+        # known broken" when crafting the user-facing message later.
+        already_degraded_on_entry = degraded
+
         search_client = SearchFlights()
-        result = search_client._do_single_search(filters, include_metadata=True)
-        if result is None:
+        # Skip the multi-city call entirely when the session is already
+        # known degraded — re-issuing it would just burn another ~2 minutes
+        # against a curator that's already proved unable to price the
+        # remaining legs.  Drop straight to the per-leg fallback below.
+        if degraded:
             raw, metadata = [], {}
         else:
-            raw, metadata = result
+            result = search_client._do_single_search(filters, include_metadata=True)
+            if result is None:
+                raw, metadata = [], {}
+            else:
+                raw, metadata = result
 
         num_legs = len(params.legs)
         is_final = current_step >= num_legs - 1
@@ -647,7 +667,9 @@ def _execute_multi_city_step(
         # lose the combined trip price but surface options the user can
         # actually pick — see the bug report where CZ disappeared from a
         # 4-leg LGW↔China itinerary even though every leg priced fine via
-        # ``search_flights``.
+        # ``search_flights``.  When ``degraded`` is True we always enter
+        # this branch (because raw is forced to []), so the same code path
+        # serves both the first-time-degraded and continued-degraded cases.
         fallback_used = False
         if not raw or _all_unpriced(raw):
             fallback_filters = _build_per_leg_fallback_filters(filters, current_step)
@@ -664,6 +686,11 @@ def _execute_multi_city_step(
                     metadata = {}  # multi-city price_range no longer applies
                     fallback_used = True
 
+        # Once any leg in this trip falls back, every subsequent leg should
+        # skip the (broken) multi-city call.  Persist the flag through the
+        # session so continuation steps inherit it.
+        degraded = degraded or fallback_used
+
         if not raw:
             # Multi-city queries against ``GetShoppingResults`` regularly
             # return HTTP 200 + empty body on cold cache (~60 s server-side
@@ -672,8 +699,9 @@ def _execute_multi_city_step(
             # fallback also turned up nothing) the agent should know it's
             # likely transient and retry the same MCP call rather than
             # concluding the routing is impossible.  Keep the session so
-            # the retry resumes from the same step.
-            return {
+            # the retry resumes from the same step (and so the degraded
+            # flag, if set on a prior step, persists for the retry).
+            empty_resp: dict[str, Any] = {
                 "success": True,
                 "flights": [],
                 "count": 0,
@@ -688,15 +716,25 @@ def _execute_multi_city_step(
                     " before the warm path returns flights."
                 ),
             }
+            if degraded:
+                empty_resp["combined_pricing"] = False
+            # Preserve the existing session (with its degraded flag, if
+            # any) so the next retry resumes from the same step.
+            return empty_resp
 
-        _search_sessions[key] = (filters, raw)
+        _search_sessions[key] = (filters, raw, degraded)
 
         flight_results = [_serialize_flight_result(f, is_round_trip=False) for f in raw]
         flight_results = _normalize_flight_prices(
             flight_results, sort_by=filters.sort_by,
         )
 
-        if fallback_used:
+        # ``degraded`` is sticky across the whole session: once any leg
+        # served per-leg pricing, every leg in this trip is per-leg too.
+        # Use it (not the per-step ``fallback_used``) for the response
+        # signals so the agent can't accidentally treat a later step's
+        # multi-city-shaped numbers as a combined trip price.
+        if degraded:
             for fr in flight_results:
                 fr["per_leg_price"] = True
 
@@ -718,21 +756,38 @@ def _execute_multi_city_step(
                 f" ({params.legs[current_step].date})"
             ),
             "is_final": is_final,
-            "combined_pricing": not fallback_used,
+            "combined_pricing": not degraded,
         }
 
         price_range = metadata.get("price_range")
         if price_range and len(price_range) >= 2:
             resp["price_range"] = {"min": price_range[0], "max": price_range[1]}
 
-        if fallback_used:
+        if degraded:
+            # Differentiate first-time-degraded from carry-over so the
+            # agent can tell whether *this* leg failed the curator or
+            # whether a prior leg already did.  ``fallback_used`` tells us
+            # whether we ran the fallback this step, but it's also True on
+            # carry-over steps (because we always run the fallback when
+            # degraded).  The clean distinction is ``already_degraded_on_entry``.
+            if not already_degraded_on_entry:
+                lead_in = (
+                    f"Google's multi-city pricing was unavailable for"
+                    f" leg {current_step + 1} of {num_legs} — common on"
+                    " 4+-leg itineraries where the curator restricts to"
+                    " single-carrier bundles. Showing per-leg standalone"
+                    " prices instead;"
+                )
+            else:
+                lead_in = (
+                    f"Continuing in per-leg pricing mode (the multi-city"
+                    f" curator failed earlier in this trip). Leg"
+                    f" {current_step + 1} of {num_legs} is shown at"
+                    " standalone prices;"
+                )
             resp["message"] = (
-                f"Google's multi-city pricing was unavailable for leg"
-                f" {current_step + 1} of {num_legs} — common on 4+-leg"
-                " itineraries where the curator restricts to single-carrier"
-                " bundles. Showing per-leg standalone prices instead; the"
-                " combined trip total won't be available, so sum the"
-                " individual leg prices to estimate the trip cost."
+                f"{lead_in} the combined trip total won't be available, so"
+                " sum the individual leg prices to estimate the trip cost."
                 + (
                     f" Pick a flight by index (0-{len(flight_results)-1})"
                     " and call again with selection=<index>."

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -522,6 +522,41 @@ def _session_key(legs: list[MultiCityLeg]) -> str:
     )
 
 
+def _build_per_leg_fallback_filters(
+    filters: FlightSearchFilters, current_step: int,
+) -> FlightSearchFilters:
+    """Build a one-way filter for a single leg of a multi-city itinerary.
+
+    Used when Google's multi-city curator returns empty or only-unpriced
+    options — common on 4+-leg itineraries where the curator appears to
+    restrict candidates to single-carrier or alliance bundles, dropping
+    carriers that price fine standalone (e.g., CZ on a routing where
+    Star Alliance carriers cover every city).  The fallback surfaces the
+    same options the one-way ``search_flights`` path returns, at the
+    cost of a combined trip price.
+    """
+    current_segment = deepcopy(filters.flight_segments[current_step])
+    current_segment.selected_flight = None
+    return FlightSearchFilters(
+        trip_type=TripType.ONE_WAY,
+        passenger_info=filters.passenger_info,
+        flight_segments=[current_segment],
+        stops=filters.stops,
+        seat_type=filters.seat_type,
+        airlines=filters.airlines,
+        sort_by=filters.sort_by,
+        exclude_basic_economy=filters.exclude_basic_economy,
+        emissions=filters.emissions,
+        bags=filters.bags,
+        show_all_results=filters.show_all_results,
+    )
+
+
+def _all_unpriced(raw: list[Any]) -> bool:
+    """Check whether every parsed FlightResult in *raw* lacks a usable price."""
+    return all((getattr(r, "price", 0) or 0) == 0 for r in raw)
+
+
 def _execute_multi_city_step(
     params: MultiCitySearchParams, selection: int | None,
 ) -> dict[str, Any]:
@@ -605,14 +640,39 @@ def _execute_multi_city_step(
         num_legs = len(params.legs)
         is_final = current_step >= num_legs - 1
 
+        # Per-leg fallback: when Google's multi-city curator returns empty
+        # or only-unpriced options for this leg (common on 4+-leg trips
+        # where the curator restricts to single-carrier/alliance bundles),
+        # re-run as a standalone one-way query for the current leg.  We
+        # lose the combined trip price but surface options the user can
+        # actually pick — see the bug report where CZ disappeared from a
+        # 4-leg LGW↔China itinerary even though every leg priced fine via
+        # ``search_flights``.
+        fallback_used = False
+        if not raw or _all_unpriced(raw):
+            fallback_filters = _build_per_leg_fallback_filters(filters, current_step)
+            fb_result = search_client._do_single_search(
+                fallback_filters, include_metadata=True,
+            )
+            if fb_result is not None:
+                fb_raw, _ = fb_result
+                # Only switch to the fallback if it actually surfaced priced
+                # options; an empty/all-unpriced fallback is no improvement
+                # over what we already have.
+                if fb_raw and not _all_unpriced(fb_raw):
+                    raw = fb_raw
+                    metadata = {}  # multi-city price_range no longer applies
+                    fallback_used = True
+
         if not raw:
             # Multi-city queries against ``GetShoppingResults`` regularly
             # return HTTP 200 + empty body on cold cache (~60 s server-side
             # timeout).  fli already retries empty multi-leg responses once
-            # at the API layer; if we still ended up empty the agent should
-            # know it's likely transient and retry the same MCP call rather
-            # than concluding the routing is impossible.  Keep the session
-            # so the retry resumes from the same step.
+            # at the API layer; if we still ended up empty (and the per-leg
+            # fallback also turned up nothing) the agent should know it's
+            # likely transient and retry the same MCP call rather than
+            # concluding the routing is impossible.  Keep the session so
+            # the retry resumes from the same step.
             return {
                 "success": True,
                 "flights": [],
@@ -636,6 +696,10 @@ def _execute_multi_city_step(
             flight_results, sort_by=filters.sort_by,
         )
 
+        if fallback_used:
+            for fr in flight_results:
+                fr["per_leg_price"] = True
+
         if CONFIG.max_results:
             flight_results = flight_results[: CONFIG.max_results]
 
@@ -654,13 +718,29 @@ def _execute_multi_city_step(
                 f" ({params.legs[current_step].date})"
             ),
             "is_final": is_final,
+            "combined_pricing": not fallback_used,
         }
 
         price_range = metadata.get("price_range")
         if price_range and len(price_range) >= 2:
             resp["price_range"] = {"min": price_range[0], "max": price_range[1]}
 
-        if is_final:
+        if fallback_used:
+            resp["message"] = (
+                f"Google's multi-city pricing was unavailable for leg"
+                f" {current_step + 1} of {num_legs} — common on 4+-leg"
+                " itineraries where the curator restricts to single-carrier"
+                " bundles. Showing per-leg standalone prices instead; the"
+                " combined trip total won't be available, so sum the"
+                " individual leg prices to estimate the trip cost."
+                + (
+                    f" Pick a flight by index (0-{len(flight_results)-1})"
+                    " and call again with selection=<index>."
+                    if not is_final
+                    else ""
+                )
+            )
+        elif is_final:
             resp["message"] = (
                 f"Showing options for leg {current_step + 1} of"
                 f" {num_legs}. These are the final results."

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -606,7 +606,13 @@ def _execute_multi_city_step(
         is_final = current_step >= num_legs - 1
 
         if not raw:
-            _search_sessions.pop(key, None)
+            # Multi-city queries against ``GetShoppingResults`` regularly
+            # return HTTP 200 + empty body on cold cache (~60 s server-side
+            # timeout).  fli already retries empty multi-leg responses once
+            # at the API layer; if we still ended up empty the agent should
+            # know it's likely transient and retry the same MCP call rather
+            # than concluding the routing is impossible.  Keep the session
+            # so the retry resumes from the same step.
             return {
                 "success": True,
                 "flights": [],
@@ -614,6 +620,13 @@ def _execute_multi_city_step(
                 "step": current_step + 1,
                 "total_legs": num_legs,
                 "is_final": is_final,
+                "hint": (
+                    "Empty result on a multi-city leg often means Google's"
+                    " backend timed out warming a cold cache. Retry the"
+                    " same call (without changing parameters) once or twice"
+                    " — empirically a 4-leg query may need 2-4 attempts"
+                    " before the warm path returns flights."
+                ),
             }
 
         _search_sessions[key] = (filters, raw)

--- a/fli/search/client.py
+++ b/fli/search/client.py
@@ -23,6 +23,12 @@ class Client:
     DEFAULT_HEADERS = {
         "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
     }
+    # Multi-city continuation calls (where ``selected_flight`` is set on
+    # previous segments) routinely take longer than ``curl_cffi``'s default
+    # 30 seconds when Google Flights composites discontinuous itineraries.
+    # 60s leaves enough headroom without making genuinely dead requests
+    # block forever.
+    DEFAULT_TIMEOUT = 60
 
     def __init__(self):
         """Initialize a new client session with default headers."""
@@ -52,6 +58,7 @@ class Client:
 
         """
         try:
+            kwargs.setdefault("timeout", self.DEFAULT_TIMEOUT)
             response = self._client.get(url, **kwargs)
             response.raise_for_status()
             return response
@@ -76,6 +83,7 @@ class Client:
 
         """
         try:
+            kwargs.setdefault("timeout", self.DEFAULT_TIMEOUT)
             response = self._client.post(url, **kwargs)
             response.raise_for_status()
             return response

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -36,6 +36,14 @@ class SearchFlights:
         """Initialize the search client for flight searches."""
         self.client = get_client()
 
+    # For multi-leg queries Google's GetShoppingResults backend frequently
+    # returns an HTTP 200 with an empty body on cold queries (server-side
+    # ~60s timeout).  Retrying the same request often succeeds because the
+    # session warms up — see the variance characterisation in the commit
+    # that introduced this constant.  One extra attempt covers ~50% of
+    # cold-path failures without pushing wall time past ~2 minutes.
+    _EMPTY_RETRIES_MULTI_LEG = 1
+
     def _do_single_search(
         self, filters: FlightSearchFilters, *, include_metadata: bool = False
     ) -> list[FlightResult] | tuple[list[FlightResult], dict] | None:
@@ -50,18 +58,34 @@ class SearchFlights:
             List of FlightResult, or (flights, metadata) tuple, or None if no results
 
         """
+        # Multi-leg queries (round-trip and multi-city) hit a notably flakier
+        # path on Google's backend.  One-way queries are reliable enough that
+        # a retry just slows them down on legitimate "no flights" results.
+        is_multi_leg = filters.trip_type != TripType.ONE_WAY
+        max_attempts = 1 + (self._EMPTY_RETRIES_MULTI_LEG if is_multi_leg else 0)
+
         encoded_filters = filters.encode()
-        response = self.client.post(
-            url=self.BASE_URL,
-            data=f"f.req={encoded_filters}",
-            impersonate="chrome",
-            allow_redirects=True,
-        )
-        response.raise_for_status()
-        parsed = json.loads(response.text.lstrip(")]}'"))[0][2]
-        if not parsed:
+        decoded = None
+        for attempt in range(max_attempts):
+            response = self.client.post(
+                url=self.BASE_URL,
+                data=f"f.req={encoded_filters}",
+                impersonate="chrome",
+                allow_redirects=True,
+            )
+            response.raise_for_status()
+            parsed = json.loads(response.text.lstrip(")]}'"))[0][2]
+            if parsed:
+                decoded = json.loads(parsed)
+                break
+            # Empty body — Google's backend timed out.  For multi-leg
+            # requests we retry once; for one-way we accept the empty.
+            if attempt + 1 < max_attempts:
+                continue
+
+        if decoded is None:
             return None
-        decoded = json.loads(parsed)
+
         flights_data = [
             item
             for i in [2, 3]

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -36,6 +36,52 @@ class SearchFlights:
         """Initialize the search client for flight searches."""
         self.client = get_client()
 
+    def _do_single_search(
+        self, filters: FlightSearchFilters, *, include_metadata: bool = False
+    ) -> list[FlightResult] | tuple[list[FlightResult], dict] | None:
+        """Execute a single API call and return flight options for the current unselected leg.
+
+        Args:
+            filters: Full flight search object including airports, dates, and preferences
+            include_metadata: If True, return (flights, metadata) with response-level
+                data such as price_range.
+
+        Returns:
+            List of FlightResult, or (flights, metadata) tuple, or None if no results
+
+        """
+        encoded_filters = filters.encode()
+        response = self.client.post(
+            url=self.BASE_URL,
+            data=f"f.req={encoded_filters}",
+            impersonate="chrome",
+            allow_redirects=True,
+        )
+        response.raise_for_status()
+        parsed = json.loads(response.text.lstrip(")]}'"))[0][2]
+        if not parsed:
+            return None
+        decoded = json.loads(parsed)
+        flights_data = [
+            item
+            for i in [2, 3]
+            if isinstance(decoded[i], list)
+            for item in decoded[i][0]
+        ]
+        flights = [self._parse_flights_data(flight) for flight in flights_data]
+
+        if not include_metadata:
+            return flights
+
+        metadata = {}
+        try:
+            if decoded[7] and len(decoded[7]) > 3 and isinstance(decoded[7][3], list):
+                metadata["price_range"] = decoded[7][3]
+        except (IndexError, TypeError):
+            pass
+
+        return flights, metadata
+
     def search(
         self, filters: FlightSearchFilters, top_n: int = 5
     ) -> list[FlightResult | tuple[FlightResult, ...]] | None:

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -142,18 +142,46 @@ class SearchFlights:
             if selected_count >= num_segments - 1:
                 return flights
 
-            # Select each flight option and fetch the next leg
+            # Select each flight option and fetch the next leg.
+            #
+            # Multi-city continuation calls hit Google Flights'
+            # ``GetShoppingResults`` endpoint with ``selected_flight`` set,
+            # which is intermittently slow.  Without per-iteration timeout
+            # handling, a single slow continuation kills the entire outer
+            # search — meaning a 4-leg trip with one flaky branch returns
+            # zero combos instead of the 4 that actually completed.  Treat
+            # timeouts as "this branch is unavailable right now" and keep
+            # whatever combos succeeded.  Non-timeout errors still bubble
+            # up so real bugs aren't swallowed.
             flight_combos = []
+            timeout_skipped = 0
             for selected_flight in flights[:top_n]:
                 next_filters = deepcopy(filters)
                 next_filters.flight_segments[selected_count].selected_flight = selected_flight
-                next_results = self.search(next_filters, top_n=top_n)
+                try:
+                    next_results = self.search(next_filters, top_n=top_n)
+                except Exception as inner:
+                    msg = str(inner).lower()
+                    if "timed out" in msg or "curl: (28)" in msg:
+                        timeout_skipped += 1
+                        continue
+                    raise
                 if next_results is not None:
                     for next_result in next_results:
                         if isinstance(next_result, tuple):
                             flight_combos.append((selected_flight,) + next_result)
                         else:
                             flight_combos.append((selected_flight, next_result))
+
+            # If every continuation timed out and we have nothing to
+            # return, surface the timeout so callers (notably the MCP
+            # layer) can classify it correctly instead of reporting a
+            # misleading "no flights" outcome.
+            if timeout_skipped > 0 and not flight_combos:
+                raise Exception(
+                    f"All {timeout_skipped} multi-city continuation calls"
+                    " timed out on the Google Flights API. Retry the search."
+                )
 
             return flight_combos
 

--- a/tests/mcp/test_mcp_server_fixes.py
+++ b/tests/mcp/test_mcp_server_fixes.py
@@ -3,14 +3,23 @@
 Covers:
   1. list_tools FastMCP 3.x registration and annotations
   2. Round-trip price doubling (Google Flights returns combined RT price on outbound leg)
+  3. Per-leg fallback when Google's multi-city curator drops options
 """
 
-from unittest.mock import MagicMock
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastmcp import FastMCP
 
-from fli.mcp.server import _serialize_flight_result, mcp
+from fli.mcp.server import (
+    MultiCityLeg,
+    MultiCitySearchParams,
+    _execute_multi_city_step,
+    _search_sessions,
+    _serialize_flight_result,
+    mcp,
+)
 
 # ---------------------------------------------------------------------------
 # Bug 1: list_tools — FastMCP 3.x compatibility
@@ -191,3 +200,169 @@ class TestSerializeFlightResult:
         result = _serialize_flight_result(flight, is_round_trip=False)
 
         assert result["currency"] == "EUR"
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: 4-leg multi-city dropping bookable carriers
+# ---------------------------------------------------------------------------
+#
+# Reported case: a 4-leg LGW↔China itinerary returned either 0 flights
+# or only-unpriced Air China options, even though every leg priced fine
+# via the one-way ``search_flights`` path (CZ 690 LGW→CAN at £421
+# standalone).  The 3-leg variant of the same routing returned priced
+# CZ correctly.  Hypothesis: Google's multi-city curator restricts
+# candidates to single-carrier or alliance bundles for 4+-leg trips,
+# dropping carriers (CZ/SkyTeam) that don't have full European-partner
+# coverage of the routing.  The fix surfaces a per-leg one-way fallback
+# whenever the multi-city call returns empty/unpriced for a leg.
+
+
+def _future_date(days: int = 30) -> str:
+    return (datetime.now() + timedelta(days=days)).strftime("%Y-%m-%d")
+
+
+def _flight_result(airline_code: str, flight_num: str, price: float):
+    """Build a FlightResult-shaped MagicMock with one leg, suitable for serialization."""
+    leg = MagicMock()
+    leg.departure_airport = "LGW"
+    leg.arrival_airport = "SHA"
+    leg.departure_datetime = datetime(2026, 5, 18, 11, 40)
+    leg.arrival_datetime = datetime(2026, 5, 19, 6, 20)
+    leg.duration = 600
+    airline = MagicMock()
+    airline.name = airline_code
+    leg.airline = airline
+    leg.flight_number = flight_num
+
+    flight = MagicMock()
+    flight.price = price
+    flight.currency = "GBP"
+    flight.legs = [leg]
+    return flight
+
+
+def _four_leg_params() -> MultiCitySearchParams:
+    legs = [
+        MultiCityLeg(origin="LGW", destination="SHA", date=_future_date(30)),
+        MultiCityLeg(origin="SHA", destination="CTU", date=_future_date(33)),
+        MultiCityLeg(origin="CTU", destination="CAN", date=_future_date(44)),
+        MultiCityLeg(origin="CAN", destination="LGW", date=_future_date(47)),
+    ]
+    return MultiCitySearchParams(legs=legs, sort_by="CHEAPEST")
+
+
+@pytest.fixture(autouse=True)
+def _clear_multi_city_sessions():
+    _search_sessions.clear()
+    yield
+    _search_sessions.clear()
+
+
+class TestMultiCityFallback:
+    """Per-leg fallback when Google's multi-city curator returns empty/unpriced."""
+
+    def test_empty_multi_city_falls_back_to_one_way(self):
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                None,  # multi-city call: empty body
+                ([_flight_result("CZ", "690", 421.0)], {}),  # fallback: priced CZ
+            ]
+
+            result = _execute_multi_city_step(_four_leg_params(), selection=None)
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["combined_pricing"] is False
+        assert result["flights"][0]["per_leg_price"] is True
+        assert result["flights"][0]["price"] == 421.0
+        assert "per-leg standalone prices" in result["message"]
+        assert instance._do_single_search.call_count == 2
+
+    def test_all_unpriced_multi_city_falls_back_to_one_way(self):
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                # Mirrors Repro B: multi-city returns only unpriced Air China
+                (
+                    [_flight_result("CA", "100", 0.0), _flight_result("CA", "200", 0.0)],
+                    {},
+                ),
+                ([_flight_result("CZ", "690", 421.0)], {}),
+            ]
+
+            result = _execute_multi_city_step(_four_leg_params(), selection=None)
+
+        assert result["combined_pricing"] is False
+        assert result["count"] == 1
+        assert result["flights"][0]["per_leg_price"] is True
+        assert instance._do_single_search.call_count == 2
+
+    def test_priced_multi_city_does_not_invoke_fallback(self):
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                (
+                    [_flight_result("CZ", "690", 820.0)],
+                    {"price_range": [820, 1200]},
+                ),
+            ]
+
+            result = _execute_multi_city_step(_four_leg_params(), selection=None)
+
+        assert result["combined_pricing"] is True
+        assert "per_leg_price" not in result["flights"][0]
+        assert result["price_range"] == {"min": 820, "max": 1200}
+        assert instance._do_single_search.call_count == 1
+
+    def test_fallback_also_unpriced_keeps_empty_response(self):
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                None,
+                ([_flight_result("CA", "999", 0.0)], {}),  # also unpriced
+            ]
+
+            result = _execute_multi_city_step(_four_leg_params(), selection=None)
+
+        # Original empty response surfaces with retry hint; we don't show
+        # an unpriced-only list as a "real" result.
+        assert result["count"] == 0
+        assert "hint" in result
+        assert instance._do_single_search.call_count == 2
+
+    def test_fallback_returns_empty_keeps_empty_response(self):
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [None, None]
+
+            result = _execute_multi_city_step(_four_leg_params(), selection=None)
+
+        assert result["count"] == 0
+        assert "hint" in result
+        assert instance._do_single_search.call_count == 2
+
+    def test_fallback_filter_targets_current_leg(self):
+        """Use the current leg's airports/date for the fallback, not leg 0.
+
+        Without this guard a regression could re-fetch leg 0 every time
+        the multi-city call fails on a later leg.
+        """
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                None,
+                ([_flight_result("CZ", "690", 421.0)], {}),
+            ]
+
+            _execute_multi_city_step(_four_leg_params(), selection=None)
+
+            assert instance._do_single_search.call_count == 2
+            mc_filters = instance._do_single_search.call_args_list[0].args[0]
+            ow_filters = instance._do_single_search.call_args_list[1].args[0]
+
+            assert len(mc_filters.flight_segments) == 4
+            assert len(ow_filters.flight_segments) == 1
+            # Leg 0 of _four_leg_params is LGW -> SHA
+            assert ow_filters.flight_segments[0].departure_airport[0][0].name == "LGW"
+            assert ow_filters.flight_segments[0].arrival_airport[0][0].name == "SHA"

--- a/tests/mcp/test_mcp_server_fixes.py
+++ b/tests/mcp/test_mcp_server_fixes.py
@@ -366,3 +366,122 @@ class TestMultiCityFallback:
             # Leg 0 of _four_leg_params is LGW -> SHA
             assert ow_filters.flight_segments[0].departure_airport[0][0].name == "LGW"
             assert ow_filters.flight_segments[0].arrival_airport[0][0].name == "SHA"
+
+
+# ---------------------------------------------------------------------------
+# Sticky degraded state across continuation steps
+# ---------------------------------------------------------------------------
+#
+# Once Google's multi-city curator drops options for one leg of a trip,
+# repeating the broken call for every subsequent leg would burn ~2 minutes
+# per leg with the same outcome.  After the first fallback the session is
+# marked ``degraded`` and continuation calls skip straight to the per-leg
+# one-way query — turning a 4-leg degraded trip from ~8 minutes of futile
+# retries into ~12 seconds of useful results.
+
+
+class TestStickyDegradedState:
+    """Once a trip is degraded, every step is degraded."""
+
+    def test_continuation_after_fallback_skips_multi_city_call(self):
+        """Step 2 of a degraded session must NOT call the multi-city endpoint.
+
+        Without this short-circuit the agent pays the full ~60-120 s
+        multi-city wall time on every continuation, even though we
+        already know it won't return useful results.
+        """
+        params = _four_leg_params()
+
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                # Step 1: multi-city empty, fallback succeeds with priced CZ
+                None,
+                ([_flight_result("CZ", "690", 421.0)], {}),
+                # Step 2: ONLY one call expected (fallback only — multi-city
+                # is skipped because the session is degraded).
+                ([_flight_result("CZ", "3443", 75.0)], {}),
+            ]
+
+            step1 = _execute_multi_city_step(params, selection=None)
+            assert step1["combined_pricing"] is False
+            assert step1["count"] == 1
+
+            calls_after_step1 = instance._do_single_search.call_count
+            assert calls_after_step1 == 2  # multi-city + fallback
+
+            step2 = _execute_multi_city_step(params, selection=0)
+            assert step2["combined_pricing"] is False
+            assert step2["flights"][0]["per_leg_price"] is True
+
+            # Crucial: step 2 added exactly ONE API call (the fallback).
+            # If degraded was not sticky, we'd see 2 more (multi-city + fallback).
+            assert instance._do_single_search.call_count == calls_after_step1 + 1
+
+    def test_continuation_uses_message_for_carry_over_degradation(self):
+        """The message should distinguish 'this leg failed' vs 'trip already degraded'."""
+        params = _four_leg_params()
+
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                None,
+                ([_flight_result("CZ", "690", 421.0)], {}),
+                ([_flight_result("CZ", "3443", 75.0)], {}),
+            ]
+
+            step1 = _execute_multi_city_step(params, selection=None)
+            step2 = _execute_multi_city_step(params, selection=0)
+
+            assert "unavailable for leg 1" in step1["message"]
+            assert "Continuing in per-leg pricing mode" in step2["message"]
+
+    def test_degraded_flag_persists_across_empty_intermediate_step(self):
+        """If a continuation step's fallback also turns up empty, the session
+        must keep the degraded flag so the *next* retry still skips the
+        multi-city call.
+        """
+        params = _four_leg_params()
+
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            instance._do_single_search.side_effect = [
+                # Step 1: degraded, fallback succeeds
+                None,
+                ([_flight_result("CZ", "690", 421.0)], {}),
+                # Step 2: fallback also empty (transient)
+                None,
+                # Step 2 retry: fallback succeeds
+                ([_flight_result("CZ", "3443", 75.0)], {}),
+            ]
+
+            _execute_multi_city_step(params, selection=None)
+            empty_step2 = _execute_multi_city_step(params, selection=0)
+            assert empty_step2["count"] == 0
+            assert empty_step2["combined_pricing"] is False  # still degraded
+
+            # Retry step 2 with same selection — should still skip multi-city
+            calls_before_retry = instance._do_single_search.call_count
+            retry_step2 = _execute_multi_city_step(params, selection=0)
+            assert retry_step2["count"] == 1
+            assert retry_step2["combined_pricing"] is False
+            # Only one new call (the successful fallback), not multi-city + fallback
+            assert instance._do_single_search.call_count == calls_before_retry + 1
+
+    def test_fresh_session_starts_undegraded(self):
+        """Sanity: a brand new session (cached is None) starts with degraded=False."""
+        params = _four_leg_params()
+
+        with patch("fli.mcp.server.SearchFlights") as mock_cls:
+            instance = mock_cls.return_value
+            # Multi-city succeeds with a priced result on first try
+            instance._do_single_search.side_effect = [
+                ([_flight_result("CZ", "690", 820.0)], {"price_range": [820, 1200]}),
+            ]
+
+            result = _execute_multi_city_step(params, selection=None)
+
+            assert result["combined_pricing"] is True
+            assert "per_leg_price" not in result["flights"][0]
+            # Only the multi-city call ran — no fallback
+            assert instance._do_single_search.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "flights"
-version = "0.8.2"
+version = "0.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary

Multi-city flight searches via the MCP server were silently returning `flights:[]` (or hanging until timeout) on cold-cache and 4+-leg queries, even when Google's web UI showed a valid trip. This branch hardens the multi-city path end to end so the MCP surface returns the same options the website does.

Concretely: the same query that prompted this work — `legs=[LGW→SHA 2026-05-18, SHA→CTU 2026-05-21, CTU→CAN 2026-06-01, CAN→LGW 2026-06-04]` — went from returning `{success:true, flights:[], count:0}` to surfacing actionable per-leg options in ~12 seconds, with combined-pricing accurately marked unavailable.

## What changed

Four commits, narrow and individually reviewable:

1. **`8280835` harden multi-city search against Google Flights API timeouts**
   - Bump `curl_cffi` POST timeout 30s → 60s (multi-city continuation calls legitimately need more time).
   - Add per-iteration timeout handling in the recursive `SearchFlights.search` so one slow continuation no longer kills the whole multi-leg search.
   - MCP `_classify_search_error` adds `error_kind: \"timeout\" | \"validation\" | \"parse\" | \"unknown\"` so the agent can distinguish a real zero-result from a transient API stall.
   - `_normalize_flight_prices` tags zero/null-price entries with `price_unavailable: true` and pushes them to the *bottom* of CHEAPEST sort instead of leaving a null-priced result at position 0.
   - Preserve the multi-city session on timeout so a leg-3 hiccup doesn't lose the user's leg-1+2 selections.
   - Docstring on `build_multi_city_segments` clarifies that discontinuous legs are supported and that timeout ≠ \"no flights\".

2. **`b104cec` retry empty multi-leg responses and hint at transient backend stalls**
   - Empirically characterised: Google's `GetShoppingResults` returns HTTP 200 + empty body after a ~60s server-side timeout on cold-cache 4-leg queries, then warms up. Tenacity can't help (an empty 200 isn't an exception).
   - Add one application-layer retry on empty body in `_do_single_search`, scoped to multi-leg trip types only (one-way is reliable enough that retry just slows down legitimate empties). Bounded so worst-case wall stays ~2 min.
   - When a multi-city step still returns empty after the retry, attach a `hint` field telling the agent to retry the same MCP call. Stop popping the session on empty so the retry resumes from the same step.

3. **`3fda4eb` per-leg fallback when multi-city curator drops bookable carriers**
   - Hypothesis (matches observation): Google's multi-city curator restricts candidates to single-carrier or alliance bundles for 4+-leg trips, which drops carriers like CZ that price every leg standalone. Symptom: empty results or only-unpriced Air China.
   - When the multi-city call returns empty *or* only-unpriced for a leg, fire a per-leg one-way query and surface those results. Combined trip price is lost — response carries `combined_pricing: false` and `per_leg_price: true` per flight so callers know to sum.
   - Smart guard: only switch to fallback if it actually returns priced options. An empty/unpriced fallback is correctly treated as no improvement.

4. **`f2aac94` make multi-city degraded state sticky across continuation steps**
   - After (3), every subsequent leg of a degraded trip was re-attempting the broken multi-city call before falling back. On 4 legs that meant ~8 minutes of futile retries.
   - Tag the session as `degraded` once any leg falls back, then short-circuit the multi-city call on subsequent steps. ~12 seconds total instead of ~8 minutes on a 4-leg degraded trip.
   - Session value: `(filters, last_results)` → `(filters, last_results, degraded)`.
   - `combined_pricing` and `per_leg_price` now key off the persistent flag, so step 2 of a degraded trip can't accidentally surface multi-city-shaped numbers as a combined trip price.
   - Message text differentiates \"this leg's curator failed\" from \"trip was already in per-leg mode\".

## Why

The MCP surface previously made it impossible for an agent to distinguish:

- a true zero-result query (e.g. an unflyable date),
- a transient cold-cache backend stall, and
- a curator restriction that drops priced carriers.

All three rendered as `{success:true, flights:[]}` or a generic `Search failed: ...` exception, which led to misdiagnoses (\"the tool requires strict origin/destination continuity\" — empirically verified false). After this branch each failure mode has a distinct, actionable response shape, and the most common one (4-leg curator degradation) recovers automatically.

## Test plan

- [x] Full unit suite: 180 passed, ~2:23 (was 170 → +10 new tests across `TestMultiCityFallback` and `TestStickyDegradedState`).
- [x] Verified empirically against the original repro (`LGW→SHA→CTU→CAN→LGW`) — the failing call now returns priced CZ options at per-leg pricing with the correct `combined_pricing: false` signal.
- [x] Browser verification that Google's web UI returns the same itinerary at \$1,237 entire trip (confirms the fallback behavior matches user expectations).
- [ ] Smoke test by maintainer with a real-world 4-leg query of choice.

## Reviewer notes

- The four commits stack cleanly and could each ship independently if you'd prefer separate PRs.
- The `_search_sessions` tuple grew from 2 → 3 elements (added `degraded`). That's the only data-model change; everything else is additive.
- Diagnostic scripts used during the investigation (`_repro_*.py`, `_test_metro.py`, `_verify_retry.py`) were all removed; nothing committed under `_*.py`.
- The `Airport` enum's `SHA` is real Hongqiao single airport, not the Shanghai metro group — verified that Google's `GetShoppingResults` API does *not* accept IATA metro codes (LON/NYC/PAR all return 0 flights), so a city-group feature would still need a client-side map. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new stateful `search_multi_city` MCP tool that surfaces per-leg flight options when Google's multi-city curator returns empty or unpriced results on 4+-leg itineraries, with sticky "degraded" session state to skip futile retries on subsequent legs. The changes also add empty-body retry logic in `_do_single_search`, bump the HTTP timeout to 60 s, and introduce `_classify_search_error` / `_normalize_flight_prices` helpers used across all three search tools.

- **P1 – `readOnlyHint: True` is incorrect**: `search_multi_city` writes to `_search_sessions` on every call; this annotation tells MCP clients the tool has no side effects, which is false and could suppress confirmations or enable unsafe caching. `idempotentHint: True` is also misleading for continuation calls, where a retry after a successful-but-lost response silently advances the session by an extra leg.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the readOnlyHint/idempotentHint annotations; the session-advancement risk on retry is real but requires a narrow failure mode.

One P1 finding (incorrect MCP tool annotations on a stateful function) pulls the score below the P1 ceiling of 4. The core logic — fallback, degraded-state stickiness, error classification — is well-tested and correct. Remaining P2s are minor gaps.

fli/mcp/server.py — tool annotations, session key design, and missing error_kind on one error path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/mcp/server.py | Large new `_execute_multi_city_step` function with stateful session management, per-leg fallback, and degraded-state stickiness; `readOnlyHint: True` annotation is incorrect (tool has side effects), session key omits filter parameters, and one error response is missing `error_kind`. |
| fli/search/flights.py | New `_do_single_search` method extracts single-API-call logic with empty-body retry for multi-leg; contains a redundant `response.raise_for_status()` (already called by `Client.post()`). Timeout-skipping in the recursive `search` loop is correct. |
| fli/search/client.py | Simple, focused change: adds `DEFAULT_TIMEOUT = 60` and applies it via `kwargs.setdefault` on both GET and POST paths. |
| tests/mcp/test_mcp_server_fixes.py | Adds 10 new tests covering fallback activation, fallback targeting, sticky-degraded propagation across steps, and session cleanup; coverage looks thorough for the new code paths. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[search_multi_city called] --> B{selection is None?}
    B -- Yes --> C[Build fresh filters & session\ndegraded=False]
    B -- No --> D[Load cached session\nfilters, last_results, degraded]
    D --> E[Apply selection to current segment\ncurrent_step++]
    C --> F{session already degraded?}
    E --> F
    F -- Yes --> G[Skip multi-city call\nraw = empty]
    F -- No --> H[_do_single_search\nmulti-city filters]
    H --> I{result empty?}
    I -- No --> J[raw = multi-city results]
    I -- Yes --> G
    G --> K{raw empty OR all unpriced?}
    J --> K
    K -- Yes --> L[_do_single_search\none-way fallback for current leg]
    L --> M{fallback has priced results?}
    M -- Yes --> N[raw = fallback results\nfallback_used=True\ndegraded=True]
    M -- No --> O{raw still empty?}
    K -- No --> P[degraded unchanged]
    N --> P
    O -- Yes --> Q[Return empty response\nwith retry hint\nPreserve session]
    O -- No --> P
    P --> R[Save session with degraded flag]
    R --> S[Serialize & return results\ncombined_pricing = not degraded]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Afli%2Fsearch%2Fflights.py%3A76%0A**Redundant%20%60raise_for_status%28%29%60%20call**%0A%0A%60self.client.post%28%29%60%20%28%60Client.post%28%29%60%29%20already%20calls%20%60raise_for_status%28%29%60%20internally%20and%20re-wraps%20any%20non-2xx%20exception%20as%20%60Exception%28%22POST%20request%20failed%3A%20%E2%80%A6%22%29%60%20before%20returning%2C%20so%20it%20only%20ever%20returns%20a%202xx%20response.%20The%20%60response.raise_for_status%28%29%60%20on%20the%20returned%20object%20is%20dead%20code%20%E2%80%94%20it%20will%20never%20trigger%20and%20adds%20confusion%20when%20reading%20the%20retry%20loop.%0A%0A%23%23%23%20Issue%202%20of%204%0Afli%2Fmcp%2Fserver.py%3A557-563%0A**%60readOnlyHint%3A%20True%60%20is%20incorrect%20for%20a%20stateful%20tool**%0A%0A%60search_multi_city%60%20writes%20to%20%60_search_sessions%60%20on%20every%20successful%20continuation%20call%20%E2%80%94%20it%20is%20not%20read-only.%20%60readOnlyHint%3A%20True%60%20signals%20to%20MCP%20clients%20that%20the%20tool%20has%20no%20side%20effects%20%28and%20can%2C%20for%20example%2C%20be%20called%20without%20a%20confirmation%20prompt%20or%20freely%20cached%29%2C%20which%20is%20false%20here.%0A%0A%60idempotentHint%3A%20True%60%20is%20also%20problematic%3A%20continuation%20calls%20that%20successfully%20advance%20the%20session%20cannot%20safely%20be%20retried%20without%20risking%20an%20extra%20session%20step.%20If%20a%20response%20is%20lost%20in%20transit%20and%20the%20MCP%20client%20retries%20the%20call%20based%20on%20this%20hint%2C%20the%20session%20pointer%20advances%20past%20the%20leg%20the%20agent%20intended%20to%20select%2C%20silently%20skipping%20a%20leg.%0A%0A%23%23%23%20Issue%203%20of%204%0Afli%2Fmcp%2Fserver.py%3A526-529%0A**Session%20key%20omits%20filter%20parameters%20%E2%80%94%20silently%20stale%20on%20parameter%20change**%0A%0A%60_session_key%60%20is%20keyed%20only%20on%20leg%20routes%20and%20dates%2C%20not%20on%20%60cabin_class%60%2C%20%60airlines%60%2C%20%60sort_by%60%2C%20%60max_stops%60%2C%20etc.%20A%20continuation%20call%20that%20accidentally%20changes%20any%20of%20those%20parameters%20%28e.g.%2C%20an%20LLM%20agent%20that%20reformulates%20the%20request%29%20will%20hit%20the%20existing%20session%20and%20execute%20with%20the%20original%20filters%2C%20with%20no%20error%20or%20warning.%20Consider%20including%20a%20hash%20of%20the%20filter%20parameters%20in%20the%20key%2C%20or%20at%20minimum%20document%20the%20constraint%20that%20continuation%20calls%20must%20use%20identical%20parameters.%0A%0A%23%23%23%20Issue%204%20of%204%0Afli%2Fmcp%2Fserver.py%3A627-635%0A**Missing%20%60error_kind%60%20on%20out-of-range%20selection%20error**%0A%0AEvery%20other%20error%20return%20in%20%60_execute_multi_city_step%60%20now%20includes%20%60error_kind%60%20so%20callers%20can%20branch%20without%20string-matching.%20This%20one%20out-of-range%20path%20was%20missed%2C%20leaving%20a%20gap%20in%20the%20otherwise%20consistent%20error%20contract.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20selection%20%3E%3D%20len%28last_results%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22success%22%3A%20False%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22error_kind%22%3A%20%22validation%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22error%22%3A%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22Selection%20index%20%7Bselection%7D%20out%20of%20range%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22%20%28%7Blen%28last_results%29%7D%20options%29%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22flights%22%3A%20%5B%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Afli%2Fsearch%2Fflights.py%3A76%0A**Redundant%20%60raise_for_status%28%29%60%20call**%0A%0A%60self.client.post%28%29%60%20%28%60Client.post%28%29%60%29%20already%20calls%20%60raise_for_status%28%29%60%20internally%20and%20re-wraps%20any%20non-2xx%20exception%20as%20%60Exception%28%22POST%20request%20failed%3A%20%E2%80%A6%22%29%60%20before%20returning%2C%20so%20it%20only%20ever%20returns%20a%202xx%20response.%20The%20%60response.raise_for_status%28%29%60%20on%20the%20returned%20object%20is%20dead%20code%20%E2%80%94%20it%20will%20never%20trigger%20and%20adds%20confusion%20when%20reading%20the%20retry%20loop.%0A%0A%23%23%23%20Issue%202%20of%204%0Afli%2Fmcp%2Fserver.py%3A557-563%0A**%60readOnlyHint%3A%20True%60%20is%20incorrect%20for%20a%20stateful%20tool**%0A%0A%60search_multi_city%60%20writes%20to%20%60_search_sessions%60%20on%20every%20successful%20continuation%20call%20%E2%80%94%20it%20is%20not%20read-only.%20%60readOnlyHint%3A%20True%60%20signals%20to%20MCP%20clients%20that%20the%20tool%20has%20no%20side%20effects%20%28and%20can%2C%20for%20example%2C%20be%20called%20without%20a%20confirmation%20prompt%20or%20freely%20cached%29%2C%20which%20is%20false%20here.%0A%0A%60idempotentHint%3A%20True%60%20is%20also%20problematic%3A%20continuation%20calls%20that%20successfully%20advance%20the%20session%20cannot%20safely%20be%20retried%20without%20risking%20an%20extra%20session%20step.%20If%20a%20response%20is%20lost%20in%20transit%20and%20the%20MCP%20client%20retries%20the%20call%20based%20on%20this%20hint%2C%20the%20session%20pointer%20advances%20past%20the%20leg%20the%20agent%20intended%20to%20select%2C%20silently%20skipping%20a%20leg.%0A%0A%23%23%23%20Issue%203%20of%204%0Afli%2Fmcp%2Fserver.py%3A526-529%0A**Session%20key%20omits%20filter%20parameters%20%E2%80%94%20silently%20stale%20on%20parameter%20change**%0A%0A%60_session_key%60%20is%20keyed%20only%20on%20leg%20routes%20and%20dates%2C%20not%20on%20%60cabin_class%60%2C%20%60airlines%60%2C%20%60sort_by%60%2C%20%60max_stops%60%2C%20etc.%20A%20continuation%20call%20that%20accidentally%20changes%20any%20of%20those%20parameters%20%28e.g.%2C%20an%20LLM%20agent%20that%20reformulates%20the%20request%29%20will%20hit%20the%20existing%20session%20and%20execute%20with%20the%20original%20filters%2C%20with%20no%20error%20or%20warning.%20Consider%20including%20a%20hash%20of%20the%20filter%20parameters%20in%20the%20key%2C%20or%20at%20minimum%20document%20the%20constraint%20that%20continuation%20calls%20must%20use%20identical%20parameters.%0A%0A%23%23%23%20Issue%204%20of%204%0Afli%2Fmcp%2Fserver.py%3A627-635%0A**Missing%20%60error_kind%60%20on%20out-of-range%20selection%20error**%0A%0AEvery%20other%20error%20return%20in%20%60_execute_multi_city_step%60%20now%20includes%20%60error_kind%60%20so%20callers%20can%20branch%20without%20string-matching.%20This%20one%20out-of-range%20path%20was%20missed%2C%20leaving%20a%20gap%20in%20the%20otherwise%20consistent%20error%20contract.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20selection%20%3E%3D%20len%28last_results%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22success%22%3A%20False%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22error_kind%22%3A%20%22validation%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22error%22%3A%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22Selection%20index%20%7Bselection%7D%20out%20of%20range%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22%20%28%7Blen%28last_results%29%7D%20options%29%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22flights%22%3A%20%5B%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=punitarani%2Ffli&pr=145&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Fmulti-city-timeouts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmulti-city-timeouts%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Afli%2Fsearch%2Fflights.py%3A76%0A**Redundant%20%60raise_for_status%28%29%60%20call**%0A%0A%60self.client.post%28%29%60%20%28%60Client.post%28%29%60%29%20already%20calls%20%60raise_for_status%28%29%60%20internally%20and%20re-wraps%20any%20non-2xx%20exception%20as%20%60Exception%28%22POST%20request%20failed%3A%20%E2%80%A6%22%29%60%20before%20returning%2C%20so%20it%20only%20ever%20returns%20a%202xx%20response.%20The%20%60response.raise_for_status%28%29%60%20on%20the%20returned%20object%20is%20dead%20code%20%E2%80%94%20it%20will%20never%20trigger%20and%20adds%20confusion%20when%20reading%20the%20retry%20loop.%0A%0A%23%23%23%20Issue%202%20of%204%0Afli%2Fmcp%2Fserver.py%3A557-563%0A**%60readOnlyHint%3A%20True%60%20is%20incorrect%20for%20a%20stateful%20tool**%0A%0A%60search_multi_city%60%20writes%20to%20%60_search_sessions%60%20on%20every%20successful%20continuation%20call%20%E2%80%94%20it%20is%20not%20read-only.%20%60readOnlyHint%3A%20True%60%20signals%20to%20MCP%20clients%20that%20the%20tool%20has%20no%20side%20effects%20%28and%20can%2C%20for%20example%2C%20be%20called%20without%20a%20confirmation%20prompt%20or%20freely%20cached%29%2C%20which%20is%20false%20here.%0A%0A%60idempotentHint%3A%20True%60%20is%20also%20problematic%3A%20continuation%20calls%20that%20successfully%20advance%20the%20session%20cannot%20safely%20be%20retried%20without%20risking%20an%20extra%20session%20step.%20If%20a%20response%20is%20lost%20in%20transit%20and%20the%20MCP%20client%20retries%20the%20call%20based%20on%20this%20hint%2C%20the%20session%20pointer%20advances%20past%20the%20leg%20the%20agent%20intended%20to%20select%2C%20silently%20skipping%20a%20leg.%0A%0A%23%23%23%20Issue%203%20of%204%0Afli%2Fmcp%2Fserver.py%3A526-529%0A**Session%20key%20omits%20filter%20parameters%20%E2%80%94%20silently%20stale%20on%20parameter%20change**%0A%0A%60_session_key%60%20is%20keyed%20only%20on%20leg%20routes%20and%20dates%2C%20not%20on%20%60cabin_class%60%2C%20%60airlines%60%2C%20%60sort_by%60%2C%20%60max_stops%60%2C%20etc.%20A%20continuation%20call%20that%20accidentally%20changes%20any%20of%20those%20parameters%20%28e.g.%2C%20an%20LLM%20agent%20that%20reformulates%20the%20request%29%20will%20hit%20the%20existing%20session%20and%20execute%20with%20the%20original%20filters%2C%20with%20no%20error%20or%20warning.%20Consider%20including%20a%20hash%20of%20the%20filter%20parameters%20in%20the%20key%2C%20or%20at%20minimum%20document%20the%20constraint%20that%20continuation%20calls%20must%20use%20identical%20parameters.%0A%0A%23%23%23%20Issue%204%20of%204%0Afli%2Fmcp%2Fserver.py%3A627-635%0A**Missing%20%60error_kind%60%20on%20out-of-range%20selection%20error**%0A%0AEvery%20other%20error%20return%20in%20%60_execute_multi_city_step%60%20now%20includes%20%60error_kind%60%20so%20callers%20can%20branch%20without%20string-matching.%20This%20one%20out-of-range%20path%20was%20missed%2C%20leaving%20a%20gap%20in%20the%20otherwise%20consistent%20error%20contract.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20selection%20%3E%3D%20len%28last_results%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22success%22%3A%20False%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22error_kind%22%3A%20%22validation%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22error%22%3A%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22Selection%20index%20%7Bselection%7D%20out%20of%20range%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f%22%20%28%7Blen%28last_results%29%7D%20options%29%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22flights%22%3A%20%5B%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
fli/search/flights.py:76
**Redundant `raise_for_status()` call**

`self.client.post()` (`Client.post()`) already calls `raise_for_status()` internally and re-wraps any non-2xx exception as `Exception("POST request failed: …")` before returning, so it only ever returns a 2xx response. The `response.raise_for_status()` on the returned object is dead code — it will never trigger and adds confusion when reading the retry loop.

### Issue 2 of 4
fli/mcp/server.py:557-563
**`readOnlyHint: True` is incorrect for a stateful tool**

`search_multi_city` writes to `_search_sessions` on every successful continuation call — it is not read-only. `readOnlyHint: True` signals to MCP clients that the tool has no side effects (and can, for example, be called without a confirmation prompt or freely cached), which is false here.

`idempotentHint: True` is also problematic: continuation calls that successfully advance the session cannot safely be retried without risking an extra session step. If a response is lost in transit and the MCP client retries the call based on this hint, the session pointer advances past the leg the agent intended to select, silently skipping a leg.

### Issue 3 of 4
fli/mcp/server.py:526-529
**Session key omits filter parameters — silently stale on parameter change**

`_session_key` is keyed only on leg routes and dates, not on `cabin_class`, `airlines`, `sort_by`, `max_stops`, etc. A continuation call that accidentally changes any of those parameters (e.g., an LLM agent that reformulates the request) will hit the existing session and execute with the original filters, with no error or warning. Consider including a hash of the filter parameters in the key, or at minimum document the constraint that continuation calls must use identical parameters.

### Issue 4 of 4
fli/mcp/server.py:627-635
**Missing `error_kind` on out-of-range selection error**

Every other error return in `_execute_multi_city_step` now includes `error_kind` so callers can branch without string-matching. This one out-of-range path was missed, leaving a gap in the otherwise consistent error contract.

```suggestion
            if selection >= len(last_results):
                return {
                    "success": False,
                    "error_kind": "validation",
                    "error": (
                        f"Selection index {selection} out of range"
                        f" ({len(last_results)} options)"
                    ),
                    "flights": [],
                }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make multi-city degraded state stic..."](https://github.com/punitarani/fli/commit/f2aac94241ceaa553bca13752c47aefc887a3f9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30599876)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->