### PR TITLE
test: add issue #144 regression for Eastar Jet live token

### DIFF
--- a/tests/search/test_search_flights.py
+++ b/tests/search/test_search_flights.py
@@ -264,6 +264,29 @@ class TestParsePriceInfo:
         ]
         assert SearchFlights._parse_price_info(data) == (118.0, "USD")
 
+    def test_parse_price_info_eastar_jet_live_token(self):
+        """Regression for issue #144: Eastar Jet ICN-NRT returns price=None.
+
+        Captured shape from a live 2026-06-15 ICN→NRT search for ZE6078: the
+        inner price head is empty (Google's "no shopping-list price" marker
+        for direct-only carriers without partner inventory) and the base64
+        token has no nested currency field. Before the fix landed in #166
+        this row reported ``price=0.0``, masking the carrier as a free fare;
+        downstream consumers worked around it with ``price <= 0`` filters,
+        dropping the entire carrier from view. Now ``price`` is ``None`` and
+        the row stays visible.
+        """
+        data = [
+            None,
+            [
+                [],
+                "CjRIRlNfZ0FHamhKdElBR3NHOVFCRy0tLS0tLS0tLW9rZXExOEFBQUFBR29IOEY4QXY4RGVBEgVaRTYwNzgc",
+            ],
+        ]
+        price, currency = SearchFlights._parse_price_info(data)
+        assert price is None
+        assert currency is None
+
 
 class TestSearchParseErrorMessage:
     """SearchParseError surfaces sample reasons when every row fails."""


### PR DESCRIPTION
Fixes #144.

## Context

While investigating issue #144 (Eastar Jet / Aero K returning `price=0.0`), I traced it to Google Flights' wire format: those carriers' rows come back with an empty price head (`[[], "<token>"]`), and the parser was silently substituting `0.0`.

PR #166 fixed that same wire-format quirk while resolving #165 (premium-cabin round-trip rows). The fix landed: `FlightResult.price` is now `NonNegativeFloat | None`, `_parse_price_info` returns `(None, currency)` for the empty-head shape, and `format_price` renders `None` as `"—"`.

I verified the issue's repro against current main (ICN↔NRT 2026-06-15/18 round-trip): Eastar Jet rows now show `price=None` — exactly the fix the issue's reporter asked for.

## What this PR adds

A focused regression test pinned to **issue #144's actual symptom**. PR #166 documents the fix as "issue #165: premium-RT" — that's the route Google takes to surface the same wire pattern, but the LCC scenario from #144 is a different real-world trigger and deserves its own regression coverage.

The new test (`test_parse_price_info_eastar_jet_live_token`) uses the actual base64 token captured live from a 2026-06-15 ICN→NRT ZE6078 search — not synthetic data — so any future regression that breaks the LCC path (e.g. if someone narrows the "empty head" handling to only fire on premium-cabin paths) gets caught.

## Test plan

- [x] `uv run pytest tests/search/test_search_flights.py::TestParsePriceInfo -v`: 10 passed
- [x] `uv run ruff check`: clean
- [x] Live verification on current main (issue's repro): Eastar Jet rows return `price=None`, carrier stays visible

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrN1QUVxZSao2tYxf6ScaC)_