### PR TITLE
fix: disambiguate duplicate Airport/Airline enum names

### DIFF
--- a/scripts/generate_enums.py
+++ b/scripts/generate_enums.py
@@ -28,9 +28,31 @@ iteration) is identical to the previous form.
 """
 
 import csv
+from collections import Counter
 from pathlib import Path
 
 PROJECT_DIR = Path(__file__).parents[1].resolve()
+
+
+def _disambiguate_names(entries: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Append IATA codes to duplicate names so every Enum value is unique.
+
+    Python's ``Enum`` treats members with the same value as aliases — the
+    second silently becomes an alias for the first.  This function detects
+    duplicate human-readable names and appends `` (CODE)`` to *all*
+    members of each duplicate group (including the first) so every entry
+    gets its own distinct Enum member.
+
+    Entries with unique names are left untouched.
+    """
+    name_counts = Counter(name for _, name in entries)
+    duplicates = {name for name, count in name_counts.items() if count > 1}
+    if not duplicates:
+        return entries
+    return [
+        (code, f"{name} ({code})" if name in duplicates else name)
+        for code, name in entries
+    ]
 
 
 def _sanitize_code(code: str, allow_digit_prefix: bool = False) -> str:
@@ -116,6 +138,7 @@ def generate_airport_enum() -> None:
     except (KeyError, csv.Error) as e:
         raise ValueError(f"Error reading CSV file: {e}") from e
 
+    entries = _disambiguate_names(entries)
     _write_enum_module(
         out_path,
         enum_name="Airport",
@@ -159,6 +182,7 @@ def generate_airline_enum() -> None:
         ]
     )
 
