### PR TITLE
Add configurable request timeout to HTTP client

### DIFF
--- a/fli/search/client.py
+++ b/fli/search/client.py
@@ -20,6 +20,7 @@ callers cooperate cleanly under Google's 10 req/sec ceiling.
 
 from __future__ import annotations
 
+import os
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,11 @@ _client_lock = threading.Lock()
 
 # Google's published ceiling.
 DEFAULT_CALLS_PER_SECOND = 10
+
+# Request timeout in seconds.  Override with the FLI_TIMEOUT env var.
+DEFAULT_TIMEOUT = 60
+_env_timeout = os.environ.get("FLI_TIMEOUT")
+REQUEST_TIMEOUT: float = float(_env_timeout) if _env_timeout else DEFAULT_TIMEOUT
 
 
 class Client:
@@ -105,6 +111,7 @@ class Client:
     def get(self, url: str, **kwargs: Any) -> Response:
         """Make a rate-limited GET request with automatic retries."""
         self._rate_limiter.acquire()
+        kwargs.setdefault("timeout", REQUEST_TIMEOUT)
         try:
             response = self._session().get(url, **kwargs)
             response.raise_for_status()
@@ -116,6 +123,7 @@ class Client:
     def post(self, url: str, **kwargs: Any) -> Response:
         """Make a rate-limited POST request with automatic retries."""
         self._rate_limiter.acquire()
+        kwargs.setdefault("timeout", REQUEST_TIMEOUT)
         try:
             response = self._session().post(url, **kwargs)
             response.raise_for_status()

--- a/fli/search/client.py
+++ b/fli/search/client.py
@@ -53,9 +53,18 @@ _client_lock = threading.Lock()
 DEFAULT_CALLS_PER_SECOND = 10
 
 # Request timeout in seconds.  Override with the FLI_TIMEOUT env var.
-DEFAULT_TIMEOUT = 60
+DEFAULT_TIMEOUT: float = 60.0
 _env_timeout = os.environ.get("FLI_TIMEOUT")
-REQUEST_TIMEOUT: float = float(_env_timeout) if _env_timeout else DEFAULT_TIMEOUT
+if _env_timeout is not None:
+    try:
+        REQUEST_TIMEOUT: float = float(_env_timeout)
+    except ValueError:
+        msg = f"FLI_TIMEOUT must be a number of seconds, got: {_env_timeout!r}"
+        raise ValueError(msg) from None
+    if REQUEST_TIMEOUT <= 0:
+        raise ValueError(f"FLI_TIMEOUT must be a positive number, got: {_env_timeout!r}")
+else:
+    REQUEST_TIMEOUT = DEFAULT_TIMEOUT
 
 
 class Client:


### PR DESCRIPTION
## Summary
Add support for configurable request timeouts in the HTTP client with a sensible default and environment variable override capability.

## Key Changes
- Added `DEFAULT_TIMEOUT` constant set to 60 seconds as the baseline timeout for all HTTP requests
- Added `FLI_TIMEOUT` environment variable support to allow runtime configuration of request timeouts
- Modified `Client.get()` and `Client.post()` methods to apply the timeout to all requests via `kwargs.setdefault("timeout", REQUEST_TIMEOUT)`

## Implementation Details
- The timeout configuration is evaluated at module load time, reading from the `FLI_TIMEOUT` environment variable if present
- Uses `setdefault()` to apply the timeout while still allowing callers to override with explicit timeout values in kwargs
- Timeout is applied consistently to both GET and POST requests in the rate-limited client
- This prevents requests from hanging indefinitely when communicating with the Google Flights API

https://claude.ai/code/session_015y48WwiMqY5XuzhVHrZGag

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a configurable request timeout to the HTTP client, preventing indefinite hangs when communicating with the Google Flights API. A `DEFAULT_TIMEOUT` of 60 seconds is applied to all `GET` and `POST` requests, with an optional `FLI_TIMEOUT` environment variable override evaluated at module load time.

- `REQUEST_TIMEOUT` is computed once at import via `float(os.environ.get(\"FLI_TIMEOUT\"))`, but the conversion is unguarded — a non-numeric value raises `ValueError` at import time and crashes the whole application.
- The fallback path assigns the `int` literal `DEFAULT_TIMEOUT` (60) rather than `float(DEFAULT_TIMEOUT)`, leaving `REQUEST_TIMEOUT` typed as `float` but holding an `int`.
- No validation exists for non-positive timeout values; `FLI_TIMEOUT=0` would cause every request to time out immediately.

