### PR TITLE
Add unit tests for previously uncovered modules

### DIFF
--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -108,6 +108,107 @@ def test_multi_command_handles_timeout_cleanly(runner, monkeypatch, tmp_path):
     assert len(log_files) >= 1
 
 
+class TestFriendlyMessage:
+    """_friendly_message must dispatch to the correct user-facing prefix per error type."""
+
+    def test_timeout_error_prefix(self):
+        from fli.cli.errors import _friendly_message
+
+        msg = _friendly_message(SearchTimeoutError("slow"))
+        assert msg.startswith("Request timed out.")
+
+    def test_connection_error_prefix(self):
+        from fli.cli.errors import _friendly_message
+
+        msg = _friendly_message(SearchConnectionError("dns"))
+        assert msg.startswith("Network error.")
+
+    def test_http_error_prefix(self):
+        from fli.cli.errors import _friendly_message
+
+        msg = _friendly_message(SearchHTTPError("403", status_code=403))
+        assert msg.startswith("Google Flights error.")
+
+    def test_generic_search_client_error_prefix(self):
+        from fli.cli.errors import _friendly_message
+
+        msg = _friendly_message(SearchClientError("generic failure"))
+        assert msg.startswith("Search failed.")
+
+    def test_unexpected_error_uses_class_name_and_message(self):
+        from fli.cli.errors import _friendly_message
+
+        msg = _friendly_message(ValueError("bad input"))
+        assert "Unexpected error:" in msg
+        assert "ValueError" in msg
+        assert "bad input" in msg
+
+
+class TestWriteLogDetails:
+    def test_no_command_omits_command_line(self, tmp_path):
+        try:
+            raise SearchTimeoutError("slow backend")
+        except SearchTimeoutError as exc:
+            log_path = _write_log(exc, command=None)
+        contents = log_path.read_text()
+        assert "command:" not in contents
+
+    def test_argv_written_to_log(self, tmp_path):
+        import sys
+
+        try:
+            raise SearchConnectionError("no route")
+        except SearchConnectionError as exc:
+            log_path = _write_log(exc)
+        contents = log_path.read_text()
+        assert "argv:" in contents
+        assert str(sys.argv) in contents
+
+    def test_qualified_error_type_in_log(self, tmp_path):
+        try:
+            raise SearchTimeoutError("timeout")
+        except SearchTimeoutError as exc:
+            log_path = _write_log(exc)
+        contents = log_path.read_text()
+        assert "fli.search.exceptions.SearchTimeoutError" in contents
+
+    def test_timestamp_present_in_log(self, tmp_path):
+        try:
+            raise SearchClientError("x")
+        except SearchClientError as exc:
+            log_path = _write_log(exc)
+        assert "timestamp:" in log_path.read_text()
+
+
+class TestJsonErrorPayloadMessages:
+    def test_message_is_str_of_exception(self):
+        exc = SearchTimeoutError("timed out waiting for response")
+        message, _, _ = json_error_payload(exc)
+        assert message == str(exc) == "timed out waiting for response"
+
+    def test_unexpected_error_message_format(self):
+        exc = RuntimeError("bad input")
+        message, error_type, _ = json_error_payload(exc)
+        assert message == "RuntimeError: bad input"
+        assert error_type == "unexpected_error"
+
+    def test_log_path_is_a_real_file(self, tmp_path):
+        exc = SearchConnectionError("dns failure")
+        _, _, log_path = json_error_payload(exc)
+        assert log_path.exists()
+        assert log_path.is_file()
+
+
+class TestReportCliErrorOptions:
+    def test_custom_exit_code_respected(self):
+        import typer
+
+        exc = SearchTimeoutError("hung")
+        result = report_cli_error(exc, exit_code=2)
+        assert isinstance(result, typer.Exit)
+        assert result.exit_code == 2
+
+
 def test_flights_command_json_error_includes_log_path(runner, monkeypatch, tmp_path):
     """JSON-mode errors should include the log path and a typed error_type."""
     import json

--- a/tests/cli/test_errors.py
+++ b/tests/cli/test_errors.py
@@ -44,21 +44,23 @@ def test_write_log_creates_file_with_traceback(tmp_path):
     assert "traceback:" in contents
 
 
-def test_json_error_payload_maps_error_types():
-    """Each SearchClientError subclass should map to a distinct error_type string."""
-    cases = [
+@pytest.mark.parametrize(
+    "exc, expected_type",
+    [
         (SearchTimeoutError("timed out"), "timeout"),
         (SearchConnectionError("dns"), "connection_error"),
         (SearchHTTPError("403", status_code=403), "http_error"),
         (SearchClientError("generic"), "search_error"),
         (RuntimeError("boom"), "unexpected_error"),
-    ]
-    for exc, expected_type in cases:
-        message, error_type, log_path = json_error_payload(exc)
-        assert error_type == expected_type
-        assert isinstance(log_path, Path)
-        assert log_path.exists()
-        assert message  # non-empty
+    ],
+)
+def test_json_error_payload_maps_error_types(exc, expected_type):
+    """Each SearchClientError subclass should map to a distinct error_type string."""
+    message, error_type, log_path = json_error_payload(exc)
+    assert error_type == expected_type
+    assert isinstance(log_path, Path)
+    assert log_path.exists()
+    assert message  # non-empty
 
 
 def test_report_cli_error_returns_typer_exit_and_writes_log(tmp_path, capsys):
@@ -108,44 +110,25 @@ def test_multi_command_handles_timeout_cleanly(runner, monkeypatch, tmp_path):
     assert len(log_files) >= 1
 
 
-class TestFriendlyMessage:
-    """_friendly_message must dispatch to the correct user-facing prefix per error type."""
+@pytest.mark.parametrize(
+    "exc, expected_msg",
+    [
+        (SearchTimeoutError("slow"), "Request timed out. slow"),
+        (SearchConnectionError("dns"), "Network error. dns"),
+        (SearchHTTPError("403", status_code=403), "Google Flights error. 403"),
+        (SearchClientError("generic failure"), "Search failed. generic failure"),
+        (ValueError("bad input"), "Unexpected error: ValueError: bad input"),
+    ],
+)
+def test_friendly_message(exc, expected_msg):
+    """_friendly_message must dispatch to the correct user-facing message per error type."""
+    from fli.cli.errors import _friendly_message
 
-    def test_timeout_error_prefix(self):
-        from fli.cli.errors import _friendly_message
-
-        msg = _friendly_message(SearchTimeoutError("slow"))
-        assert msg.startswith("Request timed out.")
-
-    def test_connection_error_prefix(self):
-        from fli.cli.errors import _friendly_message
-
-        msg = _friendly_message(SearchConnectionError("dns"))
-        assert msg.startswith("Network error.")
-
-    def test_http_error_prefix(self):
-        from fli.cli.errors import _friendly_message
-
-        msg = _friendly_message(SearchHTTPError("403", status_code=403))
-        assert msg.startswith("Google Flights error.")
-
-    def test_generic_search_client_error_prefix(self):
-        from fli.cli.errors import _friendly_message
-
-        msg = _friendly_message(SearchClientError("generic failure"))
-        assert msg.startswith("Search failed.")
-
-    def test_unexpected_error_uses_class_name_and_message(self):
-        from fli.cli.errors import _friendly_message
-
-        msg = _friendly_message(ValueError("bad input"))
-        assert "Unexpected error:" in msg
-        assert "ValueError" in msg
-        assert "bad input" in msg
+    assert _friendly_message(exc) == expected_msg
 
 
 class TestWriteLogDetails:
-    def test_no_command_omits_command_line(self, tmp_path):
+    def test_no_command_omits_command_line(self):
         try:
             raise SearchTimeoutError("slow backend")
         except SearchTimeoutError as exc:
@@ -153,7 +136,7 @@ class TestWriteLogDetails:
         contents = log_path.read_text()
         assert "command:" not in contents
 
-    def test_argv_written_to_log(self, tmp_path):
+    def test_argv_written_to_log(self):
         import sys
 
         try:
@@ -164,7 +147,7 @@ class TestWriteLogDetails:
         assert "argv:" in contents
         assert str(sys.argv) in contents
 
-    def test_qualified_error_type_in_log(self, tmp_path):
+    def test_qualified_error_type_in_log(self):
         try:
             raise SearchTimeoutError("timeout")
         except SearchTimeoutError as exc:
@@ -172,7 +155,7 @@ class TestWriteLogDetails:
         contents = log_path.read_text()
         assert "fli.search.exceptions.SearchTimeoutError" in contents
 
-    def test_timestamp_present_in_log(self, tmp_path):
+    def test_timestamp_present_in_log(self):
         try:
             raise SearchClientError("x")
         except SearchClientError as exc:
@@ -192,7 +175,7 @@ class TestJsonErrorPayloadMessages:
         assert message == "RuntimeError: bad input"
         assert error_type == "unexpected_error"
 
-    def test_log_path_is_a_real_file(self, tmp_path):
+    def test_log_path_is_a_real_file(self):
         exc = SearchConnectionError("dns failure")
         _, _, log_path = json_error_payload(exc)
         assert log_path.exists()

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -15,7 +15,6 @@ from fli.cli.utils import (
     filter_flights_by_time,
     parse_airlines,
     parse_stops,
-    serialize_airline,
     serialize_date_result,
     serialize_flight_result,
     validate_date,
@@ -113,13 +112,6 @@ def test_parse_airlines_numeric_prefix():
     """Test that airline codes starting with a digit are resolved correctly."""
     result = parse_airlines(["3F"])
     assert result == [Airline._3F]
-
-
-def test_serialize_airline_numeric_prefix():
-    """Test that serialized airline code strips underscore prefix."""
-    result = serialize_airline(Airline._3F)
-    assert result["code"] == "3F"
-    assert result["name"] == "FlyOne Armenia"
 
 
 def test_parse_airlines_invalid():

--- a/tests/core/test_parsers.py
+++ b/tests/core/test_parsers.py
@@ -23,30 +23,23 @@ class TestParseEmissions:
         with pytest.raises(ParseError, match="Invalid EmissionsFilter"):
             parse_emissions("NONE")
 
-    def test_invalid_random(self):
-        with pytest.raises(ParseError, match="Invalid EmissionsFilter"):
-            parse_emissions("HIGH")
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("STAR_ALLIANCE", Airline.STAR_ALLIANCE),
+        ("ONEWORLD", Airline.ONEWORLD),
+        ("SKYTEAM", Airline.SKYTEAM),
+    ],
+)
+def test_parse_airlines_alliance(code, expected):
+    assert parse_airlines([code]) == [expected]
 
 
-class TestParseAirlinesWithAlliances:
-    """Tests for parse_airlines with alliance codes."""
-
-    def test_alliance_star_alliance(self):
-        result = parse_airlines(["STAR_ALLIANCE"])
-        assert result == [Airline.STAR_ALLIANCE]
-
-    def test_alliance_oneworld(self):
-        result = parse_airlines(["ONEWORLD"])
-        assert result == [Airline.ONEWORLD]
-
-    def test_alliance_skyteam(self):
-        result = parse_airlines(["SKYTEAM"])
-        assert result == [Airline.SKYTEAM]
-
-    def test_alliance_mixed_with_airlines(self):
-        result = parse_airlines(["STAR_ALLIANCE", "AA"])
-        assert Airline.STAR_ALLIANCE in result
-        assert Airline.AA in result
+def test_parse_airlines_alliance_mixed_with_airlines():
+    result = parse_airlines(["STAR_ALLIANCE", "AA"])
+    assert Airline.STAR_ALLIANCE in result
+    assert Airline.AA in result
 
 
 class TestParseAirlinesSplitting:
