### PR TITLE
Improve MCP TLS error reporting

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -206,6 +206,18 @@ The MCP server can be configured via environment variables:
 | `FLI_MCP_DEFAULT_DEPARTURE_WINDOW` | Default departure window (HH-HH) | null |
 | `FLI_MCP_MAX_RESULTS` | Maximum results returned | null (no limit) |
 
+The underlying Google Flights HTTP client also honors these variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FLI_TIMEOUT` | Request timeout in seconds | 60 |
+| `FLI_CA_BUNDLE` | Path to a PEM CA bundle for networks with custom certificate authorities | unset |
+| `CURL_CA_BUNDLE` | Fallback CA bundle path, used when `FLI_CA_BUNDLE` is unset | unset |
+| `REQUESTS_CA_BUNDLE` | Fallback CA bundle path, used when the variables above are unset | unset |
+
+If a search fails with `error_type: "certificate_error"`, configure one of the CA bundle
+variables instead of disabling TLS verification.
+
 ## Example Conversations
 
 Once configured with Claude Desktop, you can have natural conversations:

--- a/fli/cli/errors.py
+++ b/fli/cli/errors.py
@@ -17,6 +17,7 @@ import typer
 
 from fli.cli.console import console
 from fli.search.exceptions import (
+    SearchCertificateError,
     SearchClientError,
     SearchConnectionError,
     SearchHTTPError,
@@ -31,6 +32,8 @@ def _friendly_message(exc: BaseException) -> str:
     """Return the short, user-facing message for ``exc``."""
     if isinstance(exc, SearchTimeoutError):
         return f"Request timed out. {exc}"
+    if isinstance(exc, SearchCertificateError):
+        return f"TLS certificate error. {exc}"
     if isinstance(exc, SearchConnectionError):
         return f"Network error. {exc}"
     if isinstance(exc, SearchHTTPError):
@@ -92,6 +95,8 @@ def json_error_payload(exc: BaseException, *, command: str | None = None) -> tup
     log_path = _write_log(exc, command=command)
     if isinstance(exc, SearchTimeoutError):
         return str(exc), "timeout", log_path
+    if isinstance(exc, SearchCertificateError):
+        return str(exc), "certificate_error", log_path
     if isinstance(exc, SearchConnectionError):
         return str(exc), "connection_error", log_path
     if isinstance(exc, SearchHTTPError):

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -530,7 +530,7 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
     except ParseError as e:
         return _error_response(e, "flights")
     except SearchClientError as e:
-        return _error_response(e, "flights", message=f"Search failed: {e}")
+        return _error_response(e, "flights")
     except Exception as e:
         error_msg = str(e)
         if "validation error" in error_msg.lower():
@@ -631,7 +631,7 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
     except ParseError as e:
         return _error_response(e, "dates")
     except SearchClientError as e:
-        return _error_response(e, "dates", message=f"Search failed: {e}")
+        return _error_response(e, "dates")
     except Exception as e:
         return _error_response(e, "dates", message=f"Search failed: {e}")
 

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -39,6 +39,13 @@ from fli.models import (
     TripType,
 )
 from fli.search import SearchDates, SearchFlights
+from fli.search.exceptions import (
+    SearchCertificateError,
+    SearchClientError,
+    SearchConnectionError,
+    SearchHTTPError,
+    SearchTimeoutError,
+)
 
 
 class FlightSearchConfig(BaseSettings):
@@ -394,6 +401,36 @@ def _serialize_date_result(date_result: Any) -> dict[str, Any]:
 # =============================================================================
 
 
+def _error_type(exc: BaseException) -> str:
+    """Map internal exceptions to stable MCP error type strings."""
+    if isinstance(exc, ParseError):
+        return "parse_error"
+    if isinstance(exc, SearchTimeoutError):
+        return "timeout"
+    if isinstance(exc, SearchCertificateError):
+        return "certificate_error"
+    if isinstance(exc, SearchConnectionError):
+        return "connection_error"
+    if isinstance(exc, SearchHTTPError):
+        return "http_error"
+    if isinstance(exc, SearchClientError):
+        return "search_error"
+    return "unexpected_error"
+
+
+def _error_response(
+    exc: BaseException, result_key: str, *, message: str | None = None
+) -> dict[str, Any]:
+    """Return a structured MCP error response while preserving legacy fields."""
+    error_message = message if message is not None else str(exc)
+    return {
+        "success": False,
+        "error": error_message,
+        "error_type": _error_type(exc),
+        result_key: [],
+    }
+
+
 def _resolve_airports(codes: str) -> list[Airport]:
     """Resolve one or more comma-separated airport codes."""
     airports = [resolve_airport(code.strip()) for code in codes.split(",") if code.strip()]
@@ -491,12 +528,14 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
         }
 
     except ParseError as e:
-        return {"success": False, "error": str(e), "flights": []}
+        return _error_response(e, "flights")
+    except SearchClientError as e:
+        return _error_response(e, "flights", message=f"Search failed: {e}")
     except Exception as e:
         error_msg = str(e)
         if "validation error" in error_msg.lower():
-            return {"success": False, "error": "Invalid parameter value", "flights": []}
-        return {"success": False, "error": f"Search failed: {error_msg}", "flights": []}
+            return _error_response(e, "flights", message="Invalid parameter value")
+        return _error_response(e, "flights", message=f"Search failed: {error_msg}")
 
 
 def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
@@ -590,9 +629,11 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
         }
 
     except ParseError as e:
-        return {"success": False, "error": str(e), "dates": []}
+        return _error_response(e, "dates")
+    except SearchClientError as e:
+        return _error_response(e, "dates", message=f"Search failed: {e}")
     except Exception as e:
-        return {"success": False, "error": f"Search failed: {str(e)}", "dates": []}
+        return _error_response(e, "dates", message=f"Search failed: {e}")
 
 
 # =============================================================================
@@ -1002,6 +1043,14 @@ def configuration_resource() -> str:
                 "FLI_MCP_DEFAULT_SORT_BY": "Set the default result sorting strategy.",
                 "FLI_MCP_DEFAULT_DEPARTURE_WINDOW": "Provide a default departure window (HH-HH).",
                 "FLI_MCP_MAX_RESULTS": "Limit the maximum number of results returned by tools.",
+                "FLI_TIMEOUT": "Set the Google Flights request timeout in seconds.",
+                "FLI_CA_BUNDLE": (
+                    "Path to a PEM CA bundle for networks with custom certificate authorities."
+                ),
+                "CURL_CA_BUNDLE": "Fallback CA bundle path when FLI_CA_BUNDLE is unset.",
+                "REQUESTS_CA_BUNDLE": (
+                    "Fallback CA bundle path when FLI_CA_BUNDLE and CURL_CA_BUNDLE are unset."
+                ),
             },
         },
     }

--- a/fli/search/__init__.py
+++ b/fli/search/__init__.py
@@ -1,5 +1,6 @@
 from .dates import DatePrice, SearchDates
 from .exceptions import (
+    SearchCertificateError,
     SearchClientError,
     SearchConnectionError,
     SearchHTTPError,
@@ -13,6 +14,7 @@ __all__ = [
     "DatePrice",
     "SearchClientError",
     "SearchTimeoutError",
+    "SearchCertificateError",
     "SearchConnectionError",
     "SearchHTTPError",
 ]

--- a/fli/search/client.py
+++ b/fli/search/client.py
@@ -28,6 +28,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 
 from fli.search._concurrency import TokenBucketRateLimiter
 from fli.search.exceptions import (
+    SearchCertificateError,
     SearchClientError,
     SearchConnectionError,
     SearchHTTPError,
@@ -60,6 +61,7 @@ DEFAULT_CALLS_PER_SECOND = 10
 
 # Request timeout in seconds.  Override with the FLI_TIMEOUT env var.
 DEFAULT_TIMEOUT: float = 60.0
+_CA_BUNDLE_ENV_VARS = ("FLI_CA_BUNDLE", "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE")
 _env_timeout = os.environ.get("FLI_TIMEOUT")
 if _env_timeout is not None:
     try:
@@ -71,6 +73,15 @@ if _env_timeout is not None:
         raise ValueError(f"FLI_TIMEOUT must be a positive number, got: {_env_timeout!r}")
 else:
     REQUEST_TIMEOUT = DEFAULT_TIMEOUT
+
+
+def _ca_bundle_from_env() -> str | None:
+    """Return the first configured CA bundle path from supported environment variables."""
+    for name in _CA_BUNDLE_ENV_VARS:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
 
 
 class Client:
@@ -106,6 +117,9 @@ class Client:
 
             session = _requests.Session()
             session.headers.update(self.DEFAULT_HEADERS)
+            ca_bundle = _ca_bundle_from_env()
+            if ca_bundle:
+                session.verify = ca_bundle
             self._sessions.session = session
         return session
 
@@ -165,6 +179,14 @@ def _wrap_request_error(method: str, url: str, exc: BaseException) -> SearchClie
     from curl_cffi.requests import exceptions as curl_exc
 
     host = _host_from_url(url)
+    certificate_error = getattr(curl_exc, "CertificateVerifyError", ())
+    if certificate_error and isinstance(exc, certificate_error):
+        env_vars = ", ".join(_CA_BUNDLE_ENV_VARS)
+        return SearchCertificateError(
+            f"TLS certificate verification failed for Google Flights ({host}). "
+            f"If your network uses a custom certificate authority, set one of "
+            f"{env_vars} to a CA bundle path and try again."
+        )
     if isinstance(exc, curl_exc.Timeout):
         return SearchTimeoutError(
             f"Timed out talking to Google Flights ({host}). "

--- a/fli/search/client.py
+++ b/fli/search/client.py
@@ -80,6 +80,11 @@ def _ca_bundle_from_env() -> str | None:
     for name in _CA_BUNDLE_ENV_VARS:
         value = os.environ.get(name)
         if value:
+            if not os.path.isfile(value) or not os.access(value, os.R_OK):
+                raise SearchCertificateError(
+                    f"{name} points to a CA bundle path that does not exist or "
+                    f"is not readable: {value!r}"
+                )
             return value
     return None
 

--- a/fli/search/exceptions.py
+++ b/fli/search/exceptions.py
@@ -21,6 +21,10 @@ class SearchConnectionError(SearchClientError):
     """A network/DNS issue prevented us from reaching Google Flights."""
 
 
+class SearchCertificateError(SearchConnectionError):
+    """TLS certificate verification failed while reaching Google Flights."""
+
+
 class SearchHTTPError(SearchClientError):
     """Google Flights returned a non-2xx HTTP response."""
 

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 from fli.cli.errors import _write_log, json_error_payload, report_cli_error
 from fli.cli.main import app
 from fli.search.exceptions import (
+    SearchCertificateError,
     SearchClientError,
     SearchConnectionError,
     SearchHTTPError,
@@ -48,6 +49,7 @@ def test_json_error_payload_maps_error_types():
     """Each SearchClientError subclass should map to a distinct error_type string."""
     cases = [
         (SearchTimeoutError("timed out"), "timeout"),
+        (SearchCertificateError("bad cert"), "certificate_error"),
         (SearchConnectionError("dns"), "connection_error"),
         (SearchHTTPError("403", status_code=403), "http_error"),
         (SearchClientError("generic"), "search_error"),

--- a/tests/mcp/test_mcp_server_fixes.py
+++ b/tests/mcp/test_mcp_server_fixes.py
@@ -10,7 +10,14 @@ from unittest.mock import MagicMock
 import pytest
 from fastmcp import FastMCP
 
-from fli.mcp.server import _serialize_flight_result, mcp
+from fli.mcp.server import DateSearchParams, FlightSearchParams, _serialize_flight_result, mcp
+from fli.mcp.server import (
+    _search_dates_from_params as search_dates_fn,
+)
+from fli.mcp.server import (
+    _search_flights_from_params as search_flights_fn,
+)
+from fli.search.exceptions import SearchCertificateError
 
 # ---------------------------------------------------------------------------
 # Bug 1: list_tools — FastMCP 3.x compatibility
@@ -77,7 +84,61 @@ class TestPrompts:
 
 
 # ---------------------------------------------------------------------------
-# Bug 2: Round-trip price doubling
+# Bug 2: Structured MCP search errors
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredMcpErrors:
+    """MCP tools should preserve machine-readable search error types."""
+
+    def test_search_flights_reports_certificate_error_type(self, monkeypatch):
+        """A TLS certificate failure should be visible to MCP clients."""
+
+        class FakeSearchFlights:
+            def search(self, *args, **kwargs):
+                raise SearchCertificateError("TLS certificate verification failed")
+
+        monkeypatch.setattr("fli.mcp.server.SearchFlights", FakeSearchFlights)
+
+        result = search_flights_fn(
+            FlightSearchParams(
+                origin="JFK",
+                destination="LHR",
+                departure_date="2026-10-25",
+            )
+        )
+
+        assert result["success"] is False
+        assert result["error_type"] == "certificate_error"
+        assert "TLS certificate verification failed" in result["error"]
+        assert result["flights"] == []
+
+    def test_search_dates_reports_certificate_error_type(self, monkeypatch):
+        """Date-search errors should use the same structured shape as flight-search errors."""
+
+        class FakeSearchDates:
+            def search(self, *args, **kwargs):
+                raise SearchCertificateError("TLS certificate verification failed")
+
+        monkeypatch.setattr("fli.mcp.server.SearchDates", FakeSearchDates)
+
+        result = search_dates_fn(
+            DateSearchParams(
+                origin="JFK",
+                destination="LHR",
+                start_date="2026-10-01",
+                end_date="2026-10-31",
+            )
+        )
+
+        assert result["success"] is False
+        assert result["error_type"] == "certificate_error"
+        assert "TLS certificate verification failed" in result["error"]
+        assert result["dates"] == []
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: Round-trip price doubling
 # ---------------------------------------------------------------------------
 
 

--- a/tests/search/test_client_errors.py
+++ b/tests/search/test_client_errors.py
@@ -1,0 +1,28 @@
+"""Tests for HTTP client error classification and configuration."""
+
+from curl_cffi.requests import exceptions as curl_exc
+
+from fli.search.client import Client, _wrap_request_error
+from fli.search.exceptions import SearchCertificateError
+
+
+def test_certificate_verify_error_maps_to_certificate_error():
+    """TLS verification failures should not be reported as generic connectivity errors."""
+    exc = curl_exc.CertificateVerifyError("unable to get local issuer certificate", 60, None)
+
+    wrapped = _wrap_request_error("GET", "https://www.google.com/travel/flights", exc)
+
+    assert isinstance(wrapped, SearchCertificateError)
+    assert "TLS certificate verification failed" in str(wrapped)
+    assert "FLI_CA_BUNDLE" in str(wrapped)
+
+
+def test_client_session_uses_configured_ca_bundle(monkeypatch):
+    """The client should honor a user-provided CA bundle without disabling TLS checks."""
+    monkeypatch.setenv("FLI_CA_BUNDLE", "C:/certs/custom-ca.pem")
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+    client = Client()
+
+    assert client._session().verify == "C:/certs/custom-ca.pem"

--- a/tests/search/test_client_errors.py
+++ b/tests/search/test_client_errors.py
@@ -1,5 +1,6 @@
 """Tests for HTTP client error classification and configuration."""
 
+import pytest
 from curl_cffi.requests import exceptions as curl_exc
 
 from fli.search.client import Client, _wrap_request_error
@@ -17,12 +18,28 @@ def test_certificate_verify_error_maps_to_certificate_error():
     assert "FLI_CA_BUNDLE" in str(wrapped)
 
 
-def test_client_session_uses_configured_ca_bundle(monkeypatch):
+def test_client_session_uses_configured_ca_bundle(monkeypatch, tmp_path):
     """The client should honor a user-provided CA bundle without disabling TLS checks."""
-    monkeypatch.setenv("FLI_CA_BUNDLE", "C:/certs/custom-ca.pem")
+    ca_bundle = tmp_path / "custom-ca.pem"
+    ca_bundle.write_text("certificate data", encoding="utf-8")
+
+    monkeypatch.setenv("FLI_CA_BUNDLE", str(ca_bundle))
     monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
 
     client = Client()
 
-    assert client._session().verify == "C:/certs/custom-ca.pem"
+    assert client._session().verify == str(ca_bundle)
+
+
+def test_client_session_rejects_missing_ca_bundle(monkeypatch, tmp_path):
+    """Bad CA bundle paths should produce the same structured certificate error type."""
+    missing = tmp_path / "missing-ca.pem"
+    monkeypatch.setenv("FLI_CA_BUNDLE", str(missing))
+    monkeypatch.delenv("CURL_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+    client = Client()
+
+    with pytest.raises(SearchCertificateError, match="does not exist or is not readable"):
+        client._session()


### PR DESCRIPTION
## Summary
- classify curl certificate verification failures as `SearchCertificateError`
- allow users to configure a CA bundle via `FLI_CA_BUNDLE`, `CURL_CA_BUNDLE`, or `REQUESTS_CA_BUNDLE`
- return stable MCP `error_type` values while preserving the legacy `error` and empty result fields
- document CA bundle configuration for MCP users

## Testing
- `uvx --system-certs ruff check .`
- `uvx --system-certs ruff format --check .`
- `UV_PROJECT_ENVIRONMENT=.venv-test uv --system-certs run pytest tests/search/test_client_errors.py tests/cli/test_errors.py tests/mcp/test_mcp_server_fixes.py -q`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves TLS error handling for the MCP server by introducing `SearchCertificateError`, a new typed exception for certificate verification failures, and allowing users to configure a custom CA bundle via `FLI_CA_BUNDLE`, `CURL_CA_BUNDLE`, or `REQUESTS_CA_BUNDLE`. It also refactors MCP error responses to include a stable `error_type` field alongside the existing `error` and result fields.

- `SearchCertificateError` is added as a subclass of `SearchConnectionError` and is classified before the parent class in every `isinstance` chain, so the more-specific type is always matched first.
- `_wrap_request_error` uses `getattr(curl_exc, \"CertificateVerifyError\", ())` as a forward-compatible guard, and `_session()` wires in the CA bundle when the env var is set.
- `_error_type` / `_error_response` helpers centralize MCP error formatting, and the CLI, MCP server, and public `__init__` exports are all updated consistently.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; all error classification paths are logically consistent and backed by new tests.

The exception hierarchy and isinstance ordering are correct throughout the CLI, MCP server, and _error_type helper. The two style concerns do not affect correctness in the normal path.

fli/search/client.py and fli/mcp/server.py are worth a second look for the CA bundle path handling and the error message prefix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/search/exceptions.py | Adds `SearchCertificateError` as a subclass of `SearchConnectionError`; clean and correctly placed in the hierarchy. |
| fli/search/client.py | Adds CA bundle env-var resolution and certificate error detection via `getattr` guard; minor concern that an invalid bundle path won't produce a `SearchCertificateError` at failure time. |
| fli/mcp/server.py | Adds `_error_type` and `_error_response` helpers with correct `isinstance` ordering; the "Search failed: " prefix on typed `SearchClientError` messages is a minor style concern. |
| fli/cli/errors.py | Adds `SearchCertificateError` handling in the correct order (before `SearchConnectionError`) in both `_friendly_message` and `json_error_payload`. |
| tests/search/test_client_errors.py | Tests certificate error mapping and CA bundle attribute assignment; verifies the attribute is set on the session but does not make a live request to confirm curl_cffi actually uses it. |
| tests/mcp/test_mcp_server_fixes.py | Adds two well-structured tests verifying `error_type: "certificate_error"` in MCP flight and date search responses. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP POST to Google Flights] --> B{Exception?}
    B -->|No| C[Return response]
    B -->|Yes| D[_wrap_request_error]
    D --> E{Already SearchClientError?}
    E -->|Yes| F[Return as-is]
    E -->|No| G{CertificateVerifyError?}
    G -->|Yes| H[SearchCertificateError\ncertificate_error]
    G -->|No| I{curl_exc.Timeout?}
    I -->|Yes| J[SearchTimeoutError\ntimeout]
    I -->|No| K{curl_exc.ConnectionError?}
    K -->|Yes| L[SearchConnectionError\nconnection_error]
    K -->|No| M{curl_exc.HTTPError?}
    M -->|Yes| N[SearchHTTPError\nhttp_error]
    M -->|No| O[SearchClientError\nsearch_error]
    H & J & L & N & O --> P[_error_response]
    P --> Q[success: false, error: msg, error_type: ...]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fmcp%2Fserver.py%3A532-533%0AThe%20%60except%20SearchClientError%60%20block%20prefixes%20every%20typed%20error%20message%20with%20%60%22Search%20failed%3A%20%22%60%2C%20including%20%60SearchCertificateError%60%20whose%20message%20is%20already%20a%20complete%2C%20actionable%20sentence.%20The%20prefix%20is%20redundant%20and%20makes%20the%20%60error%60%20field%20slightly%20awkward%20when%20presented%20verbatim%20to%20MCP%20clients.%20Passing%20the%20exception%20message%20directly%20%28like%20%60ParseError%60%20does%29%20keeps%20it%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20except%20SearchClientError%20as%20e%3A%0A%20%20%20%20%20%20%20%20return%20_error_response%28e%2C%20%22flights%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fmcp%2Fserver.py%3A633-634%0ASame%20redundant%20prefix%20for%20the%20date-search%20path%3A%20%60SearchCertificateError%60%20%28and%20other%20typed%20client%20errors%29%20already%20carry%20self-contained%20messages%2C%20so%20the%20%60%22Search%20failed%3A%20%22%60%20wrapper%20adds%20noise%20without%20value.%0A%0A%60%60%60suggestion%0A%20%20%20%20except%20SearchClientError%20as%20e%3A%0A%20%20%20%20%20%20%20%20return%20_error_response%28e%2C%20%22dates%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fclient.py%3A78-84%0A**No%20validation%20that%20the%20CA%20bundle%20path%20is%20readable**%0A%0A%60_ca_bundle_from_env%28%29%60%20returns%20any%20non-empty%20string%20verbatim.%20If%20the%20user%20sets%20%60FLI_CA_BUNDLE%60%20to%20a%20path%20that%20does%20not%20exist%20or%20is%20not%20readable%20by%20curl%2C%20the%20failure%20happens%20at%20request%20time%20as%20a%20low-level%20curl%20error.%20That%20error%20won't%20match%20%60CertificateVerifyError%60%20in%20%60_wrap_request_error%60%2C%20so%20it%20falls%20through%20to%20the%20generic%20%60SearchClientError%60%20fallback%20with%20%60error_type%3A%20%22search_error%22%60%20%E2%80%94%20exactly%20the%20opaque%20behavior%20this%20PR%20set%20out%20to%20improve.%20A%20quick%20%60os.path.isfile%60%20check%20or%20a%20startup-time%20%60ValueError%60%20similar%20to%20the%20existing%20%60FLI_TIMEOUT%60%20validation%20would%20surface%20the%20misconfiguration%20clearly.%0A%0A&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fmcp%2Fserver.py%3A532-533%0AThe%20%60except%20SearchClientError%60%20block%20prefixes%20every%20typed%20error%20message%20with%20%60%22Search%20failed%3A%20%22%60%2C%20including%20%60SearchCertificateError%60%20whose%20message%20is%20already%20a%20complete%2C%20actionable%20sentence.%20The%20prefix%20is%20redundant%20and%20makes%20the%20%60error%60%20field%20slightly%20awkward%20when%20presented%20verbatim%20to%20MCP%20clients.%20Passing%20the%20exception%20message%20directly%20%28like%20%60ParseError%60%20does%29%20keeps%20it%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20except%20SearchClientError%20as%20e%3A%0A%20%20%20%20%20%20%20%20return%20_error_response%28e%2C%20%22flights%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fmcp%2Fserver.py%3A633-634%0ASame%20redundant%20prefix%20for%20the%20date-search%20path%3A%20%60SearchCertificateError%60%20%28and%20other%20typed%20client%20errors%29%20already%20carry%20self-contained%20messages%2C%20so%20the%20%60%22Search%20failed%3A%20%22%60%20wrapper%20adds%20noise%20without%20value.%0A%0A%60%60%60suggestion%0A%20%20%20%20except%20SearchClientError%20as%20e%3A%0A%20%20%20%20%20%20%20%20return%20_error_response%28e%2C%20%22dates%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fclient.py%3A78-84%0A**No%20validation%20that%20the%20CA%20bundle%20path%20is%20readable**%0A%0A%60_ca_bundle_from_env%28%29%60%20returns%20any%20non-empty%20string%20verbatim.%20If%20the%20user%20sets%20%60FLI_CA_BUNDLE%60%20to%20a%20path%20that%20does%20not%20exist%20or%20is%20not%20readable%20by%20curl%2C%20the%20failure%20happens%20at%20request%20time%20as%20a%20low-level%20curl%20error.%20That%20error%20won't%20match%20%60CertificateVerifyError%60%20in%20%60_wrap_request_error%60%2C%20so%20it%20falls%20through%20to%20the%20generic%20%60SearchClientError%60%20fallback%20with%20%60error_type%3A%20%22search_error%22%60%20%E2%80%94%20exactly%20the%20opaque%20behavior%20this%20PR%20set%20out%20to%20improve.%20A%20quick%20%60os.path.isfile%60%20check%20or%20a%20startup-time%20%60ValueError%60%20similar%20to%20the%20existing%20%60FLI_TIMEOUT%60%20validation%20would%20surface%20the%20misconfiguration%20clearly.%0A%0A&repo=punitarani%2Ffli&pr=164&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22codex%2Fstructured-mcp-tls-errors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fstructured-mcp-tls-errors%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Afli%2Fmcp%2Fserver.py%3A532-533%0AThe%20%60except%20SearchClientError%60%20block%20prefixes%20every%20typed%20error%20message%20with%20%60%22Search%20failed%3A%20%22%60%2C%20including%20%60SearchCertificateError%60%20whose%20message%20is%20already%20a%20complete%2C%20actionable%20sentence.%20The%20prefix%20is%20redundant%20and%20makes%20the%20%60error%60%20field%20slightly%20awkward%20when%20presented%20verbatim%20to%20MCP%20clients.%20Passing%20the%20exception%20message%20directly%20%28like%20%60ParseError%60%20does%29%20keeps%20it%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20except%20SearchClientError%20as%20e%3A%0A%20%20%20%20%20%20%20%20return%20_error_response%28e%2C%20%22flights%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Afli%2Fmcp%2Fserver.py%3A633-634%0ASame%20redundant%20prefix%20for%20the%20date-search%20path%3A%20%60SearchCertificateError%60%20%28and%20other%20typed%20client%20errors%29%20already%20carry%20self-contained%20messages%2C%20so%20the%20%60%22Search%20failed%3A%20%22%60%20wrapper%20adds%20noise%20without%20value.%0A%0A%60%60%60suggestion%0A%20%20%20%20except%20SearchClientError%20as%20e%3A%0A%20%20%20%20%20%20%20%20return%20_error_response%28e%2C%20%22dates%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Afli%2Fsearch%2Fclient.py%3A78-84%0A**No%20validation%20that%20the%20CA%20bundle%20path%20is%20readable**%0A%0A%60_ca_bundle_from_env%28%29%60%20returns%20any%20non-empty%20string%20verbatim.%20If%20the%20user%20sets%20%60FLI_CA_BUNDLE%60%20to%20a%20path%20that%20does%20not%20exist%20or%20is%20not%20readable%20by%20curl%2C%20the%20failure%20happens%20at%20request%20time%20as%20a%20low-level%20curl%20error.%20That%20error%20won't%20match%20%60CertificateVerifyError%60%20in%20%60_wrap_request_error%60%2C%20so%20it%20falls%20through%20to%20the%20generic%20%60SearchClientError%60%20fallback%20with%20%60error_type%3A%20%22search_error%22%60%20%E2%80%94%20exactly%20the%20opaque%20behavior%20this%20PR%20set%20out%20to%20improve.%20A%20quick%20%60os.path.isfile%60%20check%20or%20a%20startup-time%20%60ValueError%60%20similar%20to%20the%20existing%20%60FLI_TIMEOUT%60%20validation%20would%20surface%20the%20misconfiguration%20clearly.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
