### PR TITLE
refactor: harden airport search (Pydantic AirportMatch + import-time validation)

### DIFF
--- a/fli/cli/commands/airports.py
+++ b/fli/cli/commands/airports.py
@@ -40,7 +40,10 @@ def airports(
         output = [
             {"code": r.code.name, "name": r.name, "match_type": r.match_type} for r in results
         ]
-        console.print(json.dumps(output, indent=2))
+        # Plain print() bypasses Rich's markup parsing — JSON's `[` would
+        # otherwise be interpreted as a style tag in non-TTY environments
+        # (e.g. CI, pipes), suppressing output.
+        print(json.dumps(output, indent=2))
     else:
         table = Table(title=f"Airports matching '{query}'")
         table.add_column("Code", style="bold cyan", width=6)

--- a/fli/cli/commands/airports.py
+++ b/fli/cli/commands/airports.py
@@ -37,7 +37,9 @@ def airports(
     if json_output:
         import json
 
-        output = [{"code": r.code, "name": r.name, "match_type": r.match_type} for r in results]
+        output = [
+            {"code": r.code.name, "name": r.name, "match_type": r.match_type} for r in results
+        ]
         console.print(json.dumps(output, indent=2))
     else:
         table = Table(title=f"Airports matching '{query}'")
@@ -46,6 +48,6 @@ def airports(
         table.add_column("Match", style="dim")
 
         for result in results:
-            table.add_row(result.code, result.name, result.match_type)
+            table.add_row(result.code.name, result.name, result.match_type)
 
         console.print(table)

--- a/fli/core/airports.py
+++ b/fli/core/airports.py
@@ -1,9 +1,15 @@
 """Airport search utilities for looking up airports by city or name."""
 
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
 from fli.models import Airport
 
-# Mapping of city names to IATA codes for airports where the city name
-# is NOT in the airport name (e.g., JFK doesn't contain "New York")
+# Curated mapping of city names and common abbreviations to IATA codes.
+# Provides multi-airport groupings (e.g., "new york" -> JFK, LGA, EWR) and
+# short aliases (e.g., "sf", "la", "nyc") that pure airport-name substring
+# search would miss. Validated against the Airport enum at import time.
 CITY_AIRPORTS: dict[str, list[str]] = {
     "new york": ["JFK", "LGA", "EWR"],
     "nyc": ["JFK", "LGA", "EWR"],
@@ -58,30 +64,43 @@ CITY_AIRPORTS: dict[str, list[str]] = {
     "honolulu": ["HNL"],
 }
 
+for _city, _codes in CITY_AIRPORTS.items():
+    for _code in _codes:
+        if _code not in Airport.__members__:
+            raise RuntimeError(f"CITY_AIRPORTS[{_city!r}] references unknown IATA code {_code!r}")
 
-class AirportMatch:
+MatchType = Literal["iata_exact", "iata_prefix", "city", "name"]
+
+
+class AirportMatch(BaseModel):
     """A matched airport from a search query."""
 
-    def __init__(self, code: str, name: str, match_type: str, score: float):
-        """Initialize a matched airport result."""
-        self.code = code
-        self.name = name
-        self.match_type = match_type  # "code", "city", "name"
-        self.score = score
+    model_config = ConfigDict(frozen=True)
 
-    def __repr__(self) -> str:
-        """Return a debug representation for the match."""
-        return (
-            f"AirportMatch(code={self.code!r}, name={self.name!r}, match_type={self.match_type!r})"
-        )
+    code: Airport
+    name: str
+    match_type: MatchType
+    score: float = Field(ge=0.0, le=100.0)
 
 
 def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
     """Search airports by city name, airport name, or IATA code.
 
+    Results are ranked by a 5-priority cascade, scored 0-100 (higher = better):
+
+      1. iata_exact  (score 100) - query is an exact IATA code (e.g. "JFK")
+      2. city        (score 90)  - query is an exact city/alias in CITY_AIRPORTS
+      3. city        (score 80)  - query is a prefix of a city in CITY_AIRPORTS
+      4. name        (score <=70) - query is a substring of an airport's name;
+                                   earlier match position scores higher
+      5. iata_prefix (score 60)  - query (<=3 chars) is a prefix of an IATA code
+
+    Within a single result list, each IATA code appears at most once: the
+    highest-priority match wins.
+
     Args:
-        query: Search string (e.g., "new york", "san fran", "JFK", "heathrow")
-        limit: Maximum results to return (must be >= 1).
+        query: Search string (e.g., "new york", "san fran", "JFK", "heathrow").
+        limit: Maximum results to return. Values < 1 yield an empty list.
 
     Returns:
         List of matching airports sorted by relevance (best match first).
@@ -96,23 +115,22 @@ def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
 
     # Priority 1: Exact IATA code match
     query_upper = query.strip().upper()
-    try:
+    if query_upper in Airport.__members__:
         airport = Airport[query_upper]
-        results.append(AirportMatch(query_upper, airport.value, "code", 100.0))
+        results.append(
+            AirportMatch(code=airport, name=airport.value, match_type="iata_exact", score=100.0)
+        )
         seen_codes.add(query_upper)
-    except KeyError:
-        pass
 
-    # Priority 2: City name lookup (handles "new york" -> JFK, LGA, EWR)
+    # Priority 2: Exact city name lookup (handles "new york" -> JFK, LGA, EWR)
     if query_lower in CITY_AIRPORTS:
         for code in CITY_AIRPORTS[query_lower]:
             if code not in seen_codes:
-                try:
-                    airport = Airport[code]
-                    results.append(AirportMatch(code, airport.value, "city", 90.0))
-                    seen_codes.add(code)
-                except KeyError:
-                    pass
+                airport = Airport[code]
+                results.append(
+                    AirportMatch(code=airport, name=airport.value, match_type="city", score=90.0)
+                )
+                seen_codes.add(code)
 
     # Priority 3: Partial city name match (handles "new yo" matching "new york")
     if query_lower not in CITY_AIRPORTS:
@@ -120,12 +138,13 @@ def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
             if city.startswith(query_lower):
                 for code in codes:
                     if code not in seen_codes:
-                        try:
-                            airport = Airport[code]
-                            results.append(AirportMatch(code, airport.value, "city", 80.0))
-                            seen_codes.add(code)
-                        except KeyError:
-                            pass
+                        airport = Airport[code]
+                        results.append(
+                            AirportMatch(
+                                code=airport, name=airport.value, match_type="city", score=80.0
+                            )
+                        )
+                        seen_codes.add(code)
 
     # Priority 4: Airport name substring match
     for airport in Airport:
@@ -133,10 +152,13 @@ def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
             continue
         airport_name_lower = airport.value.lower()
         if query_lower in airport_name_lower:
-            # Score based on how early the match occurs.
+            # 0.1-per-position weight keeps name matches (max ~70) below
+            # city matches (80) regardless of where the substring lands.
             pos = airport_name_lower.find(query_lower)
-            score = 70.0 - (pos * 0.1)  # Earlier matches score higher.
-            results.append(AirportMatch(airport.name, airport.value, "name", score))
+            score = 70.0 - (pos * 0.1)
+            results.append(
+                AirportMatch(code=airport, name=airport.value, match_type="name", score=score)
+            )
             seen_codes.add(airport.name)
 
     # Priority 5: IATA code prefix match (handles "SF" matching "SFO")
@@ -145,9 +167,13 @@ def search_airports(query: str, limit: int = 10) -> list[AirportMatch]:
             if airport.name in seen_codes:
                 continue
             if airport.name.startswith(query_upper):
-                results.append(AirportMatch(airport.name, airport.value, "code", 60.0))
+                results.append(
+                    AirportMatch(
+                        code=airport, name=airport.value, match_type="iata_prefix", score=60.0
+                    )
+                )
                 seen_codes.add(airport.name)
 
-    # Sort by score descending, then by code alphabetically
-    results.sort(key=lambda m: (-m.score, m.code))
+    # Sort by score descending, then by IATA code alphabetically.
+    results.sort(key=lambda m: (-m.score, m.code.name))
     return results[:limit]

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -589,6 +589,27 @@ def _search_dates_from_params(params: DateSearchParams) -> dict[str, Any]:
     return _execute_date_search(params)
 
 
+def _find_airports_impl(query: str, limit: int = 10) -> dict[str, Any]:
+    """Run search_airports and shape the result into the MCP response dict."""
+    try:
+        results = search_airports(query, limit=limit)
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+            "query": query,
+        }
+
+    return {
+        "success": True,
+        "query": query,
+        "count": len(results),
+        "airports": [
+            {"code": r.code.name, "name": r.name, "match_type": r.match_type} for r in results
+        ],
+    }
+
+
 @mcp.tool(
     annotations={
         "title": "Search Airports",
@@ -613,13 +634,7 @@ def find_airports(
     Supports city names (e.g., "new york" returns JFK, LGA, EWR),
     airport names (e.g., "heathrow" returns LHR), and IATA codes.
     """
-    results = search_airports(query, limit=limit)
-
-    return {
-        "query": query,
-        "count": len(results),
-        "airports": [{"code": r.code, "name": r.name, "match_type": r.match_type} for r in results],
-    }
+    return _find_airports_impl(query, limit=limit)
 
 
 # =============================================================================

--- a/tests/cli/test_airports.py
+++ b/tests/cli/test_airports.py
@@ -1,0 +1,44 @@
+"""Tests for the `fli airports` CLI command."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from fli.cli.main import app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestAirportsCommand:
+    def test_exact_code_table_output(self, runner):
+        result = runner.invoke(app, ["airports", "JFK"])
+        assert result.exit_code == 0
+        assert "JFK" in result.stdout
+
+    def test_json_output(self, runner):
+        result = runner.invoke(app, ["airports", "JFK", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+        assert payload[0]["code"] == "JFK"
+        assert payload[0]["match_type"] == "iata_exact"
+
+    def test_city_query_returns_all_airports(self, runner):
+        result = runner.invoke(app, ["airports", "new york", "--json"])
+        assert result.exit_code == 0
+        codes = {row["code"] for row in json.loads(result.stdout)}
+        assert {"JFK", "LGA", "EWR"} <= codes
+
+    def test_no_results_exits_with_error(self, runner):
+        result = runner.invoke(app, ["airports", "xyznonexistent"])
+        assert result.exit_code == 1
+        assert "No airports found" in result.stdout
+
+    def test_limit_caps_results(self, runner):
+        result = runner.invoke(app, ["airports", "international", "--limit", "2", "--json"])
+        assert result.exit_code == 0
+        assert len(json.loads(result.stdout)) <= 2

--- a/tests/core/test_airports.py
+++ b/tests/core/test_airports.py
@@ -1,99 +1,141 @@
 """Tests for airport search functionality."""
 
-from fli.core.airports import search_airports
+from fli.core.airports import AirportMatch, search_airports
+from fli.models import Airport
 
 
 class TestSearchAirports:
-    """Tests for the search_airports function."""
-
     def test_exact_iata_code(self):
-        """Exact IATA code returns the airport."""
         results = search_airports("JFK")
         assert len(results) >= 1
-        assert results[0].code == "JFK"
-        assert results[0].match_type == "code"
+        assert results[0].code is Airport.JFK
+        assert results[0].match_type == "iata_exact"
+        assert results[0].score == 100.0
 
     def test_iata_code_case_insensitive(self):
-        """IATA code search is case-insensitive."""
         results = search_airports("jfk")
-        assert len(results) >= 1
-        assert results[0].code == "JFK"
+        assert results[0].code is Airport.JFK
+
+    def test_iata_code_with_surrounding_whitespace(self):
+        results = search_airports("  JFK  ")
+        assert results[0].code is Airport.JFK
+        assert results[0].match_type == "iata_exact"
 
     def test_city_name_new_york(self):
-        """City name 'new york' returns NYC airports."""
-        results = search_airports("new york")
-        codes = [r.code for r in results]
-        assert "JFK" in codes
-        assert "LGA" in codes
-        assert "EWR" in codes
+        codes = {r.code for r in search_airports("new york")}
+        assert {Airport.JFK, Airport.LGA, Airport.EWR} <= codes
 
     def test_city_name_tokyo(self):
-        """City name 'tokyo' returns Tokyo airports."""
-        results = search_airports("tokyo")
-        codes = [r.code for r in results]
-        assert "NRT" in codes
-        assert "HND" in codes
+        codes = {r.code for r in search_airports("tokyo")}
+        assert {Airport.NRT, Airport.HND} <= codes
 
-    def test_city_name_london(self):
-        """City name 'london' returns London airports."""
-        results = search_airports("london")
-        codes = [r.code for r in results]
-        assert "LHR" in codes
-        assert "LGW" in codes
+    def test_city_name_london_returns_all_five(self):
+        codes = {r.code for r in search_airports("london")}
+        assert {Airport.LHR, Airport.LGW, Airport.STN, Airport.LTN, Airport.LCY} <= codes
 
     def test_airport_name_substring(self):
-        """Searching by airport name substring works."""
         results = search_airports("heathrow")
-        assert len(results) >= 1
-        assert results[0].code == "LHR"
+        assert results[0].code is Airport.LHR
+        assert results[0].match_type == "name"
 
-    def test_airport_name_san_francisco(self):
-        """Searching 'san francisco' matches via both city map and name."""
+    def test_san_francisco_dedupes_across_priorities(self):
+        # "san francisco" matches both Priority 2 (city map) and Priority 4
+        # (airport name substring). seen_codes must prevent duplicates.
         results = search_airports("san francisco")
         codes = [r.code for r in results]
-        assert "SFO" in codes
+        assert codes.count(Airport.SFO) == 1
 
     def test_partial_city_name(self):
-        """Partial city name matches."""
-        results = search_airports("new yo")
-        codes = [r.code for r in results]
-        assert "JFK" in codes
+        codes = {r.code for r in search_airports("new yo")}
+        assert Airport.JFK in codes
 
-    def test_iata_prefix(self):
-        """Partial IATA code prefix matches."""
-        results = search_airports("SF")
-        codes = [r.code for r in results]
-        assert "SFO" in codes
+    def test_iata_prefix_distinct_from_exact(self):
+        # "JF" is not an exact IATA code, not a city alias, and not a substring
+        # of any airport name -- so only Priority 5 (iata_prefix) fires.
+        results = search_airports("JF")
+        jfk_match = next(r for r in results if r.code is Airport.JFK)
+        assert jfk_match.match_type == "iata_prefix"
+        assert jfk_match.score == 60.0
+        # All results for this query should be prefix matches.
+        assert all(r.match_type == "iata_prefix" for r in results)
 
     def test_empty_query(self):
-        """Empty query returns empty list."""
         assert search_airports("") == []
         assert search_airports("   ") == []
 
     def test_no_results(self):
-        """Query with no matches returns empty list."""
-        results = search_airports("xyznonexistent")
-        assert results == []
+        assert search_airports("xyznonexistent") == []
 
-    def test_limit(self):
-        """Limit parameter caps results."""
-        results = search_airports("international", limit=3)
-        assert len(results) <= 3
+    def test_invalid_limit_returns_empty(self):
+        assert search_airports("JFK", limit=0) == []
+        assert search_airports("JFK", limit=-1) == []
 
-    def test_code_match_highest_priority(self):
-        """Exact code match scores higher than name match."""
+    def test_limit_caps_results(self):
+        assert len(search_airports("international", limit=3)) <= 3
+
+    def test_default_limit_is_ten(self):
+        # "international" appears in many airport names; default limit is 10.
+        assert len(search_airports("international")) <= 10
+
+    def test_priority_ordering(self):
+        # Exact code (100) must rank above any city/name/prefix match for the same query family.
         results = search_airports("LAX")
-        assert results[0].code == "LAX"
-        assert results[0].match_type == "code"
+        assert results[0].code is Airport.LAX
+        assert results[0].match_type == "iata_exact"
+        # Scores in the returned list must be monotonically non-increasing.
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_priority_3_skipped_when_exact_city_match(self):
+        # When query is an exact city, only Priority 2 (score 90) should fire,
+        # not Priority 3 (score 80). All city-matched results should be 90.
+        results = search_airports("london")
+        city_results = [r for r in results if r.match_type == "city"]
+        assert city_results, "expected at least one city-typed match for 'london'"
+        assert all(r.score == 90.0 for r in city_results)
+
+    def test_name_score_decreases_with_position(self):
+        # The 0.1-per-position weight means a match at position 0 outscores one later.
+        results = search_airports("international")
+        name_matches = [r for r in results if r.match_type == "name"]
+        if len(name_matches) >= 2:
+            scores = [r.score for r in name_matches]
+            assert scores == sorted(scores, reverse=True)
+            assert all(s <= 70.0 for s in scores)
 
     def test_city_abbreviation(self):
-        """City abbreviations work."""
-        results = search_airports("sf")
-        codes = [r.code for r in results]
-        assert "SFO" in codes
+        codes = {r.code for r in search_airports("sf")}
+        assert Airport.SFO in codes
 
     def test_nyc_abbreviation(self):
-        """NYC abbreviation works."""
-        results = search_airports("nyc")
-        codes = [r.code for r in results]
-        assert "JFK" in codes
+        codes = {r.code for r in search_airports("nyc")}
+        assert Airport.JFK in codes
+
+
+class TestAirportMatch:
+    def test_frozen(self):
+        m = AirportMatch(code=Airport.JFK, name="JFK Airport", match_type="iata_exact", score=100.0)
+        try:
+            m.score = 0.0
+        except Exception:
+            return
+        raise AssertionError("AirportMatch should be frozen")
+
+    def test_equality(self):
+        a = AirportMatch(code=Airport.JFK, name="JFK", match_type="city", score=90.0)
+        b = AirportMatch(code=Airport.JFK, name="JFK", match_type="city", score=90.0)
+        assert a == b
+
+    def test_rejects_invalid_match_type(self):
+        try:
+            AirportMatch(code=Airport.JFK, name="JFK", match_type="bogus", score=50.0)  # type: ignore[arg-type]
+        except Exception:
+            return
+        raise AssertionError("AirportMatch should reject unknown match_type")
+
+    def test_rejects_score_out_of_range(self):
+        try:
+            AirportMatch(code=Airport.JFK, name="JFK", match_type="iata_exact", score=101.0)
+        except Exception:
+            return
+        raise AssertionError("AirportMatch should reject score > 100")

--- a/tests/mcp/test_find_airports.py
+++ b/tests/mcp/test_find_airports.py
@@ -1,0 +1,42 @@
+"""Tests for the MCP find_airports tool."""
+
+from fli.mcp.server import _find_airports_impl
+
+
+class TestFindAirports:
+    def test_exact_code_returns_structured_result(self):
+        result = _find_airports_impl("JFK")
+        assert result["success"] is True
+        assert result["query"] == "JFK"
+        assert result["count"] >= 1
+        top = result["airports"][0]
+        assert top["code"] == "JFK"
+        assert top["match_type"] == "iata_exact"
+        assert "name" in top and isinstance(top["name"], str)
+
+    def test_city_query_returns_multiple_airports(self):
+        result = _find_airports_impl("new york")
+        codes = {a["code"] for a in result["airports"]}
+        assert {"JFK", "LGA", "EWR"} <= codes
+        assert all(
+            a["match_type"] == "city"
+            for a in result["airports"]
+            if a["code"] in {"JFK", "LGA", "EWR"}
+        )
+
+    def test_no_results_returns_empty_list_success(self):
+        result = _find_airports_impl("xyznonexistent")
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["airports"] == []
+
+    def test_limit_caps_results(self):
+        result = _find_airports_impl("international", limit=3)
+        assert len(result["airports"]) <= 3
+        assert result["count"] == len(result["airports"])
+
+    def test_invalid_limit_returns_empty_success(self):
+        # _find_airports_impl forwards limit; search_airports handles <1 by returning [].
+        result = _find_airports_impl("JFK", limit=0)
+        assert result["success"] is True
+        assert result["count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "flights"
-version = "0.8.4"
+version = "0.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary

Follow-ups to #115 that lock in the right shape for the day-old `AirportMatch` public API while it still has no external consumers, plus defensive hardening and the test coverage that #115 was missing.

## Breaking changes (in `fli.core.airports`)

**`AirportMatch` is now a frozen Pydantic `BaseModel`:**
- `code: Airport` (enum, was `str`)
- `match_type: Literal["iata_exact", "iata_prefix", "city", "name"]`
- `score: float = Field(ge=0, le=100)`

**`match_type` no longer overloads `"code"`:**
- Priority 1 (exact IATA, score 100) -> `"iata_exact"`
- Priority 5 (prefix IATA, score 60) -> `"iata_prefix"`

Previously both used `"code"`, so consumers had to inspect `score` to tell exact from prefix.

CLI and MCP consumers (`r.code.name` for the IATA string) are updated accordingly.

## Defensive hardening

- **`CITY_AIRPORTS` is validated at import time.** A typo like `JKF` for `JFK` would previously be swallowed by `except KeyError: pass` in priorities 2/3 and silently shrink results. Now it raises `RuntimeError` immediately. The silent guards in priorities 2 and 3 are removed.
- **`find_airports` MCP tool now wraps `search_airports` in `try/except`**, returning `{success: False, error, query}` on exception -- matching the envelope used by `search_flights` and `search_dates`.

## Docs

- Rewrote the misleading `CITY_AIRPORTS` module comment. The original claim that "city is NOT in the airport name" was false for many entries (atlanta, denver, seattle, miami, berlin, melbourne, sydney, singapore -- their airport names *do* contain the city).
- `search_airports` docstring now documents the 5-priority cascade and score bands.

## Tests (+19 net)

- `tests/core/test_airports.py` -- rewrote for new shape; added coverage for `limit<1`, surrounding whitespace, dedup across priorities (`san francisco` matches both city map and name substring), priority-3 skip when query is an exact city, monotonic score ordering, position-based scoring, and `AirportMatch` frozen/equality/validation behaviour.
- `tests/mcp/test_find_airports.py` (new) -- MCP tool response shape, success/error envelope, limit capping, no-results.
- `tests/cli/test_airports.py` (new) -- `CliRunner` coverage for table output, `--json` flag, no-results exit code, `--limit`.

Total suite: **220 passing** (was 201 on `main`).

## Test plan

- [x] `uv run ruff format . --check && uv run ruff check .` -> clean
- [x] `uv run pytest tests/ --all -v --ignore=tests/search/` -> 220 passed
- [ ] CI on this branch reproduces the same green run
- [ ] Sanity-check the `find_airports` MCP tool against an AI assistant by querying a city + an IATA code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the `AirportMatch` public API by converting it to a frozen Pydantic `BaseModel`, renames `match_type` values (`"code"` → `"iata_exact"` / `"iata_prefix"`), adds import-time validation of `CITY_AIRPORTS` against the `Airport` enum, wraps the MCP `find_airports` tool in a `try/except` error envelope, and ships the test coverage that was missing from #115.

- **`AirportMatch` is now a frozen Pydantic model** with `code: Airport`, `match_type: Literal[...]`, and `score: float = Field(ge=0, le=100)`; CLI and MCP consumers updated to use `r.code.name` for the IATA string.
- **Import-time `CITY_AIRPORTS` validation** replaces the silent `except KeyError: pass` guards in priorities 2/3, so a typo in the map raises `RuntimeError` immediately rather than shrinking results silently.
- **19 new tests** cover priority ordering, dedup across priorities, score monotonicity, `AirportMatch` frozen/equality/validation behavior, MCP response envelope, and CLI `--json` / `--limit` flags.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the import-time validation and Pydantic model hardening are straightforward improvements with good test coverage.

The changes are well-scoped and the logic is sound. The only code concern is that `70.0 - (pos * 0.1)` in Priority 4 has no explicit lower-bound clamp, meaning a sufficiently large match position would produce a score below `0.0` and trip the Pydantic `ge=0.0` constraint — converting `search_airports` into an unexpected exception in the CLI path. In practice no real IATA airport name is anywhere near long enough to trigger this, but the formula lacks the `max(0.0, ...)` guard that would make the invariant self-enforcing.

fli/core/airports.py — score formula in Priority 4; tests/core/test_airports.py — TestAirportMatch validation tests use bare try/except instead of pytest.raises.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/core/airports.py | Core refactor: AirportMatch promoted to a frozen Pydantic model, match_type values renamed, import-time CITY_AIRPORTS validation added, and silent KeyError guards removed. Score formula has a theoretical lower-bound gap (pos > 700) that would trip Pydantic's ge=0.0 constraint. |
| fli/mcp/server.py | Extracted _find_airports_impl helper with try/except envelope, aligning error shape with search_flights and search_dates. r.code → r.code.name update is correct. |
| fli/cli/commands/airports.py | Updated r.code → r.code.name in both JSON output and table row; straightforward adaptation to the new Airport enum field type. |
| tests/core/test_airports.py | Tests rewritten for new AirportMatch shape; good new coverage for dedup, priority ordering, and score bands. TestAirportMatch validation tests use try/except Exception instead of pytest.raises, which silently passes on any exception type. |
| tests/mcp/test_find_airports.py | New MCP test file testing _find_airports_impl directly; covers success envelope, city query, no-results, limit capping, and invalid limit. Clean and thorough. |
| tests/cli/test_airports.py | New CLI test file with CliRunner coverage for table output, --json flag, no-results exit code, and --limit; straightforward and well-scoped. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["search_airports(query, limit)"] --> B{empty or limit lt 1?}
    B -- Yes --> Z["return []"]
    B -- No --> P1
    P1["P1: Exact IATA\nscore=100, iata_exact"] --> P2
    P2["P2: Exact city lookup\nscore=90, city"] --> P3
    P3{query in CITY_AIRPORTS?}
    P3 -- No --> P3b["P3: Prefix city match\nscore=80, city"]
    P3 -- Yes --> P4
    P3b --> P4
    P4["P4: Airport name substring\nscore=70-pos*0.1, name"] --> P5
    P5{len query_upper <= 3?}
    P5 -- Yes --> P5b["P5: IATA prefix\nscore=60, iata_prefix"]
    P5 -- No --> SORT
    P5b --> SORT
    SORT["Sort by -score then code.name\nslice to limit"] --> OUT["list of AirportMatch"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afli%2Fcore%2Fairports.py%3A157-158%0AThe%20position-based%20score%20formula%20has%20no%20lower-bound%20guard.%20%6070.0%20-%20%28pos%20*%200.1%29%60%20becomes%20negative%20when%20%60pos%20%3E%20700%60.%20While%20no%20real%20IATA%20airport%20name%20is%20that%20long%20today%2C%20Pydantic's%20%60ge%3D0.0%60%20constraint%20on%20%60score%60%20would%20raise%20a%20%60ValidationError%60%20the%20moment%20it%20happens%2C%20turning%20%60search_airports%60%20into%20an%20unexpected%20exception%20in%20the%20CLI%20layer%20%28the%20MCP%20layer%20would%20catch%20it%20via%20%60_find_airports_impl%60's%20try%2Fexcept%29.%20A%20%60max%28%29%60%20clamp%20costs%20nothing%20and%20makes%20the%20invariant%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pos%20%3D%20airport_name_lower.find%28query_lower%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20max%280.0%2C%2070.0%20-%20%28pos%20*%200.1%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fcore%2Ftest_airports.py%3A116-141%0AThese%20three%20%60TestAirportMatch%60%20tests%20use%20a%20%60try%2Fexcept%20Exception%3A%20return%60%20pattern%20rather%20than%20%60pytest.raises%60.%20The%20problem%20is%20that%20the%20pattern%20passes%20for%20*any*%20exception%20%E2%80%94%20if%20Pydantic%20raises%20%28say%29%20an%20internal%20%60ImportError%60%20or%20a%20%60TypeError%60%20for%20an%20unrelated%20reason%2C%20the%20test%20silently%20greens.%20Using%20%60pytest.raises%60%20also%20pins%20the%20expected%20exception%20type%20and%20gives%20a%20cleaner%20failure%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20test_frozen%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20m%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%20Airport%22%2C%20match_type%3D%22iata_exact%22%2C%20score%3D100.0%29%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28Exception%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20m.score%20%3D%200.0%0A%0A%20%20%20%20def%20test_equality%28self%29%3A%0A%20%20%20%20%20%20%20%20a%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22city%22%2C%20score%3D90.0%29%0A%20%20%20%20%20%20%20%20b%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22city%22%2C%20score%3D90.0%29%0A%20%20%20%20%20%20%20%20assert%20a%20%3D%3D%20b%0A%0A%20%20%20%20def%20test_rejects_invalid_match_type%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28ValidationError%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22bogus%22%2C%20score%3D50.0%29%20%20%23%20type%3A%20ignore%5Barg-type%5D%0A%0A%20%20%20%20def%20test_rejects_score_out_of_range%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28ValidationError%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22iata_exact%22%2C%20score%3D101.0%29%0A%60%60%60%0A%0A&repo=punitarani%2Ffli&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afli%2Fcore%2Fairports.py%3A157-158%0AThe%20position-based%20score%20formula%20has%20no%20lower-bound%20guard.%20%6070.0%20-%20%28pos%20*%200.1%29%60%20becomes%20negative%20when%20%60pos%20%3E%20700%60.%20While%20no%20real%20IATA%20airport%20name%20is%20that%20long%20today%2C%20Pydantic's%20%60ge%3D0.0%60%20constraint%20on%20%60score%60%20would%20raise%20a%20%60ValidationError%60%20the%20moment%20it%20happens%2C%20turning%20%60search_airports%60%20into%20an%20unexpected%20exception%20in%20the%20CLI%20layer%20%28the%20MCP%20layer%20would%20catch%20it%20via%20%60_find_airports_impl%60's%20try%2Fexcept%29.%20A%20%60max%28%29%60%20clamp%20costs%20nothing%20and%20makes%20the%20invariant%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pos%20%3D%20airport_name_lower.find%28query_lower%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20max%280.0%2C%2070.0%20-%20%28pos%20*%200.1%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fcore%2Ftest_airports.py%3A116-141%0AThese%20three%20%60TestAirportMatch%60%20tests%20use%20a%20%60try%2Fexcept%20Exception%3A%20return%60%20pattern%20rather%20than%20%60pytest.raises%60.%20The%20problem%20is%20that%20the%20pattern%20passes%20for%20*any*%20exception%20%E2%80%94%20if%20Pydantic%20raises%20%28say%29%20an%20internal%20%60ImportError%60%20or%20a%20%60TypeError%60%20for%20an%20unrelated%20reason%2C%20the%20test%20silently%20greens.%20Using%20%60pytest.raises%60%20also%20pins%20the%20expected%20exception%20type%20and%20gives%20a%20cleaner%20failure%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20test_frozen%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20m%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%20Airport%22%2C%20match_type%3D%22iata_exact%22%2C%20score%3D100.0%29%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28Exception%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20m.score%20%3D%200.0%0A%0A%20%20%20%20def%20test_equality%28self%29%3A%0A%20%20%20%20%20%20%20%20a%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22city%22%2C%20score%3D90.0%29%0A%20%20%20%20%20%20%20%20b%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22city%22%2C%20score%3D90.0%29%0A%20%20%20%20%20%20%20%20assert%20a%20%3D%3D%20b%0A%0A%20%20%20%20def%20test_rejects_invalid_match_type%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28ValidationError%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22bogus%22%2C%20score%3D50.0%29%20%20%23%20type%3A%20ignore%5Barg-type%5D%0A%0A%20%20%20%20def%20test_rejects_score_out_of_range%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28ValidationError%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22iata_exact%22%2C%20score%3D101.0%29%0A%60%60%60%0A%0A&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22airport-search-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22airport-search-followups%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Afli%2Fcore%2Fairports.py%3A157-158%0AThe%20position-based%20score%20formula%20has%20no%20lower-bound%20guard.%20%6070.0%20-%20%28pos%20*%200.1%29%60%20becomes%20negative%20when%20%60pos%20%3E%20700%60.%20While%20no%20real%20IATA%20airport%20name%20is%20that%20long%20today%2C%20Pydantic's%20%60ge%3D0.0%60%20constraint%20on%20%60score%60%20would%20raise%20a%20%60ValidationError%60%20the%20moment%20it%20happens%2C%20turning%20%60search_airports%60%20into%20an%20unexpected%20exception%20in%20the%20CLI%20layer%20%28the%20MCP%20layer%20would%20catch%20it%20via%20%60_find_airports_impl%60's%20try%2Fexcept%29.%20A%20%60max%28%29%60%20clamp%20costs%20nothing%20and%20makes%20the%20invariant%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20pos%20%3D%20airport_name_lower.find%28query_lower%29%0A%20%20%20%20%20%20%20%20%20%20%20%20score%20%3D%20max%280.0%2C%2070.0%20-%20%28pos%20*%200.1%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fcore%2Ftest_airports.py%3A116-141%0AThese%20three%20%60TestAirportMatch%60%20tests%20use%20a%20%60try%2Fexcept%20Exception%3A%20return%60%20pattern%20rather%20than%20%60pytest.raises%60.%20The%20problem%20is%20that%20the%20pattern%20passes%20for%20*any*%20exception%20%E2%80%94%20if%20Pydantic%20raises%20%28say%29%20an%20internal%20%60ImportError%60%20or%20a%20%60TypeError%60%20for%20an%20unrelated%20reason%2C%20the%20test%20silently%20greens.%20Using%20%60pytest.raises%60%20also%20pins%20the%20expected%20exception%20type%20and%20gives%20a%20cleaner%20failure%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20test_frozen%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20m%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%20Airport%22%2C%20match_type%3D%22iata_exact%22%2C%20score%3D100.0%29%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28Exception%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20m.score%20%3D%200.0%0A%0A%20%20%20%20def%20test_equality%28self%29%3A%0A%20%20%20%20%20%20%20%20a%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22city%22%2C%20score%3D90.0%29%0A%20%20%20%20%20%20%20%20b%20%3D%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22city%22%2C%20score%3D90.0%29%0A%20%20%20%20%20%20%20%20assert%20a%20%3D%3D%20b%0A%0A%20%20%20%20def%20test_rejects_invalid_match_type%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28ValidationError%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22bogus%22%2C%20score%3D50.0%29%20%20%23%20type%3A%20ignore%5Barg-type%5D%0A%0A%20%20%20%20def%20test_rejects_score_out_of_range%28self%29%3A%0A%20%20%20%20%20%20%20%20import%20pytest%0A%20%20%20%20%20%20%20%20from%20pydantic%20import%20ValidationError%0A%0A%20%20%20%20%20%20%20%20with%20pytest.raises%28ValidationError%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20AirportMatch%28code%3DAirport.JFK%2C%20name%3D%22JFK%22%2C%20match_type%3D%22iata_exact%22%2C%20score%3D101.0%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
fli/core/airports.py:157-158
The position-based score formula has no lower-bound guard. `70.0 - (pos * 0.1)` becomes negative when `pos > 700`. While no real IATA airport name is that long today, Pydantic's `ge=0.0` constraint on `score` would raise a `ValidationError` the moment it happens, turning `search_airports` into an unexpected exception in the CLI layer (the MCP layer would catch it via `_find_airports_impl`'s try/except). A `max()` clamp costs nothing and makes the invariant self-documenting.

```suggestion
            pos = airport_name_lower.find(query_lower)
            score = max(0.0, 70.0 - (pos * 0.1))
```

### Issue 2 of 2
tests/core/test_airports.py:116-141
These three `TestAirportMatch` tests use a `try/except Exception: return` pattern rather than `pytest.raises`. The problem is that the pattern passes for *any* exception — if Pydantic raises (say) an internal `ImportError` or a `TypeError` for an unrelated reason, the test silently greens. Using `pytest.raises` also pins the expected exception type and gives a cleaner failure message.

```suggestion
    def test_frozen(self):
        import pytest
        from pydantic import ValidationError

        m = AirportMatch(code=Airport.JFK, name="JFK Airport", match_type="iata_exact", score=100.0)
        with pytest.raises(Exception):
            m.score = 0.0

    def test_equality(self):
        a = AirportMatch(code=Airport.JFK, name="JFK", match_type="city", score=90.0)
        b = AirportMatch(code=Airport.JFK, name="JFK", match_type="city", score=90.0)
        assert a == b

    def test_rejects_invalid_match_type(self):
        import pytest
        from pydantic import ValidationError

        with pytest.raises(ValidationError):
            AirportMatch(code=Airport.JFK, name="JFK", match_type="bogus", score=50.0)  # type: ignore[arg-type]

    def test_rejects_score_out_of_range(self):
        import pytest
        from pydantic import ValidationError

        with pytest.raises(ValidationError):
            AirportMatch(code=Airport.JFK, name="JFK", match_type="iata_exact", score=101.0)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: harden airport search with Pyd..."](https://github.com/punitarani/fli/commit/c63037c7e2865ca6742d6eb905cc99bdf96e7349) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31734015)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->