@@ -98,21 +91,10 @@ class TestParseAirlinesSplitting:
         with pytest.raises(ParseError, match="Invalid airline code: 'XXX'"):
             parse_airlines(["BA,XXX"])
 
-    def test_raises_when_only_commas(self):
+    @pytest.mark.parametrize("codes", [[","], [" "], [""], ["", " ", ","]])
+    def test_raises_when_no_valid_codes(self, codes):
         with pytest.raises(ParseError, match="No valid airline codes"):
-            parse_airlines([","])
-
-    def test_raises_when_only_whitespace(self):
-        with pytest.raises(ParseError, match="No valid airline codes"):
-            parse_airlines([" "])
-
-    def test_raises_when_only_empty_string(self):
-        with pytest.raises(ParseError, match="No valid airline codes"):
-            parse_airlines([""])
-
-    def test_raises_when_only_separators_across_items(self):
-        with pytest.raises(ParseError, match="No valid airline codes"):
-            parse_airlines(["", " ", ","])
+            parse_airlines(codes)
 
     def test_none_input_still_returns_none(self):
         assert parse_airlines(None) is None
@@ -121,25 +103,19 @@ class TestParseAirlinesSplitting:
         assert parse_airlines([]) is None
 
 
-class TestParseSortBy:
-    """Tests for parse_sort_by with updated enum values."""
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("TOP_FLIGHTS", SortBy.TOP_FLIGHTS),
+        ("BEST", SortBy.BEST),
+        ("CHEAPEST", SortBy.CHEAPEST),
+        ("EMISSIONS", SortBy.EMISSIONS),
+    ],
+)
+def test_parse_sort_by(value, expected):
+    assert parse_sort_by(value) == expected
 
-    def test_top_flights(self):
-        assert parse_sort_by("TOP_FLIGHTS") == SortBy.TOP_FLIGHTS
-        assert SortBy.TOP_FLIGHTS.value == 0
 
-    def test_best(self):
-        assert parse_sort_by("BEST") == SortBy.BEST
-        assert SortBy.BEST.value == 1
-
-    def test_cheapest(self):
-        assert parse_sort_by("CHEAPEST") == SortBy.CHEAPEST
-        assert SortBy.CHEAPEST.value == 2
-
-    def test_emissions(self):
-        assert parse_sort_by("EMISSIONS") == SortBy.EMISSIONS
-        assert SortBy.EMISSIONS.value == 6
-
-    def test_invalid(self):
-        with pytest.raises(ParseError, match="Invalid sort_by value"):
-            parse_sort_by("NONE")
+def test_parse_sort_by_invalid():
+    with pytest.raises(ParseError, match="Invalid sort_by value"):
+        parse_sort_by("NONE")

--- a/tests/mcp/test_mcp_server_unit.py
+++ b/tests/mcp/test_mcp_server_unit.py
@@ -21,6 +21,15 @@ from fli.mcp.server import (
 )
 
 
+def _make_raiser(exc: BaseException):
+    """Return a callable that unconditionally raises ``exc``."""
+
+    def _raiser(*args, **kwargs):
+        raise exc
+
+    return _raiser
+
+
 class TestAirlineCode:
     def test_enum_with_leading_underscore_stripped(self):
         airline = MagicMock()
@@ -35,10 +44,6 @@ class TestAirlineCode:
     def test_plain_string_passthrough(self):
         # Strings have no `.name` attribute, so str(airline) is used.
         assert _airline_code("AA") == "AA"
-
-    def test_none_uses_str(self):
-        # None has no `.name`, so falls back to str(None) = "None".
-        assert _airline_code(None) == "None"
 
 
 class TestSerializeFlightLeg:
@@ -224,7 +229,7 @@ class TestExecuteFlightSearchNetworkError:
 
         monkeypatch.setattr(
             "fli.mcp.server.SearchFlights.search",
-            lambda self, *a, **kw: (_ for _ in ()).throw(SearchClientError("network down")),
+            _make_raiser(SearchClientError("network down")),
         )
         result = _execute_flight_search(valid_params)
         assert result["success"] is False
@@ -232,15 +237,15 @@ class TestExecuteFlightSearchNetworkError:
     def test_exception_message_in_error_field(self, monkeypatch, valid_params):
         monkeypatch.setattr(
             "fli.mcp.server.SearchFlights.search",
-            lambda self, *a, **kw: (_ for _ in ()).throw(RuntimeError("proxy timeout")),
+            _make_raiser(RuntimeError("proxy timeout")),
         )
         result = _execute_flight_search(valid_params)
-        assert "proxy timeout" in result["error"]
+        assert result["error"] == "Search failed: proxy timeout"
 
     def test_flights_key_is_empty_list_on_error(self, monkeypatch, valid_params):
         monkeypatch.setattr(
             "fli.mcp.server.SearchFlights.search",
-            lambda self, *a, **kw: (_ for _ in ()).throw(RuntimeError("fail")),
+            _make_raiser(RuntimeError("fail")),
         )
         result = _execute_flight_search(valid_params)
         assert result["flights"] == []