fli/mcp/server.py:532-533
The `except SearchClientError` block prefixes every typed error message with `"Search failed: "`, including `SearchCertificateError` whose message is already a complete, actionable sentence. The prefix is redundant and makes the `error` field slightly awkward when presented verbatim to MCP clients. Passing the exception message directly (like `ParseError` does) keeps it clean.

```suggestion
    except SearchClientError as e:
        return _error_response(e, "flights")
```

### Issue 2 of 3
fli/mcp/server.py:633-634
Same redundant prefix for the date-search path: `SearchCertificateError` (and other typed client errors) already carry self-contained messages, so the `"Search failed: "` wrapper adds noise without value.

```suggestion
    except SearchClientError as e:
        return _error_response(e, "dates")
```

### Issue 3 of 3
fli/search/client.py:78-84
**No validation that the CA bundle path is readable**

`_ca_bundle_from_env()` returns any non-empty string verbatim. If the user sets `FLI_CA_BUNDLE` to a path that does not exist or is not readable by curl, the failure happens at request time as a low-level curl error. That error won't match `CertificateVerifyError` in `_wrap_request_error`, so it falls through to the generic `SearchClientError` fallback with `error_type: "search_error"` — exactly the opaque behavior this PR set out to improve. A quick `os.path.isfile` check or a startup-time `ValueError` similar to the existing `FLI_TIMEOUT` validation would surface the misconfiguration clearly.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Improve MCP TLS error reporting"](https://github.com/punitarani/fli/commit/542b034c8525dd1f724f71867d4c6b87d2b8fba8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32469592)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->