+    entries = _disambiguate_names(entries)
     _write_enum_module(
         out_path,
         enum_name="Airline",

--- a/scripts/generate_enums.py
+++ b/scripts/generate_enums.py
@@ -49,10 +49,7 @@ def _disambiguate_names(entries: list[tuple[str, str]]) -> list[tuple[str, str]]
     duplicates = {name for name, count in name_counts.items() if count > 1}
     if not duplicates:
         return entries
-    return [
-        (code, f"{name} ({code})" if name in duplicates else name)
-        for code, name in entries
-    ]
+    return [(code, f"{name} ({code})" if name in duplicates else name) for code, name in entries]
 
 
 def _sanitize_code(code: str, allow_digit_prefix: bool = False) -> str:


### PR DESCRIPTION
## Problem

Python's `Enum` treats members with the same value as **aliases** — the second silently becomes an alias for the first. The `Airport` enum has **44 groups of duplicate names** (90+ IATA codes affected), causing `Airport.TRI` to resolve to `Airport.PSC`.

This means searching from Bristol, TN actually searches from Pasco, WA — returning completely wrong results.

**Reproduction:**
```python
from fli.models import Airport

print(Airport.TRI)        # Airport.PSC  (wrong!)
print(Airport.TRI.name)   # PSC          (wrong!)
```

**Impact:** All 44 duplicate groups are affected, including:
- `TRI → PSC` (Tri-Cities Airport)
- `NCL → NCS` (Newcastle Airport)
- `AID → AND` (Anderson Regional Airport)
- ... and 40+ more groups

Fixes #131
Fixes #146

## Solution

Added `_disambiguate_names()` to `scripts/generate_enums.py` that:
1. Counts occurrences of each human-readable name
2. Appends ` (IATA_CODE)` to all members of each duplicate group
3. Leaves unique names untouched

**Before (broken):**
```python
PSC = "Tri-Cities Airport"
TRI = "Tri-Cities Airport"   # silently becomes alias for PSC
```

**After (fixed):**
```python
PSC = "Tri-Cities Airport (PSC)"
TRI = "Tri-Cities Airport (TRI)"
```

After merging, run `python scripts/generate_enums.py` to regenerate `airport.py` and `airline.py`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing enum aliasing bug where 44 groups of airports (and some airlines) shared the same human-readable name, causing Python's `Enum` to silently treat the second member as an alias for the first. The fix adds `_disambiguate_names()` to the code generator and calls it for both `Airport` and `Airline` enums.

- The generator logic is correct: it detects duplicate names via `Counter`, then appends `(IATA_CODE)` to every member of each duplicate group so all enum values are unique after regeneration.
- The generated model files (`fli/models/airport.py`, `fli/models/airline.py`) are tracked in git but are **not** regenerated and committed in this PR, so `Airport.TRI` still resolves to `Airport.PSC` in the current tree — the bug remains live for anyone installing from this commit.
- A minor edge case exists where the disambiguated name `"Foo (A)"` could collide with a pre-existing entry whose original name happened to be `"Foo (A)"`; a post-pass uniqueness check would guard against this.

<h3>Confidence Score: 3/5</h3>

Merging as-is does not resolve the user-facing bug; the committed model files still contain the duplicate values that cause wrong airport lookups.

The generator change is correct in isolation, but fli/models/airport.py and fli/models/airline.py are not regenerated. Both are tracked in git and still carry duplicate Tri-Cities Airport entries, so Airport.TRI would still resolve to Airport.PSC after this merge.

fli/models/airport.py and fli/models/airline.py must be regenerated and committed to actually ship the fix.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/generate_enums.py | Adds _disambiguate_names() and calls it before generating Airport and Airline enums — logic is correct, but the generated output files are not committed, so the bug is still present in the shipped library. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Read CSV entries\ncode, name pairs] --> B[Counter: count each name]
    B --> C{Any name\nappears > 1 time?}
    C -- No --> D[Return entries unchanged]
    C -- Yes --> E[Build duplicates set]
    E --> F[For each entry:\nname in duplicates?]
    F -- Yes --> G[Emit: name + IATA code]
    F -- No --> H[Emit: original name]
    G --> I[_write_enum_module]
    H --> I
    I --> J[Write AIRPORT_NAMES dict\nto airport.py]
    J --> K[Enum constructed\nfrom dict - no aliases]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/generate_enums.py`, line 141-148 ([link](https://github.com/punitarani/fli/blob/0c60047ac6568f0e02632da9f3149046f88ca88f/scripts/generate_enums.py#L141-L148)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Generated files not committed — bug still live in the library**

   The fix is only applied to the generator script, but `fli/models/airport.py` and `fli/models/airline.py` (which are committed, tracked files) have not been regenerated. A `grep` on the current `airport.py` confirms the duplicate still exists: `"PSC": "Tri-Cities Airport"` at line 5386 and `"TRI": "Tri-Cities Airport"` at line 6697. Any user who installs from the merged commit — whether from PyPI or from the repo directly — will still see `Airport.TRI` resolve to `Airport.PSC` until someone manually runs the script and commits the result. The generated files must be regenerated and included in this PR to actually ship the fix.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/generate_enums.py
   Line: 141-148

   Comment:
   **Generated files not committed — bug still live in the library**

   The fix is only applied to the generator script, but `fli/models/airport.py` and `fli/models/airline.py` (which are committed, tracked files) have not been regenerated. A `grep` on the current `airport.py` confirms the duplicate still exists: `"PSC": "Tri-Cities Airport"` at line 5386 and `"TRI": "Tri-Cities Airport"` at line 6697. Any user who installs from the merged commit — whether from PyPI or from the repo directly — will still see `Airport.TRI` resolve to `Airport.PSC` until someone manually runs the script and commits the result. The generated files must be regenerated and included in this PR to actually ship the fix.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fgenerate_enums.py%0ALine%3A%20141-148%0A%0AComment%3A%0A**Generated%20files%20not%20committed%20%E2%80%94%20bug%20still%20live%20in%20the%20library**%0A%0AThe%20fix%20is%20only%20applied%20to%20the%20generator%20script%2C%20but%20%60fli%2Fmodels%2Fairport.py%60%20and%20%60fli%2Fmodels%2Fairline.py%60%20%28which%20are%20committed%2C%20tracked%20files%29%20have%20not%20been%20regenerated.%20A%20%60grep%60%20on%20the%20current%20%60airport.py%60%20confirms%20the%20duplicate%20still%20exists%3A%20%60%22PSC%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%205386%20and%20%60%22TRI%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%206697.%20Any%20user%20who%20installs%20from%20the%20merged%20commit%20%E2%80%94%20whether%20from%20PyPI%20or%20from%20the%20repo%20directly%20%E2%80%94%20will%20still%20see%20%60Airport.TRI%60%20resolve%20to%20%60Airport.PSC%60%20until%20someone%20manually%20runs%20the%20script%20and%20commits%20the%20result.%20The%20generated%20files%20must%20be%20regenerated%20and%20included%20in%20this%20PR%20to%20actually%20ship%20the%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fgenerate_enums.py%0ALine%3A%20141-148%0A%0AComment%3A%0A**Generated%20files%20not%20committed%20%E2%80%94%20bug%20still%20live%20in%20the%20library**%0A%0AThe%20fix%20is%20only%20applied%20to%20the%20generator%20script%2C%20but%20%60fli%2Fmodels%2Fairport.py%60%20and%20%60fli%2Fmodels%2Fairline.py%60%20%28which%20are%20committed%2C%20tracked%20files%29%20have%20not%20been%20regenerated.%20A%20%60grep%60%20on%20the%20current%20%60airport.py%60%20confirms%20the%20duplicate%20still%20exists%3A%20%60%22PSC%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%205386%20and%20%60%22TRI%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%206697.%20Any%20user%20who%20installs%20from%20the%20merged%20commit%20%E2%80%94%20whether%20from%20PyPI%20or%20from%20the%20repo%20directly%20%E2%80%94%20will%20still%20see%20%60Airport.TRI%60%20resolve%20to%20%60Airport.PSC%60%20until%20someone%20manually%20runs%20the%20script%20and%20commits%20the%20result.%20The%20generated%20files%20must%20be%20regenerated%20and%20included%20in%20this%20PR%20to%20actually%20ship%20the%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=punitarani%2Ffli&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Fairport-enum-aliases%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fairport-enum-aliases%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fgenerate_enums.py%0ALine%3A%20141-148%0A%0AComment%3A%0A**Generated%20files%20not%20committed%20%E2%80%94%20bug%20still%20live%20in%20the%20library**%0A%0AThe%20fix%20is%20only%20applied%20to%20the%20generator%20script%2C%20but%20%60fli%2Fmodels%2Fairport.py%60%20and%20%60fli%2Fmodels%2Fairline.py%60%20%28which%20are%20committed%2C%20tracked%20files%29%20have%20not%20been%20regenerated.%20A%20%60grep%60%20on%20the%20current%20%60airport.py%60%20confirms%20the%20duplicate%20still%20exists%3A%20%60%22PSC%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%205386%20and%20%60%22TRI%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%206697.%20Any%20user%20who%20installs%20from%20the%20merged%20commit%20%E2%80%94%20whether%20from%20PyPI%20or%20from%20the%20repo%20directly%20%E2%80%94%20will%20still%20see%20%60Airport.TRI%60%20resolve%20to%20%60Airport.PSC%60%20until%20someone%20manually%20runs%20the%20script%20and%20commits%20the%20result.%20The%20generated%20files%20must%20be%20regenerated%20and%20included%20in%20this%20PR%20to%20actually%20ship%20the%20fix.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fgenerate_enums.py%3A141-148%0A**Generated%20files%20not%20committed%20%E2%80%94%20bug%20still%20live%20in%20the%20library**%0A%0AThe%20fix%20is%20only%20applied%20to%20the%20generator%20script%2C%20but%20%60fli%2Fmodels%2Fairport.py%60%20and%20%60fli%2Fmodels%2Fairline.py%60%20%28which%20are%20committed%2C%20tracked%20files%29%20have%20not%20been%20regenerated.%20A%20%60grep%60%20on%20the%20current%20%60airport.py%60%20confirms%20the%20duplicate%20still%20exists%3A%20%60%22PSC%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%205386%20and%20%60%22TRI%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%206697.%20Any%20user%20who%20installs%20from%20the%20merged%20commit%20%E2%80%94%20whether%20from%20PyPI%20or%20from%20the%20repo%20directly%20%E2%80%94%20will%20still%20see%20%60Airport.TRI%60%20resolve%20to%20%60Airport.PSC%60%20until%20someone%20manually%20runs%20the%20script%20and%20commits%20the%20result.%20The%20generated%20files%20must%20be%20regenerated%20and%20included%20in%20this%20PR%20to%20actually%20ship%20the%20fix.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fgenerate_enums.py%3A48-55%0A**Disambiguation%20can%20produce%20a%20new%20collision%20with%20a%20pre-existing%20name**%0A%0AIf%20an%20entry's%20original%20name%20already%20equals%20the%20post-disambiguation%20form%20of%20another%20entry%20%E2%80%94%20e.g.%20original%20name%20%60%22Foo%20%28A%29%22%60%20%28unique%29%20alongside%20two%20entries%20named%20%60%22Foo%22%60%20with%20codes%20%60%22A%22%60%20and%20%60%22B%22%60%20%E2%80%94%20then%20after%20disambiguation%20%60%22Foo%22%60%20%28code%20%60%22A%22%60%29%20becomes%20%60%22Foo%20%28A%29%22%60%2C%20colliding%20with%20the%20pre-existing%20entry.%20The%20function%20would%20silently%20create%20a%20new%20alias%20rather%20than%20fully%20resolving%20uniqueness.%20A%20second-pass%20uniqueness%20assertion%20%28or%20a%20recursive%20re-check%29%20would%20catch%20this%20before%20writing%20the%20file.%0A%0A&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fgenerate_enums.py%3A141-148%0A**Generated%20files%20not%20committed%20%E2%80%94%20bug%20still%20live%20in%20the%20library**%0A%0AThe%20fix%20is%20only%20applied%20to%20the%20generator%20script%2C%20but%20%60fli%2Fmodels%2Fairport.py%60%20and%20%60fli%2Fmodels%2Fairline.py%60%20%28which%20are%20committed%2C%20tracked%20files%29%20have%20not%20been%20regenerated.%20A%20%60grep%60%20on%20the%20current%20%60airport.py%60%20confirms%20the%20duplicate%20still%20exists%3A%20%60%22PSC%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%205386%20and%20%60%22TRI%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%206697.%20Any%20user%20who%20installs%20from%20the%20merged%20commit%20%E2%80%94%20whether%20from%20PyPI%20or%20from%20the%20repo%20directly%20%E2%80%94%20will%20still%20see%20%60Airport.TRI%60%20resolve%20to%20%60Airport.PSC%60%20until%20someone%20manually%20runs%20the%20script%20and%20commits%20the%20result.%20The%20generated%20files%20must%20be%20regenerated%20and%20included%20in%20this%20PR%20to%20actually%20ship%20the%20fix.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fgenerate_enums.py%3A48-55%0A**Disambiguation%20can%20produce%20a%20new%20collision%20with%20a%20pre-existing%20name**%0A%0AIf%20an%20entry's%20original%20name%20already%20equals%20the%20post-disambiguation%20form%20of%20another%20entry%20%E2%80%94%20e.g.%20original%20name%20%60%22Foo%20%28A%29%22%60%20%28unique%29%20alongside%20two%20entries%20named%20%60%22Foo%22%60%20with%20codes%20%60%22A%22%60%20and%20%60%22B%22%60%20%E2%80%94%20then%20after%20disambiguation%20%60%22Foo%22%60%20%28code%20%60%22A%22%60%29%20becomes%20%60%22Foo%20%28A%29%22%60%2C%20colliding%20with%20the%20pre-existing%20entry.%20The%20function%20would%20silently%20create%20a%20new%20alias%20rather%20than%20fully%20resolving%20uniqueness.%20A%20second-pass%20uniqueness%20assertion%20%28or%20a%20recursive%20re-check%29%20would%20catch%20this%20before%20writing%20the%20file.%0A%0A&repo=punitarani%2Ffli&pr=160&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Fairport-enum-aliases%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fairport-enum-aliases%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fgenerate_enums.py%3A141-148%0A**Generated%20files%20not%20committed%20%E2%80%94%20bug%20still%20live%20in%20the%20library**%0A%0AThe%20fix%20is%20only%20applied%20to%20the%20generator%20script%2C%20but%20%60fli%2Fmodels%2Fairport.py%60%20and%20%60fli%2Fmodels%2Fairline.py%60%20%28which%20are%20committed%2C%20tracked%20files%29%20have%20not%20been%20regenerated.%20A%20%60grep%60%20on%20the%20current%20%60airport.py%60%20confirms%20the%20duplicate%20still%20exists%3A%20%60%22PSC%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%205386%20and%20%60%22TRI%22%3A%20%22Tri-Cities%20Airport%22%60%20at%20line%206697.%20Any%20user%20who%20installs%20from%20the%20merged%20commit%20%E2%80%94%20whether%20from%20PyPI%20or%20from%20the%20repo%20directly%20%E2%80%94%20will%20still%20see%20%60Airport.TRI%60%20resolve%20to%20%60Airport.PSC%60%20until%20someone%20manually%20runs%20the%20script%20and%20commits%20the%20result.%20The%20generated%20files%20must%20be%20regenerated%20and%20included%20in%20this%20PR%20to%20actually%20ship%20the%20fix.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fgenerate_enums.py%3A48-55%0A**Disambiguation%20can%20produce%20a%20new%20collision%20with%20a%20pre-existing%20name**%0A%0AIf%20an%20entry's%20original%20name%20already%20equals%20the%20post-disambiguation%20form%20of%20another%20entry%20%E2%80%94%20e.g.%20original%20name%20%60%22Foo%20%28A%29%22%60%20%28unique%29%20alongside%20two%20entries%20named%20%60%22Foo%22%60%20with%20codes%20%60%22A%22%60%20and%20%60%22B%22%60%20%E2%80%94%20then%20after%20disambiguation%20%60%22Foo%22%60%20%28code%20%60%22A%22%60%29%20becomes%20%60%22Foo%20%28A%29%22%60%2C%20colliding%20with%20the%20pre-existing%20entry.%20The%20function%20would%20silently%20create%20a%20new%20alias%20rather%20than%20fully%20resolving%20uniqueness.%20A%20second-pass%20uniqueness%20assertion%20%28or%20a%20recursive%20re-check%29%20would%20catch%20this%20before%20writing%20the%20file.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/generate_enums.py:141-148
**Generated files not committed — bug still live in the library**

The fix is only applied to the generator script, but `fli/models/airport.py` and `fli/models/airline.py` (which are committed, tracked files) have not been regenerated. A `grep` on the current `airport.py` confirms the duplicate still exists: `"PSC": "Tri-Cities Airport"` at line 5386 and `"TRI": "Tri-Cities Airport"` at line 6697. Any user who installs from the merged commit — whether from PyPI or from the repo directly — will still see `Airport.TRI` resolve to `Airport.PSC` until someone manually runs the script and commits the result. The generated files must be regenerated and included in this PR to actually ship the fix.

### Issue 2 of 2
scripts/generate_enums.py:48-55
**Disambiguation can produce a new collision with a pre-existing name**

If an entry's original name already equals the post-disambiguation form of another entry — e.g. original name `"Foo (A)"` (unique) alongside two entries named `"Foo"` with codes `"A"` and `"B"` — then after disambiguation `"Foo"` (code `"A"`) becomes `"Foo (A)"`, colliding with the pre-existing entry. The function would silently create a new alias rather than fully resolving uniqueness. A second-pass uniqueness assertion (or a recursive re-check) would catch this before writing the file.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: disambiguate duplicate Airport/Airl..."](https://github.com/punitarani/fli/commit/0c60047ac6568f0e02632da9f3149046f88ca88f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32420608)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->