--- a/tests/mcp/test_mcp_server_unit.py
+++ b/tests/mcp/test_mcp_server_unit.py
@@ -1,0 +1,238 @@
+"""Unit tests for MCP server serialization helpers and error propagation.
+
+Targets functions that are only reached via integration tests in the existing
+suite: _airline_code, _serialize_flight_leg, _serialize_layover,
+_flight_extras, and the bare-except error path in _execute_flight_search.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from fli.mcp.server import (
+    FlightSearchParams,
+    _airline_code,
+    _execute_flight_search,
+    _flight_extras,
+    _serialize_flight_leg,
+    _serialize_layover,
+)
+
+
+class TestAirlineCode:
+    def test_enum_with_leading_underscore_stripped(self):
+        airline = MagicMock()
+        airline.name = "_2B"
+        assert _airline_code(airline) == "2B"
+
+    def test_plain_enum_name_unchanged(self):
+        airline = MagicMock()
+        airline.name = "DL"
+        assert _airline_code(airline) == "DL"
+
+    def test_plain_string_passthrough(self):
+        # Strings have no `.name` attribute, so str(airline) is used.
+        assert _airline_code("AA") == "AA"
+
+    def test_none_uses_str(self):
+        # None has no `.name`, so falls back to str(None) = "None".
+        assert _airline_code(None) == "None"
+
+
+class TestSerializeFlightLeg:
+    def _make_leg(self, **overrides):
+        leg = MagicMock()
+        leg.departure_airport = "JFK"
+        leg.arrival_airport = "LHR"
+        leg.departure_datetime = None
+        leg.arrival_datetime = None
+        leg.duration = 420
+        leg.airline = "AA"
+        leg.flight_number = "100"
+        leg.departure_airport_name = None
+        leg.arrival_airport_name = None
+        leg.operating_airline = None
+        leg.aircraft = None
+        leg.legroom = None
+        leg.overnight = False
+        leg.amenities = None
+        for k, v in overrides.items():
+            setattr(leg, k, v)
+        return leg
+
+    def test_required_fields_always_present(self):
+        leg = self._make_leg()
+        result = _serialize_flight_leg(leg)
+        for key in ("departure_airport", "arrival_airport", "departure_time",
+                    "arrival_time", "duration", "airline", "airline_code", "flight_number"):
+            assert key in result
+
+    def test_none_optional_fields_excluded(self):
+        leg = self._make_leg()
+        result = _serialize_flight_leg(leg)
+        assert "departure_airport_name" not in result
+        assert "arrival_airport_name" not in result
+        assert "operating_airline" not in result
+        assert "aircraft" not in result
+        assert "legroom" not in result
+
+    def test_overnight_true_included(self):
+        leg = self._make_leg(overnight=True)
+        result = _serialize_flight_leg(leg)
+        assert result.get("overnight") is True
+
+    def test_overnight_false_excluded(self):
+        leg = self._make_leg(overnight=False)
+        result = _serialize_flight_leg(leg)
+        assert "overnight" not in result
+
+    def test_operating_airline_included_when_set(self):
+        op = MagicMock()
+        op.name = "B6"
+        leg = self._make_leg(operating_airline=op)
+        result = _serialize_flight_leg(leg)
+        assert result["operating_airline"] == "B6"
+
+    def test_amenities_included_with_truthy_fields(self):
+        from fli.models import Amenities
+
+        leg = self._make_leg(amenities=Amenities(wifi=True))
+        result = _serialize_flight_leg(leg)
+        assert "amenities" in result
+        assert result["amenities"]["wifi"] is True
+
+    def test_amenities_excluded_when_none(self):
+        leg = self._make_leg(amenities=None)
+        result = _serialize_flight_leg(leg)
+        assert "amenities" not in result
+
+    def test_amenities_excluded_when_all_fields_are_none(self):
+        from fli.models import Amenities
+
+        leg = self._make_leg(amenities=Amenities())
+        result = _serialize_flight_leg(leg)
+        # model_dump(exclude_none=True) on an all-None Amenities → empty dict → not included
+        assert "amenities" not in result
+
+
+class TestSerializeLayover:
+    def _make_layover(self, **overrides):
+        lo = MagicMock()
+        lo.airport = "FRA"
+        lo.duration = 90
+        lo.overnight = False
+        lo.change_of_airport = False
+        for k, v in overrides.items():
+            setattr(lo, k, v)
+        return lo
+
+    def test_airport_and_duration_always_present(self):
+        lo = self._make_layover()
+        result = _serialize_layover(lo)
+        assert "airport" in result
+        assert result["duration"] == 90
+
+    def test_overnight_true_included(self):
+        lo = self._make_layover(overnight=True)
+        result = _serialize_layover(lo)
+        assert result.get("overnight") is True
+
+    def test_overnight_false_excluded(self):
+        lo = self._make_layover(overnight=False)
+        result = _serialize_layover(lo)
+        assert "overnight" not in result
+
+    def test_change_of_airport_true_included(self):
+        lo = self._make_layover(change_of_airport=True)
+        result = _serialize_layover(lo)
+        assert result.get("change_of_airport") is True
+
+    def test_change_of_airport_false_excluded(self):
+        lo = self._make_layover(change_of_airport=False)
+        result = _serialize_layover(lo)
+        assert "change_of_airport" not in result
+
+
+class TestFlightExtras:
+    def _make_flight(self, **overrides):
+        f = MagicMock()
+        f.primary_airline_name = None
+        f.self_transfer = None
+        f.mixed_cabin = None
+        f.booking_token = None
+        f.primary_airline = None
+        f.layovers = None
+        for k, v in overrides.items():
+            setattr(f, k, v)
+        return f
+
+    def test_booking_token_included_when_set(self):
+        f = self._make_flight(booking_token="tok123")
+        result = _flight_extras(f)
+        assert result["booking_token"] == "tok123"
+
+    def test_booking_token_excluded_when_empty_string(self):
+        f = self._make_flight(booking_token="")
+        result = _flight_extras(f)
+        assert "booking_token" not in result
+
+    def test_booking_token_excluded_when_none(self):
+        f = self._make_flight(booking_token=None)
+        result = _flight_extras(f)
+        assert "booking_token" not in result
+
+    def test_self_transfer_true_included(self):
+        f = self._make_flight(self_transfer=True)
+        result = _flight_extras(f)
+        assert result.get("self_transfer") is True
+
+    def test_layovers_serialized(self):
+        lo = MagicMock()
+        lo.airport = "CDG"
+        lo.duration = 60
+        lo.overnight = False
+        lo.change_of_airport = False
+        f = self._make_flight(layovers=[lo])
+        result = _flight_extras(f)
+        assert "layovers" in result
+        assert len(result["layovers"]) == 1
+
+
+class TestExecuteFlightSearchNetworkError:
+    """The bare-except in _execute_flight_search must produce a clean error dict."""
+
+    @pytest.fixture
+    def valid_params(self):
+        return FlightSearchParams(
+            origin="JFK",
+            destination="LHR",
+            departure_date="2026-12-01",
+        )
+
+    def test_search_client_error_returns_success_false(self, monkeypatch, valid_params):
+        from fli.search.exceptions import SearchClientError
+
+        monkeypatch.setattr(
+            "fli.mcp.server.SearchFlights.search",
+            lambda self, *a, **kw: (_ for _ in ()).throw(SearchClientError("network down")),
+        )
+        result = _execute_flight_search(valid_params)
+        assert result["success"] is False
+
+    def test_exception_message_in_error_field(self, monkeypatch, valid_params):
+        monkeypatch.setattr(
+            "fli.mcp.server.SearchFlights.search",
+            lambda self, *a, **kw: (_ for _ in ()).throw(RuntimeError("proxy timeout")),
+        )
+        result = _execute_flight_search(valid_params)
+        assert "proxy timeout" in result["error"]
+
+    def test_flights_key_is_empty_list_on_error(self, monkeypatch, valid_params):
+        monkeypatch.setattr(
+            "fli.mcp.server.SearchFlights.search",
+            lambda self, *a, **kw: (_ for _ in ()).throw(RuntimeError("fail")),
+        )
+        result = _execute_flight_search(valid_params)
+        assert result["flights"] == []

--- a/tests/mcp/test_mcp_server_unit.py
+++ b/tests/mcp/test_mcp_server_unit.py
@@ -65,8 +65,16 @@ class TestSerializeFlightLeg:
     def test_required_fields_always_present(self):
         leg = self._make_leg()
         result = _serialize_flight_leg(leg)
-        for key in ("departure_airport", "arrival_airport", "departure_time",
-                    "arrival_time", "duration", "airline", "airline_code", "flight_number"):
+        for key in (
+            "departure_airport",
+            "arrival_airport",
+            "departure_time",
+            "arrival_time",
+            "duration",
+            "airline",
+            "airline_code",
+            "flight_number",
+        ):
             assert key in result
 
     def test_none_optional_fields_excluded(self):

--- a/tests/models/test_flight_search_filters.py
+++ b/tests/models/test_flight_search_filters.py
@@ -665,4 +665,6 @@ def test_flight_search_filters(test_case):
 
     # Test URL encoding
     encoded_filters = search_filters.encode()
-    assert test_case["encoded"] is None or encoded_filters == test_case["encoded"]
+    assert isinstance(encoded_filters, str) and len(encoded_filters) > 0
+    if test_case["encoded"] is not None:
+        assert encoded_filters == test_case["encoded"]

--- a/tests/search/test_client.py
+++ b/tests/search/test_client.py
@@ -1,0 +1,120 @@
+"""Unit tests for fli.search.client — error mapping, host extraction, and singleton."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import fli.search.client as client_module
+from fli.search.client import _host_from_url, _wrap_request_error, get_client
+from fli.search.exceptions import (
+    SearchClientError,
+    SearchConnectionError,
+    SearchHTTPError,
+    SearchTimeoutError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_singleton():
+    """Each test starts with a clean singleton so tests don't share state."""
+    original = client_module.client
+    client_module.client = None
+    yield
+    client_module.client = original
+
+
+class TestWrapRequestError:
+    """_wrap_request_error must map curl_cffi errors to typed SearchClientError subclasses."""
+
+    def test_timeout_exc_returns_search_timeout_error(self):
+        from curl_cffi.requests import exceptions as curl_exc
+
+        exc = curl_exc.Timeout("curl: (28) timed out", 28, None)
+        result = _wrap_request_error("GET", "https://www.google.com/path", exc)
+        assert isinstance(result, SearchTimeoutError)
+
+    def test_timeout_message_includes_host(self):
+        from curl_cffi.requests import exceptions as curl_exc
+
+        exc = curl_exc.Timeout("timed out", 28, None)
+        result = _wrap_request_error("GET", "https://flights.google.com/search", exc)
+        assert "flights.google.com" in str(result)
+
+    def test_connection_exc_returns_search_connection_error(self):
+        from curl_cffi.requests import exceptions as curl_exc
+
+        exc = curl_exc.ConnectionError("dns lookup failed", 6, None)
+        result = _wrap_request_error("GET", "https://www.google.com/", exc)
+        assert isinstance(result, SearchConnectionError)
+
+    def test_http_exc_with_status_returns_search_http_error(self):
+        from curl_cffi.requests import exceptions as curl_exc
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        exc = curl_exc.HTTPError("403 Forbidden", 403, mock_response)
+        exc.response = mock_response
+
+        result = _wrap_request_error("POST", "https://www.google.com/", exc)
+        assert isinstance(result, SearchHTTPError)
+        assert result.status_code == 403
+        assert "403" in str(result)
+
+    def test_http_exc_without_response_has_none_status(self):
+        from curl_cffi.requests import exceptions as curl_exc
+
+        exc = curl_exc.HTTPError("error", 0, None)
+        result = _wrap_request_error("POST", "https://www.google.com/", exc)
+        assert isinstance(result, SearchHTTPError)
+        assert result.status_code is None
+
+    def test_unknown_exc_returns_search_client_error(self):
+        exc = ValueError("something unexpected")
+        result = _wrap_request_error("GET", "https://www.google.com/", exc)
+        assert isinstance(result, SearchClientError)
+        assert not isinstance(result, SearchTimeoutError | SearchConnectionError | SearchHTTPError)
+
+    def test_already_typed_error_passes_through_unchanged(self):
+        original = SearchTimeoutError("already typed")
+        result = _wrap_request_error("GET", "https://www.google.com/", original)
+        assert result is original
+
+    def test_message_uses_url_as_fallback_on_parse_failure(self):
+        exc = RuntimeError("boom")
+        result = _wrap_request_error("GET", "not-a-url", exc)
+        # Should include the raw string when urlparse can't extract a host.
+        assert "not-a-url" in str(result)
+
+
+class TestHostFromUrl:
+    def test_standard_https_url(self):
+        assert _host_from_url("https://www.google.com/path?q=1") == "www.google.com"
+
+    def test_url_without_host_returns_input(self):
+        assert _host_from_url("not-a-url") == "not-a-url"
+
+    def test_empty_string_returns_empty(self):
+        # Shouldn't raise — empty is a valid degenerate case.
+        result = _host_from_url("")
+        assert result == ""
+
+
+class TestGetClientSingleton:
+    def test_returns_client_instance(self):
+        from fli.search.client import Client
+
+        c = get_client()
+        assert isinstance(c, Client)
+
+    def test_returns_same_instance_on_repeated_calls(self):
+        c1 = get_client()
+        c2 = get_client()
+        assert c1 is c2
+
+    def test_reset_global_creates_new_instance(self):
+        c1 = get_client()
+        client_module.client = None
+        c2 = get_client()
+        assert c1 is not c2

--- a/tests/search/test_concurrency.py
+++ b/tests/search/test_concurrency.py
@@ -249,3 +249,56 @@ class TestParallelMap:
         # the synchronous fallback at max_workers=1 elsewhere.
         # Here we just verify completion + correct count.
         assert peak >= 1
+
+    def test_generator_input_materialised_and_mapped(self):
+        result = parallel_map(lambda x: x * 3, (x for x in range(4)))
+        assert result == [0, 3, 6, 9]
+
+    def test_tuple_input_works(self):
+        result = parallel_map(lambda x: x + 1, (10, 20, 30))
+        assert result == [11, 21, 31]
+
+    def test_exception_in_last_item_propagates(self):
+        def fn(x):
+            if x == 2:
+                raise RuntimeError("last item error")
+            return x
+
+        with pytest.raises(RuntimeError, match="last item error"):
+            parallel_map(fn, [0, 1, 2])
+
+
+class TestShutdownExecutor:
+    def teardown_method(self):
+        shutdown_executor()
+        configure_concurrency(10)
+
+    def test_shutdown_then_get_creates_new_executor(self):
+        original = get_executor()
+        shutdown_executor()
+        new = get_executor()
+        assert new is not original
+
+    def test_shutdown_idempotent(self):
+        # Calling shutdown twice must not raise.
+        shutdown_executor()
+        shutdown_executor()
+
+
+class TestTokenBucketEdgeCases:
+    def test_multi_token_acquire_leaves_correct_remainder(self):
+        limiter = TokenBucketRateLimiter(calls=5, period=1.0)
+        # Acquire 3 from a full 5-token bucket — should succeed immediately.
+        start = time.perf_counter()
+        assert limiter.acquire(tokens=3) is True
+        assert (time.perf_counter() - start) < 0.05
+
+    def test_capacity_property_equals_calls_arg(self):
+        limiter = TokenBucketRateLimiter(calls=7, period=2.0)
+        assert limiter.capacity == 7
+
+    def test_deadline_timeout_returns_false_on_empty_bucket(self):
+        limiter = TokenBucketRateLimiter(calls=1, period=10.0)
+        limiter.acquire()  # drain
+        # With a very short timeout the bucket won't refill in time.
+        assert limiter.acquire(tokens=1, timeout=0.02) is False

--- a/tests/search/test_concurrency.py
+++ b/tests/search/test_concurrency.py
@@ -229,6 +229,8 @@ class TestParallelMap:
 
     def test_max_workers_cap_observed(self):
         """``max_workers=2`` should not run all 4 jobs concurrently."""
+        # Reset to a known state so get_executor creates a fresh 2-worker pool.
+        shutdown_executor()
         in_flight = 0
         peak = 0
         lock = threading.Lock()
@@ -244,11 +246,8 @@ class TestParallelMap:
             return x
 
         parallel_map(fn, list(range(4)), max_workers=2)
-        # The executor caps concurrency. Note: the shared pool may already
-        # be sized larger than 2, so this only verifies behaviour through
-        # the synchronous fallback at max_workers=1 elsewhere.
-        # Here we just verify completion + correct count.
         assert peak >= 1
+        assert peak <= 2
 
     def test_generator_input_materialised_and_mapped(self):
         result = parallel_map(lambda x: x * 3, (x for x in range(4)))
@@ -286,19 +285,8 @@ class TestShutdownExecutor:
 
 
 class TestTokenBucketEdgeCases:
-    def test_multi_token_acquire_leaves_correct_remainder(self):
+    def test_bulk_acquire_from_full_bucket_is_immediate(self):
         limiter = TokenBucketRateLimiter(calls=5, period=1.0)
-        # Acquire 3 from a full 5-token bucket — should succeed immediately.
         start = time.perf_counter()
         assert limiter.acquire(tokens=3) is True
         assert (time.perf_counter() - start) < 0.05
-
-    def test_capacity_property_equals_calls_arg(self):
-        limiter = TokenBucketRateLimiter(calls=7, period=2.0)
-        assert limiter.capacity == 7
-
-    def test_deadline_timeout_returns_false_on_empty_bucket(self):
-        limiter = TokenBucketRateLimiter(calls=1, period=10.0)
-        limiter.acquire()  # drain
-        # With a very short timeout the bucket won't refill in time.
-        assert limiter.acquire(tokens=1, timeout=0.02) is False

--- a/tests/search/test_decoders.py
+++ b/tests/search/test_decoders.py
@@ -93,29 +93,20 @@ class TestParseEmissions:
         assert result["tag"] is None
         assert result["this_g"] is None
 
-    def test_tag_int_1_maps_to_lower(self):
+    @pytest.mark.parametrize(
+        "tag_int, expected_tag",
+        [
+            (1, "lower"),
+            (2, "typical"),
+            (3, "higher"),
+            (4, None),
+        ],
+    )
+    def test_tag_int_mapping(self, tag_int, expected_tag):
         block = [None] * 12
-        block[11] = 1
+        block[11] = tag_int
         result = _parse_emissions(self._detail_with_emissions(block))
-        assert result["tag"] == "lower"
-
-    def test_tag_int_2_maps_to_typical(self):
-        block = [None] * 12
-        block[11] = 2
-        result = _parse_emissions(self._detail_with_emissions(block))
-        assert result["tag"] == "typical"
-
-    def test_tag_int_3_maps_to_higher(self):
-        block = [None] * 12
-        block[11] = 3
-        result = _parse_emissions(self._detail_with_emissions(block))
-        assert result["tag"] == "higher"
-
-    def test_tag_int_out_of_range_returns_none(self):
-        block = [None] * 12
-        block[11] = 4
-        result = _parse_emissions(self._detail_with_emissions(block))
-        assert result["tag"] is None
+        assert result["tag"] == expected_tag
 
     def test_g_values_extracted(self):
         block = [None] * 12

--- a/tests/search/test_decoders.py
+++ b/tests/search/test_decoders.py
@@ -1,0 +1,234 @@
+"""Unit tests for fli.search._decoders — direct decoder function coverage.
+
+Tests import private helpers directly to cover branches that integration tests
+and snapshot fixtures can't reach (warning-log paths, empty/None inputs,
+unusual wire-format shapes).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import pytest
+
+from fli.search._decoders import (
+    _extract_booking_urls,
+    _extract_fare_name,
+    _parse_emissions,
+    _safe_airline,
+    parse_booking_chunk,
+)
+
+
+class TestSafeAirline:
+    def test_known_code_returns_enum(self):
+        from fli.models import Airline
+
+        result = _safe_airline("DL")
+        assert result is Airline.DL
+
+    def test_none_returns_none(self):
+        assert _safe_airline(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _safe_airline("") is None
+
+    def test_int_returns_none(self):
+        assert _safe_airline(42) is None
+
+    def test_sentinel_multi_returns_none_silently(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="fli.search._decoders"):
+            result = _safe_airline("multi")
+        assert result is None
+        assert not caplog.records
+
+    def test_unknown_code_returns_none_and_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="fli.search._decoders"):
+            result = _safe_airline("ZZFAKE")
+        assert result is None
+        assert any("ZZFAKE" in r.message for r in caplog.records)
+
+
+class TestParseDatetime:
+    def test_valid_arrays_produce_datetime(self):
+        from fli.search._decoders import _parse_datetime
+
+        dt = _parse_datetime([2026, 7, 15], [20, 25])
+        assert dt == datetime(2026, 7, 15, 20, 25)
+
+    def test_all_none_date_raises_value_error(self):
+        from fli.search._decoders import _parse_datetime
+
+        with pytest.raises(ValueError):
+            _parse_datetime([None, None, None], [0, 0])
+
+    def test_all_none_time_raises_value_error(self):
+        from fli.search._decoders import _parse_datetime
+
+        with pytest.raises(ValueError):
+            _parse_datetime([2026, 1, 1], [None, None])
+
+    def test_none_time_values_coerced_to_zero(self):
+        from fli.search._decoders import _parse_datetime
+
+        # None minute → coerced to 0 by the `x or 0` expression.
+        dt = _parse_datetime([2026, 7, 15], [10, None])
+        assert dt == datetime(2026, 7, 15, 10, 0)
+
+
+class TestParseEmissions:
+    def _detail_with_emissions(self, emissions_block):
+        """Build a minimal detail list with the given emissions block at index 22."""
+        detail = [None] * 23
+        detail[22] = emissions_block
+        return detail
+
+    def test_missing_block_returns_all_none(self):
+        result = _parse_emissions([])
+        assert result == {"this_g": None, "typical_g": None, "delta_pct": None, "tag": None}
+
+    def test_non_list_block_returns_all_none(self):
+        result = _parse_emissions(self._detail_with_emissions("bad"))
+        assert result["tag"] is None
+        assert result["this_g"] is None
+
+    def test_tag_int_1_maps_to_lower(self):
+        block = [None] * 12
+        block[11] = 1
+        result = _parse_emissions(self._detail_with_emissions(block))
+        assert result["tag"] == "lower"
+
+    def test_tag_int_2_maps_to_typical(self):
+        block = [None] * 12
+        block[11] = 2
+        result = _parse_emissions(self._detail_with_emissions(block))
+        assert result["tag"] == "typical"
+
+    def test_tag_int_3_maps_to_higher(self):
+        block = [None] * 12
+        block[11] = 3
+        result = _parse_emissions(self._detail_with_emissions(block))
+        assert result["tag"] == "higher"
+
+    def test_tag_int_out_of_range_returns_none(self):
+        block = [None] * 12
+        block[11] = 4
+        result = _parse_emissions(self._detail_with_emissions(block))
+        assert result["tag"] is None
+
+    def test_g_values_extracted(self):
+        block = [None] * 12
+        block[7] = 150000  # this_g
+        block[8] = 180000  # typical_g
+        block[3] = -17  # delta_pct
+        block[11] = 1
+        result = _parse_emissions(self._detail_with_emissions(block))
+        assert result["this_g"] == 150000
+        assert result["typical_g"] == 180000
+        assert result["delta_pct"] == -17
+
+
+class TestExtractBookingUrls:
+    def test_returns_vendor_and_google_urls(self):
+        block = ["https://vendor.com/book", None, ["/travel/clk?hl=en"]]
+        vendor_url, google_url = _extract_booking_urls(block)
+        assert vendor_url == "https://vendor.com/book"
+        assert google_url == "/travel/clk?hl=en"
+
+    def test_none_block_returns_none_none(self):
+        assert _extract_booking_urls(None) == (None, None)
+
+    def test_non_list_block_returns_none_none(self):
+        assert _extract_booking_urls("string") == (None, None)
+
+    def test_missing_google_url_returns_none(self):
+        block = ["https://vendor.com"]  # len < 3, no block[2]
+        vendor_url, google_url = _extract_booking_urls(block)
+        assert vendor_url == "https://vendor.com"
+        assert google_url is None
+
+    def test_google_url_without_travel_clk_not_returned(self):
+        block = ["https://vendor.com", None, ["https://other.com/book"]]
+        _, google_url = _extract_booking_urls(block)
+        assert google_url is None
+
+    def test_non_string_first_element_returns_none_vendor(self):
+        block = [42, None, ["/travel/clk?x=1"]]
+        vendor_url, _ = _extract_booking_urls(block)
+        assert vendor_url is None
+
+
+class TestExtractFareName:
+    def test_row21_position_preferred(self):
+        row = [None] * 22
+        row[21] = [None, None, None, "Basic Economy"]
+        assert _extract_fare_name(row) == "Basic Economy"
+
+    def test_falls_back_to_row14_nested(self):
+        row = [None] * 22
+        row[21] = []  # too short — len <= 3
+        row[14] = [[[None, [None, "Main Cabin"]]]]
+        assert _extract_fare_name(row) == "Main Cabin"
+
+    def test_returns_none_when_both_absent(self):
+        row = [None] * 22
+        assert _extract_fare_name(row) is None
+
+    def test_empty_string_in_row21_skipped(self):
+        row = [None] * 22
+        row[21] = [None, None, None, ""]  # empty string is not a valid fare name
+        assert _extract_fare_name(row) is None
+
+    def test_row14_fallback_index_error_returns_none(self):
+        row = [None] * 22
+        row[21] = []
+        row[14] = [[[]]]  # too short to reach row[14][0][0][1][1]
+        assert _extract_fare_name(row) is None
+
+
+class TestParseBookingChunk:
+    def _make_booking_row(self, index=0, vendor_code="AA", vendor_name="American", price=100.0):
+        """Build a minimal booking row that passes _try_parse_booking_row's shape checks."""
+        return [
+            index,  # [0] int
+            [[vendor_code, vendor_name]],  # [1] vendor list
+            None,  # [2]
+            [],  # [3] flights
+            None,  # [4]
+            None,  # [5] URL block
+            None,  # [6]
+            [[None, price]],  # [7] price block
+        ]
+
+    def test_empty_chunk_returns_empty_list(self):
+        assert parse_booking_chunk([]) == []
+
+    def test_none_chunk_returns_empty_list(self):
+        assert parse_booking_chunk(None) == []
+
+    def test_finds_booking_row_at_top_level(self):
+        row = self._make_booking_row(vendor_code="UA", price=250.0)
+        result = parse_booking_chunk([row])
+        assert len(result) == 1
+        assert result[0].vendor_code == "UA"
+        assert result[0].price == 250.0
+
+    def test_finds_booking_row_nested_one_level(self):
+        row = self._make_booking_row(vendor_code="DL", price=199.0)
+        result = parse_booking_chunk([[row]])
+        assert len(result) == 1
+        assert result[0].vendor_code == "DL"
+
+    def test_non_booking_shape_lists_are_ignored(self):
+        # A list with a string first element doesn't match (needs int at [0]).
+        result = parse_booking_chunk([["not", "a", "booking", "row", None, None, None, None]])
+        assert result == []
+
+    def test_multiple_booking_rows_all_returned(self):
+        row1 = self._make_booking_row(index=0, vendor_code="AA", price=300.0)
+        row2 = self._make_booking_row(index=1, vendor_code="UA", price=320.0)
+        result = parse_booking_chunk([row1, row2])
+        assert len(result) == 2
+        codes = {r.vendor_code for r in result}
+        assert codes == {"AA", "UA"}

--- a/tests/search/test_helpers.py
+++ b/tests/search/test_helpers.py
@@ -1,0 +1,128 @@
+"""Unit tests for fli.search._helpers — the defensive accessors used by all decoders."""
+
+from __future__ import annotations
+
+from fli.search._helpers import as_bool, as_int, as_non_negative_int, as_str, safe_get
+
+
+class TestSafeGet:
+    def test_returns_element_at_valid_index(self):
+        assert safe_get([1, 2, 3], 1) == 2
+
+    def test_returns_none_for_out_of_bounds(self):
+        assert safe_get([1], 5) is None
+
+    def test_returns_none_for_negative_index(self):
+        assert safe_get([1, 2], -1) is None
+
+    def test_returns_none_for_non_list_string(self):
+        assert safe_get("abc", 0) is None
+
+    def test_returns_none_for_non_list_dict(self):
+        assert safe_get({"a": 1}, 0) is None
+
+    def test_returns_none_for_none_seq(self):
+        assert safe_get(None, 0) is None
+
+    def test_returns_none_for_empty_list(self):
+        assert safe_get([], 0) is None
+
+    def test_returns_falsy_zero_at_index(self):
+        # 0 at a valid index is NOT None — callers rely on this distinction.
+        assert safe_get([False, 0, None], 1) == 0
+
+    def test_returns_false_at_index(self):
+        assert safe_get([False, 0, None], 0) is False
+
+    def test_returns_none_element_at_index(self):
+        # None stored at a valid index should be returned as-is.
+        assert safe_get([1, None, 3], 1) is None
+
+
+class TestAsBool:
+    def test_true_returns_true(self):
+        assert as_bool(True) is True
+
+    def test_false_returns_false(self):
+        # False is a valid bool — must NOT return None.
+        result = as_bool(False)
+        assert result is False
+        assert result is not None
+
+    def test_int_one_returns_none(self):
+        assert as_bool(1) is None
+
+    def test_int_zero_returns_none(self):
+        assert as_bool(0) is None
+
+    def test_string_true_returns_none(self):
+        assert as_bool("true") is None
+
+    def test_none_returns_none(self):
+        assert as_bool(None) is None
+
+
+class TestAsStr:
+    def test_non_empty_string_returned(self):
+        assert as_str("hello") == "hello"
+
+    def test_empty_string_returns_none(self):
+        assert as_str("") is None
+
+    def test_int_returns_none(self):
+        assert as_str(42) is None
+
+    def test_none_returns_none(self):
+        assert as_str(None) is None
+
+    def test_whitespace_only_string_returned(self):
+        # Only the empty string is rejected; whitespace-only is kept.
+        assert as_str("  ") == "  "
+
+    def test_bool_returns_none(self):
+        assert as_str(True) is None
+
+
+class TestAsInt:
+    def test_positive_int_returned(self):
+        assert as_int(5) == 5
+
+    def test_zero_returned(self):
+        assert as_int(0) == 0
+
+    def test_negative_int_returned(self):
+        assert as_int(-3) == -3
+
+    def test_bool_true_returns_none(self):
+        # bool is a subclass of int in Python — must be explicitly rejected.
+        assert as_int(True) is None
+
+    def test_bool_false_returns_none(self):
+        assert as_int(False) is None
+
+    def test_float_returns_none(self):
+        assert as_int(3.0) is None
+
+    def test_string_returns_none(self):
+        assert as_int("5") is None
+
+    def test_none_returns_none(self):
+        assert as_int(None) is None
+
+
+class TestAsNonNegativeInt:
+    def test_zero_returned(self):
+        assert as_non_negative_int(0) == 0
+
+    def test_positive_returned(self):
+        assert as_non_negative_int(42) == 42
+
+    def test_negative_returns_none(self):
+        assert as_non_negative_int(-1) is None
+
+    def test_bool_returns_none(self):
+        # Inherits as_int rejection of bools.
+        assert as_non_negative_int(True) is None
+
+    def test_none_returns_none(self):
+        assert as_non_negative_int(None) is None

--- a/tests/search/test_helpers.py
+++ b/tests/search/test_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from fli.search._helpers import as_bool, as_int, as_non_negative_int, as_str, safe_get
 
 
@@ -39,90 +41,66 @@ class TestSafeGet:
         assert safe_get([1, None, 3], 1) is None
 
 
-class TestAsBool:
-    def test_true_returns_true(self):
-        assert as_bool(True) is True
-
-    def test_false_returns_false(self):
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        (True, True),
         # False is a valid bool — must NOT return None.
-        result = as_bool(False)
-        assert result is False
-        assert result is not None
-
-    def test_int_one_returns_none(self):
-        assert as_bool(1) is None
-
-    def test_int_zero_returns_none(self):
-        assert as_bool(0) is None
-
-    def test_string_true_returns_none(self):
-        assert as_bool("true") is None
-
-    def test_none_returns_none(self):
-        assert as_bool(None) is None
+        (False, False),
+        (1, None),
+        (0, None),
+        ("true", None),
+        (None, None),
+    ],
+)
+def test_as_bool(val, expected):
+    assert as_bool(val) is expected
 
 
-class TestAsStr:
-    def test_non_empty_string_returned(self):
-        assert as_str("hello") == "hello"
-
-    def test_empty_string_returns_none(self):
-        assert as_str("") is None
-
-    def test_int_returns_none(self):
-        assert as_str(42) is None
-
-    def test_none_returns_none(self):
-        assert as_str(None) is None
-
-    def test_whitespace_only_string_returned(self):
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        ("hello", "hello"),
         # Only the empty string is rejected; whitespace-only is kept.
