### PR TITLE
fix: centralize airline parsing; raise on empty; refresh stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ fli flights JFK LHR 2026-10-25
 # Advanced search with filters
 fli flights JFK LHR 2026-10-25 \
     --time 6-20 \             # Departure time window (6 AM - 8 PM)
-    --airlines BA KL \        # Airlines (British Airways, KLM)
+    --airlines BA,KL \        # Airlines (British Airways, KLM)
     --class BUSINESS \        # Cabin class
     --stops NON_STOP \        # Non-stop flights only
     --sort DURATION           # Sort by duration
@@ -197,7 +197,7 @@ fli multi \
 |------------------|-----------------------|------------------------|
 | `--return, -r`   | Return date           | `2026-10-30`           |
 | `--time, -t`     | Departure time window | `6-20`                 |
-| `--airlines, -a` | Airline IATA codes    | `BA KL`                |
+| `--airlines, -a` | Airline IATA codes    | `BA,KL`                |
 | `--class, -c`    | Cabin class           | `ECONOMY`, `BUSINESS`  |
 | `--stops, -s`    | Maximum stops         | `NON_STOP`, `ONE_STOP` |
 | `--sort, -o`     | Sort results by       | `CHEAPEST`, `DURATION` |
@@ -211,7 +211,7 @@ fli multi \
 | `--to`             | End date               | `2026-02-01`           |
 | `--duration, -d`   | Trip duration in days  | `3`                    |
 | `--round, -R`      | Round-trip search      | (flag)                 |
-| `--airlines, -a`   | Airline IATA codes     | `BA KL`                |
+| `--airlines, -a`   | Airline IATA codes     | `BA,KL`                |
 | `--class, -c`      | Cabin class            | `ECONOMY`, `BUSINESS`  |
 | `--stops, -s`      | Maximum stops          | `NON_STOP`, `ONE_STOP` |
 | `--time`           | Departure time window  | `6-20`                 |

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -37,7 +37,7 @@ fli flights JFK LHR 2026-06-01 --return 2026-06-15
 ```bash
 fli flights JFK LHR 2026-06-01 \
     --time 6-20 \             # Departure window (6 AM - 8 PM)
-    --airlines BA KL \        # Airlines (British Airways, KLM)
+    --airlines BA,KL \        # Airlines (British Airways, KLM)
     --class BUSINESS \        # Cabin class
     --stops NON_STOP          # Non-stop flights only
 ```

--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -1,6 +1,5 @@
 """Date search CLI command for finding cheapest travel dates."""
 
-import re
 from datetime import datetime, timedelta
 from typing import Annotated
 