<h3>Confidence Score: 3/5</h3>

The change is narrow but the env-var parsing is unguarded — any deployment that sets FLI_TIMEOUT to a non-numeric value will fail to import the module and break the entire application.

The core idea of applying a default timeout via setdefault in both get() and post() is correct and safe. The risk is concentrated in the module-level float() conversion: if FLI_TIMEOUT holds an invalid value, the module fails to import and takes the whole app down with a cryptic traceback.

fli/search/client.py — specifically the REQUEST_TIMEOUT initialization block at lines 57-58.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/search/client.py | Adds configurable request timeout via DEFAULT_TIMEOUT constant and FLI_TIMEOUT env var; get() and post() now call kwargs.setdefault. The env-var parsing is unguarded — an invalid value raises ValueError at import time, crashing the whole app. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Env as Environment
    participant Mod as client.py (module load)
    participant Client as Client.get() / Client.post()
    participant Session as curl_cffi Session

    Env->>Mod: FLI_TIMEOUT (optional)
    Mod->>Mod: float(_env_timeout) to REQUEST_TIMEOUT
    Note over Mod: ValueError if FLI_TIMEOUT is non-numeric

    Client->>Client: _rate_limiter.acquire()
    Client->>Client: kwargs.setdefault(timeout, REQUEST_TIMEOUT)
    Client->>Session: "get(url, timeout=REQUEST_TIMEOUT)"
    Session-->>Client: Response
    Client-->>Client: response.raise_for_status()
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fsearch%2Fclient.py%3A58%0A**Unguarded%20%60float%28%29%60%20conversion%20crashes%20at%20import%20time**%0A%0AIf%20%60FLI_TIMEOUT%60%20is%20set%20to%20a%20non-numeric%20value%20%28e.g.%20%60FLI_TIMEOUT%3Ddisabled%60%20or%20%60FLI_TIMEOUT%3D60s%60%29%2C%20%60float%28_env_timeout%29%60%20raises%20a%20%60ValueError%60%20at%20module%20load%20time.%20Because%20%60client.py%60%20is%20imported%20transitively%20by%20every%20search%20path%2C%20this%20crashes%20the%20entire%20application%20before%20any%20user-facing%20error%20handling%20can%20run.%20The%20fix%20is%20to%20wrap%20the%20conversion%20in%20a%20%60try%2Fexcept%60%20and%20fall%20back%20to%20%60DEFAULT_TIMEOUT%60%20%28or%20raise%20a%20clear%20%60ValueError%60%20with%20a%20helpful%20message%29.%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fsearch%2Fclient.py%3A58%0A**%60REQUEST_TIMEOUT%60%20should%20always%20be%20a%20%60float%60**%20%E2%80%94%20when%20%60_env_timeout%60%20is%20falsy%2C%20the%20fallback%20assigns%20the%20%60int%60%20literal%20%60DEFAULT_TIMEOUT%60%20%2860%29%20instead%20of%20a%20%60float%60%2C%20which%20doesn't%20match%20the%20%60%3A%20float%60%20annotation.%20Changing%20the%20default%20to%20%60float%28DEFAULT_TIMEOUT%29%60%20keeps%20the%20type%20consistent%20and%20matches%20the%20intent.%0A%0A%60%60%60suggestion%0AREQUEST_TIMEOUT%3A%20float%20%3D%20float%28_env_timeout%29%20if%20_env_timeout%20else%20float%28DEFAULT_TIMEOUT%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fclient.py%3A57-58%0A**No%20validation%20for%20non-positive%20timeout%20values**%20%E2%80%94%20%60FLI_TIMEOUT%3D0%60%20produces%20%60REQUEST_TIMEOUT%20%3D%200.0%60%2C%20which%20with%20%60curl_cffi%60%20likely%20causes%20every%20request%20to%20time%20out%20immediately.%20A%20simple%20guard%20that%20falls%20back%20to%20%60DEFAULT_TIMEOUT%60%20%28or%20raises%20with%20a%20clear%20message%29%20when%20the%20parsed%20value%20is%20%60%3C%3D%200%60%20would%20protect%20against%20accidental%20misconfiguration.%0A%0A%60%60%60suggestion%0A_env_timeout%20%3D%20os.environ.get%28%22FLI_TIMEOUT%22%29%0AREQUEST_TIMEOUT%3A%20float%20%3D%20float%28_env_timeout%29%20if%20_env_timeout%20else%20float%28DEFAULT_TIMEOUT%29%0Aif%20REQUEST_TIMEOUT%20%3C%3D%200%3A%0A%20%20%20%20raise%20ValueError%28f%22FLI_TIMEOUT%20must%20be%20a%20positive%20number%2C%20got%20%7B_env_timeout!r%7D%22%29%0A%60%60%60%0A%0A&repo=punitarani%2Ffli&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fsearch%2Fclient.py%3A58%0A**Unguarded%20%60float%28%29%60%20conversion%20crashes%20at%20import%20time**%0A%0AIf%20%60FLI_TIMEOUT%60%20is%20set%20to%20a%20non-numeric%20value%20%28e.g.%20%60FLI_TIMEOUT%3Ddisabled%60%20or%20%60FLI_TIMEOUT%3D60s%60%29%2C%20%60float%28_env_timeout%29%60%20raises%20a%20%60ValueError%60%20at%20module%20load%20time.%20Because%20%60client.py%60%20is%20imported%20transitively%20by%20every%20search%20path%2C%20this%20crashes%20the%20entire%20application%20before%20any%20user-facing%20error%20handling%20can%20run.%20The%20fix%20is%20to%20wrap%20the%20conversion%20in%20a%20%60try%2Fexcept%60%20and%20fall%20back%20to%20%60DEFAULT_TIMEOUT%60%20%28or%20raise%20a%20clear%20%60ValueError%60%20with%20a%20helpful%20message%29.%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fsearch%2Fclient.py%3A58%0A**%60REQUEST_TIMEOUT%60%20should%20always%20be%20a%20%60float%60**%20%E2%80%94%20when%20%60_env_timeout%60%20is%20falsy%2C%20the%20fallback%20assigns%20the%20%60int%60%20literal%20%60DEFAULT_TIMEOUT%60%20%2860%29%20instead%20of%20a%20%60float%60%2C%20which%20doesn't%20match%20the%20%60%3A%20float%60%20annotation.%20Changing%20the%20default%20to%20%60float%28DEFAULT_TIMEOUT%29%60%20keeps%20the%20type%20consistent%20and%20matches%20the%20intent.%0A%0A%60%60%60suggestion%0AREQUEST_TIMEOUT%3A%20float%20%3D%20float%28_env_timeout%29%20if%20_env_timeout%20else%20float%28DEFAULT_TIMEOUT%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fclient.py%3A57-58%0A**No%20validation%20for%20non-positive%20timeout%20values**%20%E2%80%94%20%60FLI_TIMEOUT%3D0%60%20produces%20%60REQUEST_TIMEOUT%20%3D%200.0%60%2C%20which%20with%20%60curl_cffi%60%20likely%20causes%20every%20request%20to%20time%20out%20immediately.%20A%20simple%20guard%20that%20falls%20back%20to%20%60DEFAULT_TIMEOUT%60%20%28or%20raises%20with%20a%20clear%20message%29%20when%20the%20parsed%20value%20is%20%60%3C%3D%200%60%20would%20protect%20against%20accidental%20misconfiguration.%0A%0A%60%60%60suggestion%0A_env_timeout%20%3D%20os.environ.get%28%22FLI_TIMEOUT%22%29%0AREQUEST_TIMEOUT%3A%20float%20%3D%20float%28_env_timeout%29%20if%20_env_timeout%20else%20float%28DEFAULT_TIMEOUT%29%0Aif%20REQUEST_TIMEOUT%20%3C%3D%200%3A%0A%20%20%20%20raise%20ValueError%28f%22FLI_TIMEOUT%20must%20be%20a%20positive%20number%2C%20got%20%7B_env_timeout!r%7D%22%29%0A%60%60%60%0A%0A&pr=161&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22claude%2Fincrease-default-timeout-Je1t9%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fincrease-default-timeout-Je1t9%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fsearch%2Fclient.py%3A58%0A**Unguarded%20%60float%28%29%60%20conversion%20crashes%20at%20import%20time**%0A%0AIf%20%60FLI_TIMEOUT%60%20is%20set%20to%20a%20non-numeric%20value%20%28e.g.%20%60FLI_TIMEOUT%3Ddisabled%60%20or%20%60FLI_TIMEOUT%3D60s%60%29%2C%20%60float%28_env_timeout%29%60%20raises%20a%20%60ValueError%60%20at%20module%20load%20time.%20Because%20%60client.py%60%20is%20imported%20transitively%20by%20every%20search%20path%2C%20this%20crashes%20the%20entire%20application%20before%20any%20user-facing%20error%20handling%20can%20run.%20The%20fix%20is%20to%20wrap%20the%20conversion%20in%20a%20%60try%2Fexcept%60%20and%20fall%20back%20to%20%60DEFAULT_TIMEOUT%60%20%28or%20raise%20a%20clear%20%60ValueError%60%20with%20a%20helpful%20message%29.%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fsearch%2Fclient.py%3A58%0A**%60REQUEST_TIMEOUT%60%20should%20always%20be%20a%20%60float%60**%20%E2%80%94%20when%20%60_env_timeout%60%20is%20falsy%2C%20the%20fallback%20assigns%20the%20%60int%60%20literal%20%60DEFAULT_TIMEOUT%60%20%2860%29%20instead%20of%20a%20%60float%60%2C%20which%20doesn't%20match%20the%20%60%3A%20float%60%20annotation.%20Changing%20the%20default%20to%20%60float%28DEFAULT_TIMEOUT%29%60%20keeps%20the%20type%20consistent%20and%20matches%20the%20intent.%0A%0A%60%60%60suggestion%0AREQUEST_TIMEOUT%3A%20float%20%3D%20float%28_env_timeout%29%20if%20_env_timeout%20else%20float%28DEFAULT_TIMEOUT%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fclient.py%3A57-58%0A**No%20validation%20for%20non-positive%20timeout%20values**%20%E2%80%94%20%60FLI_TIMEOUT%3D0%60%20produces%20%60REQUEST_TIMEOUT%20%3D%200.0%60%2C%20which%20with%20%60curl_cffi%60%20likely%20causes%20every%20request%20to%20time%20out%20immediately.%20A%20simple%20guard%20that%20falls%20back%20to%20%60DEFAULT_TIMEOUT%60%20%28or%20raises%20with%20a%20clear%20message%29%20when%20the%20parsed%20value%20is%20%60%3C%3D%200%60%20would%20protect%20against%20accidental%20misconfiguration.%0A%0A%60%60%60suggestion%0A_env_timeout%20%3D%20os.environ.get%28%22FLI_TIMEOUT%22%29%0AREQUEST_TIMEOUT%3A%20float%20%3D%20float%28_env_timeout%29%20if%20_env_timeout%20else%20float%28DEFAULT_TIMEOUT%29%0Aif%20REQUEST_TIMEOUT%20%3C%3D%200%3A%0A%20%20%20%20raise%20ValueError%28f%22FLI_TIMEOUT%20must%20be%20a%20positive%20number%2C%20got%20%7B_env_timeout!r%7D%22%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
fli/search/client.py:58
**Unguarded `float()` conversion crashes at import time**