-        assert as_str("  ") == "  "
+        ("  ", "  "),
+        ("", None),
+        (42, None),
+        (True, None),
+        (None, None),
+    ],
+)
+def test_as_str(val, expected):
+    assert as_str(val) == expected
 
-    def test_bool_returns_none(self):
-        assert as_str(True) is None
 
-
-class TestAsInt:
-    def test_positive_int_returned(self):
-        assert as_int(5) == 5
-
-    def test_zero_returned(self):
-        assert as_int(0) == 0
-
-    def test_negative_int_returned(self):
-        assert as_int(-3) == -3
-
-    def test_bool_true_returns_none(self):
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        (5, 5),
+        (0, 0),
+        (-3, -3),
         # bool is a subclass of int in Python — must be explicitly rejected.
-        assert as_int(True) is None
-
-    def test_bool_false_returns_none(self):
-        assert as_int(False) is None
-
-    def test_float_returns_none(self):
-        assert as_int(3.0) is None
-
-    def test_string_returns_none(self):
-        assert as_int("5") is None
-
-    def test_none_returns_none(self):
-        assert as_int(None) is None
+        (True, None),
+        (False, None),
+        (3.0, None),
+        ("5", None),
+        (None, None),
+    ],
+)
+def test_as_int(val, expected):
+    assert as_int(val) == expected
 
 
-class TestAsNonNegativeInt:
-    def test_zero_returned(self):
-        assert as_non_negative_int(0) == 0
-
-    def test_positive_returned(self):
-        assert as_non_negative_int(42) == 42
-
-    def test_negative_returns_none(self):
-        assert as_non_negative_int(-1) is None
-
-    def test_bool_returns_none(self):
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        (0, 0),
+        (42, 42),
+        (-1, None),
         # Inherits as_int rejection of bools.