@@ -219,14 +218,6 @@ def dates(
         trip_type = TripType.ROUND_TRIP if is_round_trip else TripType.ONE_WAY
         stops = parse_max_stops(max_stops)
         seat_type = parse_cabin_class(cabin_class)
-        # Normalize airlines: split each element on commas to support "BA,KL" in a single flag
-        if airlines:
-            airlines = [
-                code.strip().upper()
-                for item in airlines
-                for code in re.split(r"[,\s]+", item)
-                if code.strip()
-            ]
         parsed_airlines = parse_airlines(airlines)
         selected_days = _build_selected_days(
             monday=monday,

--- a/fli/cli/commands/flights.py
+++ b/fli/cli/commands/flights.py
@@ -1,6 +1,5 @@
 """Flight search CLI command."""
 
-import re
 from typing import Annotated, Any
 
 import typer
@@ -55,14 +54,6 @@ def _search_flights_core(
     currency: str = "USD",
 ) -> None:
     """Core flight search functionality."""
-    # Normalize airlines: split each element on commas/spaces to support "BA,KL" in a single flag
-    if airlines:
-        airlines = [
-            code.strip().upper()
-            for item in airlines
-            for code in re.split(r"[,\s]+", item)
-            if code.strip()
-        ]
     query: dict[str, Any] = {
         "origin": origin.upper(),
         "destination": destination.upper(),
@@ -326,12 +317,12 @@ def flights(
     """Search for flights on a specific date.
 
     Example:
-        fli flights JFK LHR 2025-10-25 --time 6-20 --airlines BA KL --stops NON_STOP
-        fli flights JFK LHR 2025-10-25 --format json
-        fli flights JFK LHR 2025-10-25 --exclude-basic
-        fli flights JFK LAX 2025-10-25 --bags 1 --carry-on
-        fli flights JFK LAX 2025-10-25 --emissions LESS
-        fli flights JFK LAX 2025-10-25 --all
+        fli flights JFK LHR 2026-10-25 --time 6-20 --airlines BA,KL --stops NON_STOP
+        fli flights JFK LHR 2026-10-25 --format json
+        fli flights JFK LHR 2026-10-25 --exclude-basic
+        fli flights JFK LAX 2026-10-25 --bags 1 --carry-on
+        fli flights JFK LAX 2026-10-25 --emissions LESS
+        fli flights JFK LAX 2026-10-25 --all
 
     """
     _search_flights_core(

--- a/fli/cli/commands/flights.py
+++ b/fli/cli/commands/flights.py
@@ -60,7 +60,7 @@ def _search_flights_core(
         "departure_date": departure_date,
         "return_date": return_date,
         "departure_window": None,
-        "airlines": [airline.upper() for airline in airlines] if airlines else None,
+        "airlines": None,
         "cabin_class": cabin_class.upper(),
         "max_stops": max_stops.upper(),
         "sort_by": sort_by.upper(),
@@ -82,6 +82,9 @@ def _search_flights_core(
         seat_type = parse_cabin_class(cabin_class)
         stops = parse_max_stops(max_stops)
         parsed_airlines = parse_airlines(airlines)
+        query["airlines"] = (
+            [airline.name.lstrip("_") for airline in parsed_airlines] if parsed_airlines else None
+        )
         sort = parse_sort_by(sort_by)
         emissions_filter = parse_emissions(emissions)
 

--- a/fli/cli/commands/multi.py
+++ b/fli/cli/commands/multi.py
@@ -67,7 +67,7 @@ def multi(
         typer.Option(
             "--airlines",
             "-a",
-            help="List of airline IATA codes (e.g., BA KL)",
+            help="Airline IATA codes (e.g., BA,KL or repeated --airlines BA --airlines KL)",
         ),
     ] = None,
     cabin_class: Annotated[

--- a/fli/core/parsers.py
+++ b/fli/core/parsers.py
@@ -4,10 +4,13 @@ This module provides parsing functions used by both the CLI and MCP interfaces
 to convert user input into domain model objects.
 """
 
+import re
 from enum import Enum
 from typing import TypeVar
 
 from fli.models import Airline, Airport, EmissionsFilter, MaxStops, SeatType, SortBy
+
+_AIRLINE_SEPARATORS = re.compile(r"[,\s]+")
 
 T = TypeVar("T", bound=Enum)
 
@@ -63,24 +66,38 @@ def resolve_airport(code: str) -> Airport:
 def parse_airlines(codes: list[str] | None) -> list[Airline] | None:
     """Parse a list of airline codes into Airline enums.
 
+    Each item may itself contain multiple codes separated by commas or whitespace,
+    so callers can pass either ``["BA", "KL"]`` (one code per item) or
+    ``["BA,KL"]`` / ``["BA KL"]`` (combined). This lets the CLI accept the
+    documented ``--airlines BA,KL`` and ``--airlines "BA KL"`` forms in addition
+    to the repeated-flag form Typer collects natively.
+
     Args:
-        codes: List of IATA airline codes (e.g., ['BA', 'KL'])
+        codes: List of IATA airline codes; entries may be combined with commas or
+            whitespace (e.g., ['BA', 'KL'] or ['BA,KL'] or ['BA KL']).
 
     Returns:
-        List of Airline enums, or None if input is empty
+        List of Airline enums, or None if ``codes`` is None or an empty list.
 
     Raises:
-        ParseError: If any code is not a valid airline
+        ParseError: If any code is not a valid airline, or if ``codes`` was
+            non-empty but contained no parsable codes (e.g., [","]).
 
     """
     if not codes:
         return None
 
+    expanded = [
+        token.strip().upper()
+        for item in codes
+        for token in _AIRLINE_SEPARATORS.split(item)
+        if token.strip()
+    ]
+    if not expanded:
+        raise ParseError(f"No valid airline codes found in: {codes!r}")
+
     airlines = []
-    for code in codes:
-        code = code.strip().upper()
-        if not code:
-            continue
+    for code in expanded:
         # Airline codes starting with a digit need an underscore prefix
         # to match the Airline enum member names (e.g., "3F" -> "_3F")
         enum_key = f"_{code}" if code[0].isdigit() else code
@@ -90,7 +107,7 @@ def parse_airlines(codes: list[str] | None) -> list[Airline] | None:
         except AttributeError as e:
             raise ParseError(f"Invalid airline code: '{code}'") from e
 
-    return airlines if airlines else None
+    return airlines
 
 
 def parse_max_stops(stops: str) -> MaxStops:

--- a/skills/fli/SKILL.md
+++ b/skills/fli/SKILL.md
@@ -123,7 +123,7 @@ Use filters like these when the user asks for them:
 ```bash
 fli flights JFK LHR 2026-10-25 \
   --time 6-20 \
-  --airlines BA KL \
+  --airlines BA,KL \
   --class BUSINESS \
   --stops NON_STOP \
   --sort DURATION

--- a/tests/cli/test_dates.py
+++ b/tests/cli/test_dates.py
@@ -7,6 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from fli.cli.main import app
+from fli.models import Airline
 from fli.models.google_flights.base import TripType
 from fli.search import DatePrice
 
@@ -72,7 +73,7 @@ def test_dates_with_days(runner, mock_search_dates, mock_console):
 
 
 def test_dates_with_airlines(runner, mock_search_dates, mock_console):
-    """Test dates search with airline filter."""
+    """Repeated -a flags resolve to the matching Airline enums on the filter."""
     mock_search_dates.search.return_value = [
         DatePrice(
             date=(datetime.now() + timedelta(days=1),),
@@ -84,7 +85,25 @@ def test_dates_with_airlines(runner, mock_search_dates, mock_console):
         ["dates", "JFK", "LAX", "-a", "DL", "-a", "UA"],
     )
     assert result.exit_code == 0
-    mock_search_dates.search.assert_called_once()
+    args, _ = mock_search_dates.search.call_args
+    assert args[0].airlines == [Airline.DL, Airline.UA]
+
+
+def test_dates_with_comma_separated_airlines(runner, mock_search_dates, mock_console):
+    """Single -a flag with comma-joined codes splits into multiple airlines."""
+    mock_search_dates.search.return_value = [
+        DatePrice(
+            date=(datetime.now() + timedelta(days=1),),
+            price=299.99,
+        ),
+    ]
+    result = runner.invoke(
+        app,
+        ["dates", "JFK", "LAX", "-a", "DL,UA"],
+    )
+    assert result.exit_code == 0
+    args, _ = mock_search_dates.search.call_args
+    assert args[0].airlines == [Airline.DL, Airline.UA]
 
 
 def test_dates_with_cabin_class(runner, mock_search_dates, mock_console):

--- a/tests/cli/test_flights.py
+++ b/tests/cli/test_flights.py
@@ -42,7 +42,7 @@ def test_flights_with_time_filter(runner, mock_search_flights, mock_console):
 
 
 def test_flights_with_airlines(runner, mock_search_flights, mock_console):
-    """Test flights search with airline filter."""
+    """Repeated -a flags resolve to the matching Airline enums on the filter."""
     result = runner.invoke(
         app,
         [
@@ -57,7 +57,26 @@ def test_flights_with_airlines(runner, mock_search_flights, mock_console):
         ],
     )
     assert result.exit_code == 0
-    mock_search_flights.search.assert_called_once()
+    args, _ = mock_search_flights.search.call_args
+    assert args[0].airlines == [Airline.DL, Airline.UA]
+
+
+def test_flights_with_comma_separated_airlines(runner, mock_search_flights, mock_console):
+    """Single -a flag with comma-joined codes splits into multiple airlines."""
+    result = runner.invoke(
+        app,
+        [
+            "flights",
+            "JFK",
+            "LAX",
+            datetime.now().strftime("%Y-%m-%d"),
+            "-a",
+            "DL,UA",
+        ],
+    )
+    assert result.exit_code == 0
+    args, _ = mock_search_flights.search.call_args
+    assert args[0].airlines == [Airline.DL, Airline.UA]
 
 
 def test_flights_with_cabin_class(runner, mock_search_flights, mock_console):

--- a/tests/cli/test_flights.py
+++ b/tests/cli/test_flights.py
@@ -79,6 +79,26 @@ def test_flights_with_comma_separated_airlines(runner, mock_search_flights, mock
     assert args[0].airlines == [Airline.DL, Airline.UA]
 
 
+def test_flights_json_query_echoes_split_airlines(runner, mock_search_flights, mock_console):
+    """JSON query echo reflects the parsed, split airline list — not the raw input."""
+    result = runner.invoke(
+        app,
+        [
+            "flights",
+            "JFK",
+            "LAX",
+            datetime.now().strftime("%Y-%m-%d"),
+            "-a",
+            "DL,UA",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["query"]["airlines"] == ["DL", "UA"]
+
+
 def test_flights_with_cabin_class(runner, mock_search_flights, mock_console):
     """Test flights search with cabin class."""
     result = runner.invoke(

--- a/tests/core/test_parsers.py
+++ b/tests/core/test_parsers.py
@@ -49,6 +49,78 @@ class TestParseAirlinesWithAlliances:
         assert Airline.AA in result
 
 
+class TestParseAirlinesSplitting:
+    """Tests for parse_airlines accepting comma- and whitespace-separated codes per item.
+
+    Motivated by the documented `--airlines BA,KL` (single token) and
+    `--airlines "BA KL"` (quoted) CLI forms, plus the same tolerance now extended
+    to MCP callers passing combined strings.
+    """
+
+    def test_comma_separated_in_one_item(self):
+        result = parse_airlines(["BA,KL"])
+        assert result == [Airline.BA, Airline.KL]
+
+    def test_space_separated_in_one_item(self):
+        result = parse_airlines(["BA KL"])
+        assert result == [Airline.BA, Airline.KL]
+
+    def test_tab_separator(self):
+        result = parse_airlines(["BA\tKL"])
+        assert result == [Airline.BA, Airline.KL]
+
+    def test_collapses_consecutive_separators(self):
+        result = parse_airlines(["BA,,KL", "AA  UA"])
+        assert result == [Airline.BA, Airline.KL, Airline.AA, Airline.UA]
+
+    def test_strips_leading_and_trailing_separators(self):
+        result = parse_airlines([",BA,", " KL "])
+        assert result == [Airline.BA, Airline.KL]
+
+    def test_mixed_forms(self):
+        result = parse_airlines(["BA,KL", "LH"])
+        assert result == [Airline.BA, Airline.KL, Airline.LH]
+
+    def test_repeated_items_still_work(self):
+        # Backwards compat: `--airlines BA --airlines KL` arrives as ["BA", "KL"].
+        result = parse_airlines(["BA", "KL"])
+        assert result == [Airline.BA, Airline.KL]
+
+    def test_lowercase_in_split_is_uppercased(self):
+        result = parse_airlines(["ba,kl"])
+        assert result == [Airline.BA, Airline.KL]
+
+    def test_numeric_prefix_in_split(self):
+        result = parse_airlines(["BA,3F"])
+        assert result == [Airline.BA, Airline._3F]
+
+    def test_invalid_code_in_split_propagates(self):
+        with pytest.raises(ParseError, match="Invalid airline code: 'XXX'"):
+            parse_airlines(["BA,XXX"])
+
+    def test_raises_when_only_commas(self):
+        with pytest.raises(ParseError, match="No valid airline codes"):
+            parse_airlines([","])
+
+    def test_raises_when_only_whitespace(self):
+        with pytest.raises(ParseError, match="No valid airline codes"):
+            parse_airlines([" "])
+
+    def test_raises_when_only_empty_string(self):
+        with pytest.raises(ParseError, match="No valid airline codes"):
+            parse_airlines([""])
+
+    def test_raises_when_only_separators_across_items(self):
+        with pytest.raises(ParseError, match="No valid airline codes"):
+            parse_airlines(["", " ", ","])
+
+    def test_none_input_still_returns_none(self):
+        assert parse_airlines(None) is None
+
+    def test_empty_list_still_returns_none(self):
+        assert parse_airlines([]) is None
+
+
 class TestParseSortBy:
     """Tests for parse_sort_by with updated enum values."""
 


### PR DESCRIPTION
## Summary

Follow-ups from the review of #112. Three fixes in one PR:

- **Centralize airline parsing.** The duplicated `re.split(r\"[,\\s]+\", ...)` block in `flights.py` and `dates.py` is moved into `parse_airlines()` in `fli/core/parsers.py`. The MCP server and the `multi` CLI command both call `parse_airlines()` directly, so they now also accept `[\"BA,KL\"]` and `[\"BA KL\"]` instead of only `[\"BA\", \"KL\"]`.
- **Fail loud on empty input.** `parse_airlines()` now raises `ParseError(\"No valid airline codes found in: ...\")` when the input was non-empty but every entry stripped to empty (e.g., `[\",\"]`, `[\" \"]`, `[\"\"]`). Previously the search silently ran with no airline filter — the user got results that didn't match the filter they thought they applied. **Note for MCP callers:** this is a user-visible behavior change for malformed input. Well-formed input is unaffected.
- **Refresh stale docs.** README, quickstart guide, skill docs, and the `flights` docstring example were still showing `--airlines BA KL` (the unquoted form that issue #56 reported as broken). Updated to `--airlines BA,KL` (or repeated `--airlines` flags), which match the help text introduced in #112. The `multi` command's `--airlines` help text gets the same treatment as `flights` and `dates`.

## Test plan

- [x] 16 new unit tests in `tests/core/test_parsers.py::TestParseAirlinesSplitting` cover comma split, whitespace split, tab separator, consecutive separators, leading/trailing separators, mixed forms, repeated items (regression guard), lowercase, numeric prefix, invalid-in-CSV, and four \"raises on empty\" cases.
- [x] `test_flights_with_airlines` and `test_dates_with_airlines` previously asserted only `assert_called_once()`; they now assert `args[0].airlines == [Airline.DL, Airline.UA]`, which closes the regression hole flagged in the #112 review.
- [x] New `test_*_with_comma_separated_airlines` tests prove the new form flows end-to-end through the CLI.
- [x] Full suite: `uv run pytest tests/` → 240 passed (was 222 before; +16 parser tests, +2 CLI tests, 2 strengthened in place).
- [x] `uv run ruff format . --check` clean; `uv run ruff check .` clean.
- [x] Live CLI smoke: `uv run fli flights JFK LAX 2026-12-01 --airlines \"DL,UA\" --no-all` returned flights; `--airlines \",\"` raised `Error: No valid airline codes found in: [',']` instead of silently dropping the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates airline input normalisation into `parse_airlines()` in `fli/core/parsers.py`, removes the duplicated `re.split` blocks from `flights.py` and `dates.py`, and updates docs/help text from the broken space-separated form to the comma-separated form.

- **Centralised parsing**: `parse_airlines()` now splits each entry on `[,\\s]+`, so both CLI (`--airlines BA,KL`) and MCP callers receive consistent handling without per-command boilerplate.
- **Fail-loud on empty input**: A `ParseError` is raised when all tokens reduce to whitespace/separators, closing the silent no-filter bug.
- **Strengthened tests**: 16 new parser unit tests and two new CLI end-to-end tests; existing `test_*_with_airlines` tests now assert the resolved `Airline` enum list rather than just `assert_called_once()`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core parsing and search logic is correct. The only cosmetic gap is in the JSON query echo for the flights command.

The consolidation into parse_airlines() is clean and well-tested. One small inconsistency remains in flights.py: the query dict is built from the raw airlines argument before parse_airlines() expands it, so JSON responses will echo ["DL,UA"] rather than ["DL", "UA"] when the comma-separated form is used. dates.py does this correctly by deriving query["airlines"] from the already-parsed enums.

fli/cli/commands/flights.py — the query dict airlines field (line 63) is built before parse_airlines() runs.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| fli/core/parsers.py | Centralises airline normalisation into parse_airlines(); adds comma/whitespace splitting via _AIRLINE_SEPARATORS and raises ParseError on all-separator input. Return type is now always a non-empty list (or None), removing the old empty-list-→-None fallback. |
| fli/cli/commands/flights.py | Removes the local normalisation block; the query dict at line 63 still uses the raw airlines list before parse_airlines() is called, so JSON output reflects the unsplit form (e.g., ["DL,UA"]) rather than the expanded form. |
| fli/cli/commands/dates.py | Removes local normalisation block; query dict correctly derives airlines from parsed_airlines after parse_airlines() resolves them, so JSON output is unaffected. |
| fli/cli/commands/multi.py | Updates --airlines help text to document the comma-separated form; calls parse_airlines() directly (no local query dict), so no JSON echo concern. |
| tests/core/test_parsers.py | Adds 16 new tests in TestParseAirlinesSplitting covering comma/space/tab splitting, consecutive separators, mixed forms, lowercase, numeric prefix, invalid codes, and four empty-input raises cases. |
| tests/cli/test_flights.py | Strengthens existing test to assert args[0].airlines == [Airline.DL, Airline.UA] and adds a new end-to-end comma-separated test. |
| tests/cli/test_dates.py | Same strengthening pattern as test_flights.py: asserts parsed airlines enum list and adds comma-separated CLI test. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CLI or MCP caller\npasses airlines arg"] --> B{codes is None\nor empty?}
    B -- Yes --> C[return None]
    B -- No --> D[split each item on\ncomma or whitespace]
    D --> E{expanded\nlist empty?}
    E -- Yes --> F[raise ParseError]
    E -- No --> G[look up each token\nin Airline enum]
    G --> H{valid?}
    H -- No --> I[raise ParseError\ninvalid code]
    H -- Yes --> J[append to result]
    J --> K[return airline list]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `fli/cli/commands/flights.py`, line 63 ([link](https://github.com/punitarani/fli/blob/e3439535c839899fdb8dd7e75775115d55a15d49/fli/cli/commands/flights.py#L63)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **JSON query echo shows unsplit airline input**

   The `query` dict is built from the raw `airlines` argument before `parse_airlines()` normalises it, so when a caller passes `--airlines "DL,UA"` with `--format json`, the echoed `query.airlines` field is `["DL,UA"]` rather than `["DL", "UA"]`. In the old code the normalisation block ran before this assignment, so the query always reflected the expanded form. `dates.py` avoids this by deriving its `query["airlines"]` entry from `parsed_airlines` (the already-resolved enums) after the parsing step.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: fli/cli/commands/flights.py
   Line: 63

   Comment:
   **JSON query echo shows unsplit airline input**

   The `query` dict is built from the raw `airlines` argument before `parse_airlines()` normalises it, so when a caller passes `--airlines "DL,UA"` with `--format json`, the echoed `query.airlines` field is `["DL,UA"]` rather than `["DL", "UA"]`. In the old code the normalisation block ran before this assignment, so the query always reflected the expanded form. `dates.py` avoids this by deriving its `query["airlines"]` entry from `parsed_airlines` (the already-resolved enums) after the parsing step.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20fli%2Fcli%2Fcommands%2Fflights.py%0ALine%3A%2063%0A%0AComment%3A%0A**JSON%20query%20echo%20shows%20unsplit%20airline%20input**%0A%0AThe%20%60query%60%20dict%20is%20built%20from%20the%20raw%20%60airlines%60%20argument%20before%20%60parse_airlines%28%29%60%20normalises%20it%2C%20so%20when%20a%20caller%20passes%20%60--airlines%20%22DL%2CUA%22%60%20with%20%60--format%20json%60%2C%20the%20echoed%20%60query.airlines%60%20field%20is%20%60%5B%22DL%2CUA%22%5D%60%20rather%20than%20%60%5B%22DL%22%2C%20%22UA%22%5D%60.%20In%20the%20old%20code%20the%20normalisation%20block%20ran%20before%20this%20assignment%2C%20so%20the%20query%20always%20reflected%20the%20expanded%20form.%20%60dates.py%60%20avoids%20this%20by%20deriving%20its%20%60query%5B%22airlines%22%5D%60%20entry%20from%20%60parsed_airlines%60%20%28the%20already-resolved%20enums%29%20after%20the%20parsing%20step.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=punitarani%2Ffli&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20fli%2Fcli%2Fcommands%2Fflights.py%0ALine%3A%2063%0A%0AComment%3A%0A**JSON%20query%20echo%20shows%20unsplit%20airline%20input**%0A%0AThe%20%60query%60%20dict%20is%20built%20from%20the%20raw%20%60airlines%60%20argument%20before%20%60parse_airlines%28%29%60%20normalises%20it%2C%20so%20when%20a%20caller%20passes%20%60--airlines%20%22DL%2CUA%22%60%20with%20%60--format%20json%60%2C%20the%20echoed%20%60query.airlines%60%20field%20is%20%60%5B%22DL%2CUA%22%5D%60%20rather%20than%20%60%5B%22DL%22%2C%20%22UA%22%5D%60.%20In%20the%20old%20code%20the%20normalisation%20block%20ran%20before%20this%20assignment%2C%20so%20the%20query%20always%20reflected%20the%20expanded%20form.%20%60dates.py%60%20avoids%20this%20by%20deriving%20its%20%60query%5B%22airlines%22%5D%60%20entry%20from%20%60parsed_airlines%60%20%28the%20already-resolved%20enums%29%20after%20the%20parsing%20step.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Fairlines-cli-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fairlines-cli-followups%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20fli%2Fcli%2Fcommands%2Fflights.py%0ALine%3A%2063%0A%0AComment%3A%0A**JSON%20query%20echo%20shows%20unsplit%20airline%20input**%0A%0AThe%20%60query%60%20dict%20is%20built%20from%20the%20raw%20%60airlines%60%20argument%20before%20%60parse_airlines%28%29%60%20normalises%20it%2C%20so%20when%20a%20caller%20passes%20%60--airlines%20%22DL%2CUA%22%60%20with%20%60--format%20json%60%2C%20the%20echoed%20%60query.airlines%60%20field%20is%20%60%5B%22DL%2CUA%22%5D%60%20rather%20than%20%60%5B%22DL%22%2C%20%22UA%22%5D%60.%20In%20the%20old%20code%20the%20normalisation%20block%20ran%20before%20this%20assignment%2C%20so%20the%20query%20always%20reflected%20the%20expanded%20form.%20%60dates.py%60%20avoids%20this%20by%20deriving%20its%20%60query%5B%22airlines%22%5D%60%20entry%20from%20%60parsed_airlines%60%20%28the%20already-resolved%20enums%29%20after%20the%20parsing%20step.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afli%2Fcli%2Fcommands%2Fflights.py%3A63%0A**JSON%20query%20echo%20shows%20unsplit%20airline%20input**%0A%0AThe%20%60query%60%20dict%20is%20built%20from%20the%20raw%20%60airlines%60%20argument%20before%20%60parse_airlines%28%29%60%20normalises%20it%2C%20so%20when%20a%20caller%20passes%20%60--airlines%20%22DL%2CUA%22%60%20with%20%60--format%20json%60%2C%20the%20echoed%20%60query.airlines%60%20field%20is%20%60%5B%22DL%2CUA%22%5D%60%20rather%20than%20%60%5B%22DL%22%2C%20%22UA%22%5D%60.%20In%20the%20old%20code%20the%20normalisation%20block%20ran%20before%20this%20assignment%2C%20so%20the%20query%20always%20reflected%20the%20expanded%20form.%20%60dates.py%60%20avoids%20this%20by%20deriving%20its%20%60query%5B%22airlines%22%5D%60%20entry%20from%20%60parsed_airlines%60%20%28the%20already-resolved%20enums%29%20after%20the%20parsing%20step.%0A%0A&repo=punitarani%2Ffli&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afli%2Fcli%2Fcommands%2Fflights.py%3A63%0A**JSON%20query%20echo%20shows%20unsplit%20airline%20input**%0A%0AThe%20%60query%60%20dict%20is%20built%20from%20the%20raw%20%60airlines%60%20argument%20before%20%60parse_airlines%28%29%60%20normalises%20it%2C%20so%20when%20a%20caller%20passes%20%60--airlines%20%22DL%2CUA%22%60%20with%20%60--format%20json%60%2C%20the%20echoed%20%60query.airlines%60%20field%20is%20%60%5B%22DL%2CUA%22%5D%60%20rather%20than%20%60%5B%22DL%22%2C%20%22UA%22%5D%60.%20In%20the%20old%20code%20the%20normalisation%20block%20ran%20before%20this%20assignment%2C%20so%20the%20query%20always%20reflected%20the%20expanded%20form.%20%60dates.py%60%20avoids%20this%20by%20deriving%20its%20%60query%5B%22airlines%22%5D%60%20entry%20from%20%60parsed_airlines%60%20%28the%20already-resolved%20enums%29%20after%20the%20parsing%20step.%0A%0A&pr=151&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Fairlines-cli-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fairlines-cli-followups%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Afli%2Fcli%2Fcommands%2Fflights.py%3A63%0A**JSON%20query%20echo%20shows%20unsplit%20airline%20input**%0A%0AThe%20%60query%60%20dict%20is%20built%20from%20the%20raw%20%60airlines%60%20argument%20before%20%60parse_airlines%28%29%60%20normalises%20it%2C%20so%20when%20a%20caller%20passes%20%60--airlines%20%22DL%2CUA%22%60%20with%20%60--format%20json%60%2C%20the%20echoed%20%60query.airlines%60%20field%20is%20%60%5B%22DL%2CUA%22%5D%60%20rather%20than%20%60%5B%22DL%22%2C%20%22UA%22%5D%60.%20In%20the%20old%20code%20the%20normalisation%20block%20ran%20before%20this%20assignment%2C%20so%20the%20query%20always%20reflected%20the%20expanded%20form.%20%60dates.py%60%20avoids%20this%20by%20deriving%20its%20%60query%5B%22airlines%22%5D%60%20entry%20from%20%60parsed_airlines%60%20%28the%20already-resolved%20enums%29%20after%20the%20parsing%20step.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
fli/cli/commands/flights.py:63
**JSON query echo shows unsplit airline input**

The `query` dict is built from the raw `airlines` argument before `parse_airlines()` normalises it, so when a caller passes `--airlines "DL,UA"` with `--format json`, the echoed `query.airlines` field is `["DL,UA"]` rather than `["DL", "UA"]`. In the old code the normalisation block ran before this assignment, so the query always reflected the expanded form. `dates.py` avoids this by deriving its `query["airlines"]` entry from `parsed_airlines` (the already-resolved enums) after the parsing step.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: centralize airline parsing; raise o..."](https://github.com/punitarani/fli/commit/e3439535c839899fdb8dd7e75775115d55a15d49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31723169)</sub>

<!-- /greptile_comment -->