If `FLI_TIMEOUT` is set to a non-numeric value (e.g. `FLI_TIMEOUT=disabled` or `FLI_TIMEOUT=60s`), `float(_env_timeout)` raises a `ValueError` at module load time. Because `client.py` is imported transitively by every search path, this crashes the entire application before any user-facing error handling can run. The fix is to wrap the conversion in a `try/except` and fall back to `DEFAULT_TIMEOUT` (or raise a clear `ValueError` with a helpful message).

### Issue 2 of 3
fli/search/client.py:58
**`REQUEST_TIMEOUT` should always be a `float`** — when `_env_timeout` is falsy, the fallback assigns the `int` literal `DEFAULT_TIMEOUT` (60) instead of a `float`, which doesn't match the `: float` annotation. Changing the default to `float(DEFAULT_TIMEOUT)` keeps the type consistent and matches the intent.

```suggestion
REQUEST_TIMEOUT: float = float(_env_timeout) if _env_timeout else float(DEFAULT_TIMEOUT)
```

### Issue 3 of 3
fli/search/client.py:57-58
**No validation for non-positive timeout values** — `FLI_TIMEOUT=0` produces `REQUEST_TIMEOUT = 0.0`, which with `curl_cffi` likely causes every request to time out immediately. A simple guard that falls back to `DEFAULT_TIMEOUT` (or raises with a clear message) when the parsed value is `<= 0` would protect against accidental misconfiguration.

```suggestion
_env_timeout = os.environ.get("FLI_TIMEOUT")
REQUEST_TIMEOUT: float = float(_env_timeout) if _env_timeout else float(DEFAULT_TIMEOUT)
if REQUEST_TIMEOUT <= 0:
    raise ValueError(f"FLI_TIMEOUT must be a positive number, got {_env_timeout!r}")
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Increase default HTTP timeout to 60s and..."](https://github.com/punitarani/fli/commit/f87e7bd5707a3ebe95af723b826838387bf22bc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32421675)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->