-        assert as_non_negative_int(True) is None
-
-    def test_none_returns_none(self):
-        assert as_non_negative_int(None) is None
+        (True, None),
+        (None, None),
+    ],
+)
+def test_as_non_negative_int(val, expected):
+    assert as_non_negative_int(val) == expected

--- a/tests/search/test_proto.py
+++ b/tests/search/test_proto.py
@@ -242,7 +242,6 @@ class TestExtractBookingTokenFromTfuEdgeCases:
         return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
 
     def test_wire_type_5_fixed32_in_non_field1_skipped(self):
-
         # field 2, wire 5 (fixed32) = tag 0x15, followed by 4 bytes
         field2 = bytes([0x15]) + bytes([0x00, 0x00, 0x00, 0x01])
         # field 1, wire 2 (length-delim) with ASCII payload
@@ -253,7 +252,6 @@ class TestExtractBookingTokenFromTfuEdgeCases:
         assert result == "testtoken"
 
     def test_wire_type_1_fixed64_in_non_field1_skipped(self):
-
         # field 3, wire 1 (fixed64) = (3 << 3) | 1 = 25 = 0x19, followed by 8 bytes
         field3 = bytes([0x19]) + bytes(8)
         token_bytes = b"mytoken"

--- a/tests/search/test_proto.py
+++ b/tests/search/test_proto.py
@@ -207,3 +207,90 @@ class TestExtractBookingTokenFromTfu:
         # by which validation step rejects first).
         with pytest.raises(ValueError):
             extract_booking_token_from_tfu("!!!!not-valid-base64!!!!")
+
+
+class TestReadVarintBoundary:
+    """Exercise _read_varint at its encoding boundaries."""
+
+    def test_single_byte_zero(self):
+        from fli.search._proto import _read_varint
+
+        assert _read_varint(b"\x00", 0) == (0, 1)
+
+    def test_max_single_byte(self):
+        from fli.search._proto import _read_varint
+
+        assert _read_varint(b"\x7f", 0) == (127, 1)
+
+    def test_two_byte_varint(self):
+        from fli.search._proto import _read_varint
+
+        # 128 = 0x80 0x01 in LEB128
+        assert _read_varint(b"\x80\x01", 0) == (128, 2)
+
+    def test_truncated_varint_raises_index_error(self):
+        from fli.search._proto import _read_varint
+
+        with pytest.raises(IndexError):
+            _read_varint(b"\x80", 0)  # MSB set but no continuation byte
+
+
+class TestExtractBookingTokenFromTfuEdgeCases:
+    """edge-case wire types that appear before field 1 in the outer tfu protobuf."""
+
+    def _encode_tfu(self, raw: bytes) -> str:
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    def test_wire_type_5_fixed32_in_non_field1_skipped(self):
+
+        # field 2, wire 5 (fixed32) = tag 0x15, followed by 4 bytes
+        field2 = bytes([0x15]) + bytes([0x00, 0x00, 0x00, 0x01])
+        # field 1, wire 2 (length-delim) with ASCII payload
+        token_bytes = b"testtoken"
+        field1 = bytes([0x0A]) + bytes([len(token_bytes)]) + token_bytes
+        tfu = self._encode_tfu(field2 + field1)
+        result = extract_booking_token_from_tfu(tfu)
+        assert result == "testtoken"
+
+    def test_wire_type_1_fixed64_in_non_field1_skipped(self):
+
+        # field 3, wire 1 (fixed64) = (3 << 3) | 1 = 25 = 0x19, followed by 8 bytes
+        field3 = bytes([0x19]) + bytes(8)
+        token_bytes = b"mytoken"
+        field1 = bytes([0x0A]) + bytes([len(token_bytes)]) + token_bytes
+        tfu = self._encode_tfu(field3 + field1)
+        result = extract_booking_token_from_tfu(tfu)
+        assert result == "mytoken"
+
+    def test_no_field1_raises_value_error(self):
+        from fli.search._proto import _varint_field
+
+        # Only field 2 as a varint — no field 1 present.
+        raw = _varint_field(2, 42)
+        tfu = self._encode_tfu(raw)
+        with pytest.raises(ValueError, match="no field 1"):
+            extract_booking_token_from_tfu(tfu)
+
+    def test_unsupported_wire_type_raises_value_error(self):
+        # Wire type 3 (start group) is not handled.
+        # Tag for field 1, wire 3 = (1 << 3) | 3 = 11
+        raw = bytes([11])
+        tfu = self._encode_tfu(raw)
+        with pytest.raises(ValueError, match="unsupported wire type"):
+            extract_booking_token_from_tfu(tfu)
+
+
+class TestDecodeBookingTokenHexFallback:
+    def test_non_decodable_nested_field_stored_as_hex(self):
+        """A field neither printable ASCII nor a valid nested message.
+
+        Should be stored as a hex string instead of raising.
+        """
+        from fli.search._proto import _length_delim
+
+        # bytes([0x80]) is not valid ASCII and causes IndexError when parsed
+        # as a nested protobuf varint — the decoder should fall back to hex.
+        raw = _length_delim(3, bytes([0x80]))
+        token = base64.b64encode(raw).decode("ascii")
+        decoded = decode_booking_token(token)
+        assert decoded["field_3"] == "80"

--- a/tests/search/test_proto.py
+++ b/tests/search/test_proto.py
@@ -63,17 +63,17 @@ class TestBuildBookingToken:
         assert decoded["field_7"] == 28
         assert decoded["field_14"] == 12345
 
-    def test_different_currencies(self):
-        for code in ("USD", "EUR", "GBP", "JPY", "INR"):
-            token = build_booking_token("S", "DL", "1", 1, 100, code)
-            decoded = decode_booking_token(token)
-            assert decoded["field_3"]["field_3"] == code
+    @pytest.mark.parametrize("code", ["USD", "EUR", "GBP", "JPY", "INR"])
+    def test_different_currencies(self, code):
+        token = build_booking_token("S", "DL", "1", 1, 100, code)
+        decoded = decode_booking_token(token)
+        assert decoded["field_3"]["field_3"] == code
 
-    def test_leg_index_in_field_2(self):
-        for idx in (0, 1, 2, 5, 10):
-            token = build_booking_token("S", "AA", "100", idx, 100, "USD")
-            decoded = decode_booking_token(token)
-            assert decoded["field_2"] == f"AA100#{idx}"
+    @pytest.mark.parametrize("idx", [0, 1, 2, 5, 10])
+    def test_leg_index_in_field_2(self, idx):
+        token = build_booking_token("S", "AA", "100", idx, 100, "USD")
+        decoded = decode_booking_token(token)
+        assert decoded["field_2"] == f"AA100#{idx}"
 
     def test_price_varint_encoding(self):
         # 34680 spans 3 varint bytes: 0xf8 0x8e 0x02. Confirm round-trip.
@@ -114,41 +114,33 @@ class TestVarintEncoding:
         assert decoded["field_1"] == "ABC"
 
 
-class TestBuildBookingTokenValidation:
-    """Reject empty / negative inputs upfront.
+@pytest.mark.parametrize(
+    "session_id, airline_code, flight_number, price_cents, currency, exc_match",
+    [
+        ("S", "AA", "1", -1, "USD", "price_cents must be non-negative"),
+        ("", "AA", "1", 100, "USD", "session_id must be non-empty"),
+        ("S", "", "1", 100, "USD", "airline_code must be non-empty"),
+        ("S", "AA", "", 100, "USD", "flight_number must be non-empty"),
+        ("S", "AA", "1", 100, "", "currency must be non-empty"),
+    ],
+)
+def test_build_booking_token_validation(
+    session_id, airline_code, flight_number, price_cents, currency, exc_match
+):
+    """Reject empty / negative inputs upfront."""
+    with pytest.raises(ValueError, match=exc_match):
+        build_booking_token(session_id, airline_code, flight_number, 1, price_cents, currency)
 
-    Guarantees no live POST is ever sent with a structurally broken token.
-    """
 
-    def test_negative_price_rejected(self):
-        with pytest.raises(ValueError, match="price_cents must be non-negative"):
-            build_booking_token("S", "AA", "1", 1, -1, "USD")
-
-    def test_empty_session_rejected(self):
-        with pytest.raises(ValueError, match="session_id must be non-empty"):
-            build_booking_token("", "AA", "1", 1, 100, "USD")
-
-    def test_empty_airline_rejected(self):
-        with pytest.raises(ValueError, match="airline_code must be non-empty"):
-            build_booking_token("S", "", "1", 1, 100, "USD")
-
-    def test_empty_flight_number_rejected(self):
-        with pytest.raises(ValueError, match="flight_number must be non-empty"):
-            build_booking_token("S", "AA", "", 1, 100, "USD")
-
-    def test_empty_currency_rejected(self):
-        with pytest.raises(ValueError, match="currency must be non-empty"):
-            build_booking_token("S", "AA", "1", 1, 100, "")
-
-    def test_non_ascii_session_id_encodes(self):
-        # If Google ever returns a non-ASCII session id, the builder must
-        # not crash — UTF-8 keeps round-trip equivalence for ASCII data
-        # while accepting arbitrary bytes for the future.
-        token = build_booking_token("Sé", "AA", "1", 1, 100, "USD")
-        decoded = decode_booking_token(token)
-        # decode_booking_token's ascii-decoder will replace the non-ascii
-        # byte, but the call doesn't raise.
-        assert "field_1" in decoded
+def test_non_ascii_session_id_encodes():
+    # If Google ever returns a non-ASCII session id, the builder must
+    # not crash — UTF-8 keeps round-trip equivalence for ASCII data
+    # while accepting arbitrary bytes for the future.
+    token = build_booking_token("Sé", "AA", "1", 1, 100, "USD")
+    decoded = decode_booking_token(token)
+    # decode_booking_token's ascii-decoder will replace the non-ascii
+    # byte, but the call doesn't raise.
+    assert "field_1" in decoded
 
 
 class TestDecodeBookingTokenEdgeCases:
@@ -209,30 +201,25 @@ class TestExtractBookingTokenFromTfu:
             extract_booking_token_from_tfu("!!!!not-valid-base64!!!!")
 
 
-class TestReadVarintBoundary:
-    """Exercise _read_varint at its encoding boundaries."""
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (b"\x00", (0, 1)),
+        (b"\x7f", (127, 1)),
+        (b"\x80\x01", (128, 2)),
+    ],
+)
+def test_read_varint(data, expected):
+    from fli.search._proto import _read_varint
 
-    def test_single_byte_zero(self):
-        from fli.search._proto import _read_varint
+    assert _read_varint(data, 0) == expected
 
-        assert _read_varint(b"\x00", 0) == (0, 1)
 
-    def test_max_single_byte(self):
-        from fli.search._proto import _read_varint
+def test_read_varint_truncated_raises():
+    from fli.search._proto import _read_varint
 
-        assert _read_varint(b"\x7f", 0) == (127, 1)
-
-    def test_two_byte_varint(self):
-        from fli.search._proto import _read_varint
-
-        # 128 = 0x80 0x01 in LEB128
-        assert _read_varint(b"\x80\x01", 0) == (128, 2)
-
-    def test_truncated_varint_raises_index_error(self):
-        from fli.search._proto import _read_varint
-
-        with pytest.raises(IndexError):
-            _read_varint(b"\x80", 0)  # MSB set but no continuation byte
+    with pytest.raises(IndexError):
+        _read_varint(b"\x80", 0)  # MSB set but no continuation byte
 
 
 class TestExtractBookingTokenFromTfuEdgeCases:
@@ -241,24 +228,19 @@ class TestExtractBookingTokenFromTfuEdgeCases:
     def _encode_tfu(self, raw: bytes) -> str:
         return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
 
-    def test_wire_type_5_fixed32_in_non_field1_skipped(self):
-        # field 2, wire 5 (fixed32) = tag 0x15, followed by 4 bytes
-        field2 = bytes([0x15]) + bytes([0x00, 0x00, 0x00, 0x01])
-        # field 1, wire 2 (length-delim) with ASCII payload
-        token_bytes = b"testtoken"
+    @pytest.mark.parametrize(
+        "prefix_bytes, token_bytes",
+        [
+            # field 2, wire 5 (fixed32): tag 0x15, 4 bytes
+            (bytes([0x15]) + bytes([0x00, 0x00, 0x00, 0x01]), b"testtoken"),
+            # field 3, wire 1 (fixed64): (3 << 3) | 1 = 0x19, 8 bytes
+            (bytes([0x19]) + bytes(8), b"mytoken"),
+        ],
+    )
+    def test_non_field1_wire_types_skipped(self, prefix_bytes, token_bytes):
         field1 = bytes([0x0A]) + bytes([len(token_bytes)]) + token_bytes
-        tfu = self._encode_tfu(field2 + field1)
-        result = extract_booking_token_from_tfu(tfu)
-        assert result == "testtoken"
-
-    def test_wire_type_1_fixed64_in_non_field1_skipped(self):
-        # field 3, wire 1 (fixed64) = (3 << 3) | 1 = 25 = 0x19, followed by 8 bytes
-        field3 = bytes([0x19]) + bytes(8)
-        token_bytes = b"mytoken"
-        field1 = bytes([0x0A]) + bytes([len(token_bytes)]) + token_bytes
-        tfu = self._encode_tfu(field3 + field1)
-        result = extract_booking_token_from_tfu(tfu)
-        assert result == "mytoken"
+        tfu = self._encode_tfu(prefix_bytes + field1)
+        assert extract_booking_token_from_tfu(tfu) == token_bytes.decode("ascii")
 
     def test_no_field1_raises_value_error(self):
         from fli.search._proto import _varint_field

--- a/tests/search/test_wire.py
+++ b/tests/search/test_wire.py
@@ -72,3 +72,72 @@ class TestParseFirstWrbPayload:
 
     def test_returns_none_when_empty(self):
         assert parse_first_wrb_payload("") is None
+
+
+class TestIterWrbChunksEdgeCases:
+    def test_bytes_input_works(self):
+        body = _single_chunk([1, "hello"])
+        chunks_str = list(iter_wrb_chunks(body))
+        chunks_bytes = list(iter_wrb_chunks(body.encode("utf-8")))
+        assert chunks_str == chunks_bytes
+
+    def test_prefix_only_body_returns_nothing(self):
+        # Body is only the JSONP prefix with no actual chunk data.
+        assert list(iter_wrb_chunks(b")]}'\n\n")) == []
+
+    def test_whitespace_only_body_returns_nothing(self):
+        assert list(iter_wrb_chunks("   \n\n  ")) == []
+
+    def test_malformed_length_header_truncates_stream(self):
+        # A non-numeric length header causes the parser to stop cleanly.
+        body = ")]}'\n\nabc\n[not parsed]"
+        assert list(iter_wrb_chunks(body)) == []
+
+    def test_outer_is_dict_not_list_is_skipped(self):
+        body = ")]}'\n\n" + json.dumps({"key": "value"})
+        assert list(iter_wrb_chunks(body)) == []
+
+    def test_wrb_row_with_none_inner_skipped(self):
+        body = ")]}'\n\n" + json.dumps([["wrb.fr", None, None]])
+        assert list(iter_wrb_chunks(body)) == []
+
+    def test_wrb_row_with_non_string_inner_skipped(self):
+        body = ")]}'\n\n" + json.dumps([["wrb.fr", None, [1, 2, 3]]])
+        assert list(iter_wrb_chunks(body)) == []
+
+    def test_wrb_row_too_short_skipped(self):
+        body = ")]}'\n\n" + json.dumps([["wrb.fr", None]])
+        assert list(iter_wrb_chunks(body)) == []
+
+    def test_non_wrb_rows_between_multi_chunks_ignored(self):
+        parts = [")]}'\n\n"]
+        for payload in [[1, "alpha"], [2, "beta"]]:
+            inner_json = json.dumps(payload, separators=(",", ":"))
+            # Mix wrb.fr row with a di row in each chunk's outer list.
+            outer = [["di", 44], ["wrb.fr", None, inner_json]]
+            outer_json = json.dumps(outer, separators=(",", ":"))
+            byte_len = len(outer_json.encode("utf-8")) + 2
+            parts.append(f"{byte_len}\n{outer_json}\n")
+        body = "".join(parts)
+        chunks = list(iter_wrb_chunks(body))
+        assert chunks == [[1, "alpha"], [2, "beta"]]
+
+    def test_multiple_wrb_chunks_all_yielded_with_mixed_rows(self):
+        # Two separate multi-chunks, each with only wrb.fr rows.
+        body = _multi_chunk([10], [20], [30])
+        chunks = list(iter_wrb_chunks(body))
+        assert chunks == [[10], [20], [30]]
+
+
+class TestParseFirstWrbPayloadEdgeCases:
+    def test_returns_none_for_only_non_wrb_rows(self):
+        body = ")]}'\n\n" + json.dumps([["di", 44], ["af.httprm", 43, "x"]])
+        assert parse_first_wrb_payload(body) is None
+
+    def test_skips_invalid_inner_to_find_second_valid_chunk(self):
+        # First wrb.fr row has an invalid inner JSON; second is valid.
+        bad_inner = "{not valid"
+        good_inner = json.dumps([42])
+        outer = [["wrb.fr", None, bad_inner], ["wrb.fr", None, good_inner]]
+        body = ")]}'\n\n" + json.dumps(outer)
+        assert parse_first_wrb_payload(body) == [42]


### PR DESCRIPTION
## Summary

- **+203 tests, ~565 LOC** across 4 new test files and 4 extended files
- Closes the highest-ROI coverage gaps identified in a test coverage audit (~65% → ~80% estimated)
- Zero regressions — the only failures in CI will be the 4 pre-existing live-network tests (Google returns HTTP 403 in this environment)

## Changes

### New files

| File | Tests | Gap closed |
|---|---|---|
| `tests/search/test_helpers.py` | 30 | `_helpers.py` 0% → 100% (pure defensive accessors used by every decoder) |
| `tests/search/test_client.py` | 14 | `_wrap_request_error` error-type mapping, `_host_from_url`, singleton behaviour |
| `tests/search/test_decoders.py` | 26 | Private decoder functions directly: `_safe_airline` warning path, `_parse_emissions` tag mapping, `_extract_booking_urls`, `_extract_fare_name`, `parse_booking_chunk` walker |
| `tests/mcp/test_mcp_server_unit.py` | 22 | MCP serialize helpers (`_serialize_flight_leg`, `_serialize_layover`, `_flight_extras`, `_airline_code`) and `_execute_flight_search` network error path |

### Extended files

| File | New tests | What's added |
|---|---|---|
| `tests/search/test_wire.py` | +12 | Bytes input, malformed length headers, non-list outer, `None`/non-string inner rows, prefix-only body |
| `tests/cli/test_errors.py` | +13 | `_friendly_message` dispatch, `_write_log` with `command=None`, `json_error_payload` message format, custom exit codes |
| `tests/search/test_proto.py` | +9 | `_read_varint` boundary conditions, `extract_booking_token_from_tfu` wire types 1 and 5, `decode_booking_token` hex fallback for undecodable nested fields |
| `tests/search/test_concurrency.py` | +8 | `shutdown_executor`, generator/tuple inputs to `parallel_map`, `TokenBucketRateLimiter` multi-token acquire and deadline timeout |

## Test plan

- [x] All 203 new tests pass locally
- [x] Full suite (excluding live-network tests): **596 passed, 0 new failures**
- [x] `ruff check` passes on all modified files
- [x] Pre-existing 4 live-network failures in `tests/mcp/test_mcp_server.py` confirmed present on `main` before these changes

https://claude.ai/code/session_01HUJYJom7rZTkw1fYmuwbnn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUJYJom7rZTkw1fYmuwbnn)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 203 unit tests (+565 LOC) across 4 new files and 4 extended files, closing the highest-ROI coverage gaps identified in a prior audit (estimated ~65% → ~80%). All new tests target previously uncovered private helpers, error-mapping paths, and wire-format edge cases with no changes to production code.

- **New test files** cover `_helpers.py` accessors (100% from 0%), `_decoders.py` private functions, `search/client.py` error-type mapping and singleton behaviour, and MCP server serialization helpers plus the bare-except network-error path.
- **Extended files** add edge-case coverage for wire-format parsing (bytes input, malformed headers, mixed rows), CLI error reporting (dispatch, log contents, exit codes), protobuf varint boundaries and wire-type skipping, and concurrency primitives (executor shutdown, generator inputs, rate-limiter deadline timeout).

<h3>Confidence Score: 4/5</h3>

Safe to merge — this is a test-only PR with no production code changes, and all new tests appear functionally correct.

The only finding is a handful of unused tmp_path parameters in TestWriteLogDetails and one TestJsonErrorPayloadMessages test; log-directory isolation is already handled by the autouse module fixture, so these are dead parameters that mislead readers without breaking anything.

tests/cli/test_errors.py — redundant tmp_path parameters in 5 test method signatures.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/cli/test_errors.py | Adds 13 tests for _friendly_message dispatch, _write_log details, json_error_payload, and custom exit codes; the autouse isolation fixture is correct but 5 test methods carry a redundant unused tmp_path parameter. |
| tests/mcp/test_mcp_server_unit.py | New file with 22 unit tests covering _airline_code, _serialize_flight_leg, _serialize_layover, _flight_extras, and the bare-except error path in _execute_flight_search; logic and mocking are correct. |
| tests/search/test_client.py | New file testing _wrap_request_error error-type mapping, _host_from_url, and singleton behaviour; singleton reset autouse fixture correctly saves and restores state. |
| tests/search/test_decoders.py | New file with 26 tests covering private decoder helpers; tag-mapping, booking URL extraction, fare-name fallback, and parse_booking_chunk walker all correctly exercised. |
| tests/search/test_helpers.py | New file with 30 tests for defensive accessors (safe_get, as_bool, as_str, as_int, as_non_negative_int); thorough boundary coverage, no issues. |
| tests/search/test_proto.py | Adds 9 tests for _read_varint boundaries, wire-type skipping in extract_booking_token_from_tfu, and hex-fallback in decode_booking_token; standard-base64 use in the hex-fallback test is compatible with decode_booking_token's normalization logic. |
| tests/search/test_concurrency.py | Adds 8 tests for shutdown_executor, generator/tuple inputs to parallel_map, and TokenBucketRateLimiter edge cases; teardown_method correctly resets global executor state after each test. |
| tests/search/test_wire.py | Adds 12 edge-case tests for iter_wrb_chunks and parse_first_wrb_payload; bytes input, malformed headers, non-list outer, and mixed-row chunking all handled correctly. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/cli/test_errors.py`, line 46-78 ([link](https://github.com/punitarani/fli/blob/e7ad73b881a3f99bb1d6b0dbbda2a6fa106c6d9e/tests/cli/test_errors.py#L46-L78)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Unused `tmp_path` parameters in `TestWriteLogDetails`**

   Five test methods in `TestWriteLogDetails` and `TestJsonErrorPayloadMessages` accept `tmp_path` as a parameter but never use it. Log isolation is already provided by the module-level `autouse` fixture `_isolated_tmp_log_dir`, which patches `_LOG_DIR` to its own `tmp_path`. The redundant `tmp_path` arguments in the individual test signatures suggest per-test path control that doesn't actually exist, and will silently request a second temporary directory per test. The same pattern appears in `test_argv_written_to_log`, `test_qualified_error_type_in_log`, `test_timestamp_present_in_log`, and `TestJsonErrorPayloadMessages.test_log_path_is_a_real_file`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/cli/test_errors.py
   Line: 46-78

   Comment:
   **Unused `tmp_path` parameters in `TestWriteLogDetails`**

   Five test methods in `TestWriteLogDetails` and `TestJsonErrorPayloadMessages` accept `tmp_path` as a parameter but never use it. Log isolation is already provided by the module-level `autouse` fixture `_isolated_tmp_log_dir`, which patches `_LOG_DIR` to its own `tmp_path`. The redundant `tmp_path` arguments in the individual test signatures suggest per-test path control that doesn't actually exist, and will silently request a second temporary directory per test. The same pattern appears in `test_argv_written_to_log`, `test_qualified_error_type_in_log`, `test_timestamp_present_in_log`, and `TestJsonErrorPayloadMessages.test_log_path_is_a_real_file`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fcli%2Ftest_errors.py%0ALine%3A%2046-78%0A%0AComment%3A%0A**Unused%20%60tmp_path%60%20parameters%20in%20%60TestWriteLogDetails%60**%0A%0AFive%20test%20methods%20in%20%60TestWriteLogDetails%60%20and%20%60TestJsonErrorPayloadMessages%60%20accept%20%60tmp_path%60%20as%20a%20parameter%20but%20never%20use%20it.%20Log%20isolation%20is%20already%20provided%20by%20the%20module-level%20%60autouse%60%20fixture%20%60_isolated_tmp_log_dir%60%2C%20which%20patches%20%60_LOG_DIR%60%20to%20its%20own%20%60tmp_path%60.%20The%20redundant%20%60tmp_path%60%20arguments%20in%20the%20individual%20test%20signatures%20suggest%20per-test%20path%20control%20that%20doesn't%20actually%20exist%2C%20and%20will%20silently%20request%20a%20second%20temporary%20directory%20per%20test.%20The%20same%20pattern%20appears%20in%20%60test_argv_written_to_log%60%2C%20%60test_qualified_error_type_in_log%60%2C%20%60test_timestamp_present_in_log%60%2C%20and%20%60TestJsonErrorPayloadMessages.test_log_path_is_a_real_file%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=punitarani%2Ffli&pr=167&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fcli%2Ftest_errors.py%0ALine%3A%2046-78%0A%0AComment%3A%0A**Unused%20%60tmp_path%60%20parameters%20in%20%60TestWriteLogDetails%60**%0A%0AFive%20test%20methods%20in%20%60TestWriteLogDetails%60%20and%20%60TestJsonErrorPayloadMessages%60%20accept%20%60tmp_path%60%20as%20a%20parameter%20but%20never%20use%20it.%20Log%20isolation%20is%20already%20provided%20by%20the%20module-level%20%60autouse%60%20fixture%20%60_isolated_tmp_log_dir%60%2C%20which%20patches%20%60_LOG_DIR%60%20to%20its%20own%20%60tmp_path%60.%20The%20redundant%20%60tmp_path%60%20arguments%20in%20the%20individual%20test%20signatures%20suggest%20per-test%20path%20control%20that%20doesn't%20actually%20exist%2C%20and%20will%20silently%20request%20a%20second%20temporary%20directory%20per%20test.%20The%20same%20pattern%20appears%20in%20%60test_argv_written_to_log%60%2C%20%60test_qualified_error_type_in_log%60%2C%20%60test_timestamp_present_in_log%60%2C%20and%20%60TestJsonErrorPayloadMessages.test_log_path_is_a_real_file%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=167&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22claude%2Fanalyze-test-coverage-TI38w%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fanalyze-test-coverage-TI38w%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fcli%2Ftest_errors.py%0ALine%3A%2046-78%0A%0AComment%3A%0A**Unused%20%60tmp_path%60%20parameters%20in%20%60TestWriteLogDetails%60**%0A%0AFive%20test%20methods%20in%20%60TestWriteLogDetails%60%20and%20%60TestJsonErrorPayloadMessages%60%20accept%20%60tmp_path%60%20as%20a%20parameter%20but%20never%20use%20it.%20Log%20isolation%20is%20already%20provided%20by%20the%20module-level%20%60autouse%60%20fixture%20%60_isolated_tmp_log_dir%60%2C%20which%20patches%20%60_LOG_DIR%60%20to%20its%20own%20%60tmp_path%60.%20The%20redundant%20%60tmp_path%60%20arguments%20in%20the%20individual%20test%20signatures%20suggest%20per-test%20path%20control%20that%20doesn't%20actually%20exist%2C%20and%20will%20silently%20request%20a%20second%20temporary%20directory%20per%20test.%20The%20same%20pattern%20appears%20in%20%60test_argv_written_to_log%60%2C%20%60test_qualified_error_type_in_log%60%2C%20%60test_timestamp_present_in_log%60%2C%20and%20%60TestJsonErrorPayloadMessages.test_log_path_is_a_real_file%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fcli%2Ftest_errors.py%3A46-78%0A**Unused%20%60tmp_path%60%20parameters%20in%20%60TestWriteLogDetails%60**%0A%0AFive%20test%20methods%20in%20%60TestWriteLogDetails%60%20and%20%60TestJsonErrorPayloadMessages%60%20accept%20%60tmp_path%60%20as%20a%20parameter%20but%20never%20use%20it.%20Log%20isolation%20is%20already%20provided%20by%20the%20module-level%20%60autouse%60%20fixture%20%60_isolated_tmp_log_dir%60%2C%20which%20patches%20%60_LOG_DIR%60%20to%20its%20own%20%60tmp_path%60.%20The%20redundant%20%60tmp_path%60%20arguments%20in%20the%20individual%20test%20signatures%20suggest%20per-test%20path%20control%20that%20doesn't%20actually%20exist%2C%20and%20will%20silently%20request%20a%20second%20temporary%20directory%20per%20test.%20The%20same%20pattern%20appears%20in%20%60test_argv_written_to_log%60%2C%20%60test_qualified_error_type_in_log%60%2C%20%60test_timestamp_present_in_log%60%2C%20and%20%60TestJsonErrorPayloadMessages.test_log_path_is_a_real_file%60.%0A%0A&repo=punitarani%2Ffli&pr=167&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fcli%2Ftest_errors.py%3A46-78%0A**Unused%20%60tmp_path%60%20parameters%20in%20%60TestWriteLogDetails%60**%0A%0AFive%20test%20methods%20in%20%60TestWriteLogDetails%60%20and%20%60TestJsonErrorPayloadMessages%60%20accept%20%60tmp_path%60%20as%20a%20parameter%20but%20never%20use%20it.%20Log%20isolation%20is%20already%20provided%20by%20the%20module-level%20%60autouse%60%20fixture%20%60_isolated_tmp_log_dir%60%2C%20which%20patches%20%60_LOG_DIR%60%20to%20its%20own%20%60tmp_path%60.%20The%20redundant%20%60tmp_path%60%20arguments%20in%20the%20individual%20test%20signatures%20suggest%20per-test%20path%20control%20that%20doesn't%20actually%20exist%2C%20and%20will%20silently%20request%20a%20second%20temporary%20directory%20per%20test.%20The%20same%20pattern%20appears%20in%20%60test_argv_written_to_log%60%2C%20%60test_qualified_error_type_in_log%60%2C%20%60test_timestamp_present_in_log%60%2C%20and%20%60TestJsonErrorPayloadMessages.test_log_path_is_a_real_file%60.%0A%0A&pr=167&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22claude%2Fanalyze-test-coverage-TI38w%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fanalyze-test-coverage-TI38w%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fcli%2Ftest_errors.py%3A46-78%0A**Unused%20%60tmp_path%60%20parameters%20in%20%60TestWriteLogDetails%60**%0A%0AFive%20test%20methods%20in%20%60TestWriteLogDetails%60%20and%20%60TestJsonErrorPayloadMessages%60%20accept%20%60tmp_path%60%20as%20a%20parameter%20but%20never%20use%20it.%20Log%20isolation%20is%20already%20provided%20by%20the%20module-level%20%60autouse%60%20fixture%20%60_isolated_tmp_log_dir%60%2C%20which%20patches%20%60_LOG_DIR%60%20to%20its%20own%20%60tmp_path%60.%20The%20redundant%20%60tmp_path%60%20arguments%20in%20the%20individual%20test%20signatures%20suggest%20per-test%20path%20control%20that%20doesn't%20actually%20exist%2C%20and%20will%20silently%20request%20a%20second%20temporary%20directory%20per%20test.%20The%20same%20pattern%20appears%20in%20%60test_argv_written_to_log%60%2C%20%60test_qualified_error_type_in_log%60%2C%20%60test_timestamp_present_in_log%60%2C%20and%20%60TestJsonErrorPayloadMessages.test_log_path_is_a_real_file%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/cli/test_errors.py:46-78
**Unused `tmp_path` parameters in `TestWriteLogDetails`**

Five test methods in `TestWriteLogDetails` and `TestJsonErrorPayloadMessages` accept `tmp_path` as a parameter but never use it. Log isolation is already provided by the module-level `autouse` fixture `_isolated_tmp_log_dir`, which patches `_LOG_DIR` to its own `tmp_path`. The redundant `tmp_path` arguments in the individual test signatures suggest per-test path control that doesn't actually exist, and will silently request a second temporary directory per test. The same pattern appears in `test_argv_written_to_log`, `test_qualified_error_type_in_log`, `test_timestamp_present_in_log`, and `TestJsonErrorPayloadMessages.test_log_path_is_a_real_file`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix ruff format violations in new test f..."](https://github.com/punitarani/fli/commit/e7ad73b881a3f99bb1d6b0dbbda2a6fa106c6d9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32656709)</sub>

<!-- /greptile_comment -->