### PR TITLE
Inline publish step into release.yml to fix PyPI attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,16 @@
 name: Upload Python Package
 
+# Triggers:
+# - release: published    -> auto-publish when a GH Release is created manually
+#                            (e.g. via the manual fallback in docs/guides/release.md)
+# - workflow_dispatch     -> manual publish, used for TestPyPI smoke tests or
+#                            recovery (e.g. shipping a tag that release.yml failed
+#                            to publish). Pick the tag/branch in the dispatch UI.
+#
+# This workflow is NOT called from release.yml -- release.yml inlines its own
+# publish steps. See docs/guides/release.md for the rationale (PyPI Trusted
+# Publishing attestations are incompatible with reusable workflow chains).
+
 on:
   release:
     types: [ published ]
@@ -13,17 +24,6 @@ on:
         options:
         - testpypi
         - pypi
-  workflow_call:
-    inputs:
-      environment:
-        description: 'Environment to publish to (pypi or testpypi)'
-        required: false
-        default: 'pypi'
-        type: string
-      ref:
-        description: 'Git ref (tag/branch/SHA) to build from. Required when called from release.yml so the build picks up the bump commit, not the caller-event SHA.'
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -33,8 +33,6 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-    with:
-      ref: ${{ inputs.ref }}
 
   release-build:
     needs: [ test ]
@@ -42,8 +40,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,21 +229,63 @@ jobs:
             cat release_notes.md
           } >> "$GITHUB_STEP_SUMMARY"
 
-  publish:
+  # Run the standard test suite against the new tag before publishing.
+  # Called via workflow_call (not publish), so no OIDC/attestation concerns.
+  test:
     needs: release
     if: ${{ needs.release.outputs.did_release == 'true' }}
-    uses: ./.github/workflows/publish.yml
+    uses: ./.github/workflows/test.yml
     with:
-      environment: pypi
-      # Build from the new tag, not the caller-event SHA. workflow_call
-      # inherits the parent's github.sha (the SHA at release-dispatch time,
-      # before the bump commit lands), so without this the publish job would
-      # rebuild the previous version and PyPI would reject it as duplicate.
       ref: ${{ needs.release.outputs.tag }}
+
+  publish:
+    needs: [ release, test ]
+    if: ${{ needs.release.outputs.did_release == 'true' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: write
-      pull-requests: write
       id-token: write
-    secrets: inherit
+    environment:
+      name: pypi
+      url: https://pypi.org/p/flights
+    steps:
+      # IMPORTANT: build and publish steps live here (inline) rather than
+      # invoking publish.yml via workflow_call. PyPI's Trusted Publishing
+      # attestations are incompatible with reusable workflow chains -- the
+      # OIDC token's job_workflow_ref points at the called workflow while
+      # the Sigstore cert's Build Config URI points at the top-level
+      # workflow. PyPI ties both to the same publisher, so chained
+      # publishes always fail attestation verification.
+      # See https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Check code quality
+        run: |
+          uv run ruff format --check .
+          uv run ruff check .
+
+      - name: Build release distributions
+        run: uv build
+
+      - name: Check package
+        run: uv run twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
 

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -5,20 +5,34 @@ on push to `main`; cutting a release is always an explicit, one-click action.
 
 ## Overview
 
-The release pipeline is two workflows:
+The release pipeline is two independent workflows:
 
 | Workflow | File | Trigger |
 | --- | --- | --- |
 | **Release** | `.github/workflows/release.yml` | `workflow_dispatch` only |
-| **Upload Python Package** | `.github/workflows/publish.yml` | `release: published`, `workflow_dispatch`, `workflow_call` |
+| **Upload Python Package** | `.github/workflows/publish.yml` | `release: published`, `workflow_dispatch` |
 
-`release.yml` bumps the version in `pyproject.toml`, refreshes `uv.lock`,
-commits to `main`, creates an annotated tag and GitHub Release, then calls
-`publish.yml` to build and upload to PyPI via Trusted Publishing.
+`release.yml` is the end-to-end release pipeline: it bumps the version in
+`pyproject.toml`, refreshes `uv.lock`, commits to `main`, creates an annotated
+tag and GitHub Release, runs the full test matrix against the new tag, and
+builds + uploads to PyPI via Trusted Publishing — all inline, no chained
+workflow.
 
-`publish.yml` can also be triggered independently — by publishing a GitHub
-Release manually, or via `workflow_dispatch` (defaults to TestPyPI for
-safe smoke tests).
+`publish.yml` is a standalone publish workflow used for:
+- **Manual recovery** — if `release.yml`'s publish step ever fails, dispatch
+  `publish.yml` on the failed tag (`environment: pypi`) to ship it.
+- **Manual GitHub Release** — if you create a release in the UI from an
+  existing tag, the `release: published` trigger picks it up and publishes.
+- **TestPyPI smoke tests** — `workflow_dispatch` with `environment: testpypi`.
+
+> **Why two workflows instead of one reusable?** PyPI's Trusted Publishing
+> attestations are incompatible with reusable workflow chains
+> ([pypa/gh-action-pypi-publish#166](https://github.com/pypa/gh-action-pypi-publish/issues/166)).
+> When `release.yml` calls `publish.yml` via `workflow_call`, the OIDC token's
+> `job_workflow_ref` points at `publish.yml` while the Sigstore cert's
+> `Build Config URI` points at `release.yml`; PyPI ties both to the same
+> publisher and rejects the attestation. Inlining the publish step into
+> `release.yml` sidesteps this entirely.
 
 ## Cutting a release
 
@@ -65,14 +79,21 @@ modify `pyproject.toml`.
 
 These need to be in place once on the GitHub side:
 
-* **PyPI Trusted Publisher** for the `flights` project, bound to this repo
-  and the `pypi` environment. `publish.yml` requests an OIDC token via
-  `id-token: write` and uses `pypa/gh-action-pypi-publish`.
+* **PyPI Trusted Publishers** for the `flights` project, both bound to this
+  repo and the `pypi` environment:
+  * `release.yml` — used by the automated end-to-end release flow
+  * `publish.yml` — used by manual recovery, `release: published`, and
+    TestPyPI dispatch
+  
+  Configure both at
+  [pypi.org/manage/project/flights/settings/publishing/](https://pypi.org/manage/project/flights/settings/publishing/).
+  Set Environment name to `pypi` on both.
 * **Branch protection on `main`** must permit pushes from `github-actions[bot]`.
   If protection blocks the bot, the release workflow's push will fail; switch
   the checkout step's `token:` to a PAT secret instead.
 * **Workflow permissions**: `release.yml` requires `contents: write` (already
-  declared at the workflow level).
+  declared at the workflow level) and `id-token: write` on the `publish`
+  job for OIDC.
 
 ## Troubleshooting
 
@@ -88,10 +109,26 @@ These need to be in place once on the GitHub side:
 * **Release notes look wrong on first run** — the workflow walks back to the
   last commit whose subject starts with `Bump version`. If you've changed
   that convention, edit `release.yml`'s "Determine commit range" step.
+* **PyPI returns 400 "Invalid attestations supplied"** with cert URI mismatch
+  — the publish job is running via a `workflow_call` chain (the original
+  bug). Make sure the publish job is defined inline in `release.yml`, not
+  invoked via `uses: ./.github/workflows/publish.yml`. As a one-time recovery
+  for the failed tag, dispatch `publish.yml` standalone on that tag.
 
 ## Manual fallback
 
-If the workflow is broken and a release is urgent, you can still:
+If `release.yml`'s publish step fails after the tag and GitHub Release have
+already been created (e.g. transient PyPI outage), recover with:
+
+1. Actions → **Upload Python Package** → Run workflow
+2. **Branch dropdown**: switch to the failed tag (e.g. `vX.Y.Z`)
+3. `environment`: `pypi`
+4. Run
+
+This dispatches `publish.yml` standalone and uploads the same tag's artifact.
+
+If the entire `release.yml` workflow is broken and a release is urgent, you
+can also:
 
 1. Bump the version in `pyproject.toml` and `uv.lock` on a branch, merge to
    `main`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flights"
-version = "0.9.0"
+version = "0.10.0"
 description = "A Python wrapper for Google Flights API"
 authors = [
     { name = "Punit Arani", email = "punitsai36@gmail.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "flights"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary

Refactors the release pipeline to inline the publish step directly into `release.yml` instead of calling `publish.yml` via `workflow_call`. This resolves a critical issue where PyPI's Trusted Publishing attestations fail when the publish job is invoked through a reusable workflow chain.

## Problem

PyPI's Trusted Publishing requires that the OIDC token's `job_workflow_ref` and the Sigstore certificate's `Build Config URI` both point to the same workflow. When `release.yml` calls `publish.yml` via `workflow_call`, these fields point to different workflows, causing PyPI to reject the attestation with a 400 error.

## Key Changes

- **`release.yml`**: 
  - Removed `workflow_call` invocation of `publish.yml`
  - Added inline `test` job that runs the full test matrix against the new tag (via `test.yml`)
  - Added inline `publish` job with build and publish steps previously in `publish.yml`
  - Publish job now runs after both release and test jobs complete
  - Updated documentation comments explaining the attestation incompatibility

- **`publish.yml`**:
  - Removed `workflow_call` trigger and its `inputs` (environment, ref)
  - Simplified to standalone workflow triggered only by `release: published` and `workflow_dispatch`
  - Removed `ref` parameter passing (now uses default `github.ref`)
  - Removed test job invocation with custom ref (test now runs in `release.yml`)
  - Updated header comments to clarify use cases: manual recovery, manual GitHub Release, and TestPyPI smoke tests

- **`docs/guides/release.md`**:
  - Updated overview to clarify workflows are "independent" not "chained"
  - Documented the new inline publish architecture
  - Added detailed explanation of why two workflows exist (attestation incompatibility)
  - Updated setup instructions to require two separate PyPI Trusted Publishers
  - Added troubleshooting section for attestation mismatches
  - Expanded manual fallback section with step-by-step recovery instructions

## Implementation Details

- The publish job in `release.yml` includes all necessary steps: checkout, uv setup, dependencies, code quality checks, build, package check, and PyPI upload
- Test job runs against the new tag before publishing, ensuring quality before upload
- Both workflows can now operate independently without OIDC/attestation concerns
- `publish.yml` remains available for manual recovery and TestPyPI testing

https://claude.ai/code/session_01YE3uzAHtuh4Exz8ZStnhmF

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the release pipeline to fix PyPI Trusted Publishing attestation failures that occurred when `release.yml` called `publish.yml` via `workflow_call`. The fix inlines the build and publish steps directly into `release.yml` and adds clear documentation explaining the architectural constraint.

- **`release.yml`**: Adds a `test` job (via `test.yml`) and an inline `publish` job with all build/upload steps, eliminating the reusable-workflow chain that broke OIDC attestation matching.
- **`publish.yml`**: Drops `workflow_call` trigger and `ref` input, simplifying it to a standalone recovery/manual workflow — but retains `release: published` without filtering out bot-created releases, creating a race with `release.yml`'s publish job.
- **`docs/guides/release.md`**: Updated to document the independent-workflow architecture, two required PyPI Trusted Publishers, and a step-by-step recovery procedure.

<h3>Confidence Score: 3/5</h3>

The core attestation fix in release.yml is correct, but publish.yml will still fire on every automated release and race to upload the same package version to PyPI.

Every time release.yml completes successfully it programmatically creates a GitHub Release, which triggers publish.yml's release:published handler. Both pipelines independently build and attempt to upload the same version; whichever loses the race gets a PyPI 400 File already exists rejection, producing a failed workflow run on every release. The fix is a one-line actor guard on the pypi-publish job.

.github/workflows/publish.yml — the release:published trigger and the pypi-publish job condition need an actor check to avoid the duplicate-upload race.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Inlines publish steps (checkout, uv, build, pypi-publish) directly into a new publish job that runs after the existing release and a new test job. The inline approach correctly resolves the PyPI attestation mismatch caused by reusable workflow chains. |
| .github/workflows/publish.yml | Removes workflow_call trigger and ref input passing. However, retaining release:published without a bot-actor guard means this workflow races release.yml to publish to PyPI on every automated release, causing one of the two to fail. |
| docs/guides/release.md | Documentation updated to reflect the new independent-workflows architecture, explains the attestation incompatibility rationale, and adds a troubleshooting entry and step-by-step recovery instructions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant ReleaseYML as release.yml
    participant TestYML as test.yml
    participant GHRelease as GitHub Release
    participant PublishYML as publish.yml
    participant PyPI as PyPI

    Dev->>ReleaseYML: workflow_dispatch (bump)
    ReleaseYML->>ReleaseYML: Bump version, commit, tag, push
    ReleaseYML->>GHRelease: gh release create vX.Y.Z
    GHRelease-->>PublishYML: release:published event (⚠️ race)
    ReleaseYML->>TestYML: "workflow_call (ref=tag)"
    TestYML-->>ReleaseYML: tests pass
    ReleaseYML->>PyPI: build + pypa/gh-action-pypi-publish
    PublishYML->>TestYML: workflow_call (no ref)
    TestYML-->>PublishYML: tests pass
    PublishYML->>PyPI: build + pypa/gh-action-pypi-publish (⚠️ duplicate!)
    PyPI-->>PublishYML: 400 File already exists
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/publish.yml`, line 55-57 ([link](https://github.com/punitarani/fli/blob/0637230ec27c21066ace1e41758054f27a3bdd7c/.github/workflows/publish.yml#L55-L57)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Tests run twice in `publish.yml`**

   The `release-build` job already `needs: [test]`, where `test` calls `test.yml` and runs the full 4-version matrix. The `Run tests` step here repeats a subset of those tests on a single Python version, adding several minutes to every `publish.yml` invocation with no additional signal.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/publish.yml
   Line: 55-57

   Comment:
   **Tests run twice in `publish.yml`**

   The `release-build` job already `needs: [test]`, where `test` calls `test.yml` and runs the full 4-version matrix. The `Run tests` step here repeats a subset of those tests on a single Python version, adding several minutes to every `publish.yml` invocation with no additional signal.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish.yml%0ALine%3A%2055-57%0A%0AComment%3A%0A**Tests%20run%20twice%20in%20%60publish.yml%60**%0A%0AThe%20%60release-build%60%20job%20already%20%60needs%3A%20%5Btest%5D%60%2C%20where%20%60test%60%20calls%20%60test.yml%60%20and%20runs%20the%20full%204-version%20matrix.%20The%20%60Run%20tests%60%20step%20here%20repeats%20a%20subset%20of%20those%20tests%20on%20a%20single%20Python%20version%2C%20adding%20several%20minutes%20to%20every%20%60publish.yml%60%20invocation%20with%20no%20additional%20signal.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=punitarani%2Ffli&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish.yml%0ALine%3A%2055-57%0A%0AComment%3A%0A**Tests%20run%20twice%20in%20%60publish.yml%60**%0A%0AThe%20%60release-build%60%20job%20already%20%60needs%3A%20%5Btest%5D%60%2C%20where%20%60test%60%20calls%20%60test.yml%60%20and%20runs%20the%20full%204-version%20matrix.%20The%20%60Run%20tests%60%20step%20here%20repeats%20a%20subset%20of%20those%20tests%20on%20a%20single%20Python%20version%2C%20adding%20several%20minutes%20to%20every%20%60publish.yml%60%20invocation%20with%20no%20additional%20signal.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Finline-publish-into-release%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Finline-publish-into-release%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpublish.yml%0ALine%3A%2055-57%0A%0AComment%3A%0A**Tests%20run%20twice%20in%20%60publish.yml%60**%0A%0AThe%20%60release-build%60%20job%20already%20%60needs%3A%20%5Btest%5D%60%2C%20where%20%60test%60%20calls%20%60test.yml%60%20and%20runs%20the%20full%204-version%20matrix.%20The%20%60Run%20tests%60%20step%20here%20repeats%20a%20subset%20of%20those%20tests%20on%20a%20single%20Python%20version%2C%20adding%20several%20minutes%20to%20every%20%60publish.yml%60%20invocation%20with%20no%20additional%20signal.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish.yml%3A14-16%0A**Duplicate%20PyPI%20publish%20race%20condition**%0A%0A%60publish.yml%60%20keeps%20%60release%3A%20published%60%20as%20a%20trigger%2C%20but%20%60release.yml%60%20now%20creates%20a%20GitHub%20Release%20programmatically%20via%20%60gh%20release%20create%60.%20That%20event%20fires%20%60publish.yml%60%2C%20so%20every%20successful%20%60release.yml%60%20run%20launches%20*two*%20independent%20pipelines%20racing%20to%20%60pypa%2Fgh-action-pypi-publish%60.%20Whichever%20finishes%20second%20will%20receive%20a%20PyPI%20400%20%22File%20already%20exists%22%20error%2C%20causing%20%60publish.yml%60%20to%20fail%20and%20generating%20spurious%20failure%20alerts%20on%20every%20release.%0A%0ATo%20avoid%20the%20conflict%2C%20the%20%60pypi-publish%60%20job%20should%20be%20guarded%20so%20it%20only%20runs%20when%20the%20release%20was%20created%20by%20a%20human%2C%20not%20by%20%60github-actions%5Bbot%5D%60%3A%0A%0A%60if%3A%20%24%7B%7B%20github.event_name%20%3D%3D%20'workflow_dispatch'%20%7C%7C%20%28github.event_name%20%3D%3D%20'release'%20%26%26%20github.actor%20!%3D%20'github-actions%5Bbot%5D'%29%20%7D%7D%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish.yml%3A55-57%0A**Tests%20run%20twice%20in%20%60publish.yml%60**%0A%0AThe%20%60release-build%60%20job%20already%20%60needs%3A%20%5Btest%5D%60%2C%20where%20%60test%60%20calls%20%60test.yml%60%20and%20runs%20the%20full%204-version%20matrix.%20The%20%60Run%20tests%60%20step%20here%20repeats%20a%20subset%20of%20those%20tests%20on%20a%20single%20Python%20version%2C%20adding%20several%20minutes%20to%20every%20%60publish.yml%60%20invocation%20with%20no%20additional%20signal.%0A%0A&repo=punitarani%2Ffli&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish.yml%3A14-16%0A**Duplicate%20PyPI%20publish%20race%20condition**%0A%0A%60publish.yml%60%20keeps%20%60release%3A%20published%60%20as%20a%20trigger%2C%20but%20%60release.yml%60%20now%20creates%20a%20GitHub%20Release%20programmatically%20via%20%60gh%20release%20create%60.%20That%20event%20fires%20%60publish.yml%60%2C%20so%20every%20successful%20%60release.yml%60%20run%20launches%20*two*%20independent%20pipelines%20racing%20to%20%60pypa%2Fgh-action-pypi-publish%60.%20Whichever%20finishes%20second%20will%20receive%20a%20PyPI%20400%20%22File%20already%20exists%22%20error%2C%20causing%20%60publish.yml%60%20to%20fail%20and%20generating%20spurious%20failure%20alerts%20on%20every%20release.%0A%0ATo%20avoid%20the%20conflict%2C%20the%20%60pypi-publish%60%20job%20should%20be%20guarded%20so%20it%20only%20runs%20when%20the%20release%20was%20created%20by%20a%20human%2C%20not%20by%20%60github-actions%5Bbot%5D%60%3A%0A%0A%60if%3A%20%24%7B%7B%20github.event_name%20%3D%3D%20'workflow_dispatch'%20%7C%7C%20%28github.event_name%20%3D%3D%20'release'%20%26%26%20github.actor%20!%3D%20'github-actions%5Bbot%5D'%29%20%7D%7D%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish.yml%3A55-57%0A**Tests%20run%20twice%20in%20%60publish.yml%60**%0A%0AThe%20%60release-build%60%20job%20already%20%60needs%3A%20%5Btest%5D%60%2C%20where%20%60test%60%20calls%20%60test.yml%60%20and%20runs%20the%20full%204-version%20matrix.%20The%20%60Run%20tests%60%20step%20here%20repeats%20a%20subset%20of%20those%20tests%20on%20a%20single%20Python%20version%2C%20adding%20several%20minutes%20to%20every%20%60publish.yml%60%20invocation%20with%20no%20additional%20signal.%0A%0A&pr=173&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Finline-publish-into-release%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Finline-publish-into-release%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpublish.yml%3A14-16%0A**Duplicate%20PyPI%20publish%20race%20condition**%0A%0A%60publish.yml%60%20keeps%20%60release%3A%20published%60%20as%20a%20trigger%2C%20but%20%60release.yml%60%20now%20creates%20a%20GitHub%20Release%20programmatically%20via%20%60gh%20release%20create%60.%20That%20event%20fires%20%60publish.yml%60%2C%20so%20every%20successful%20%60release.yml%60%20run%20launches%20*two*%20independent%20pipelines%20racing%20to%20%60pypa%2Fgh-action-pypi-publish%60.%20Whichever%20finishes%20second%20will%20receive%20a%20PyPI%20400%20%22File%20already%20exists%22%20error%2C%20causing%20%60publish.yml%60%20to%20fail%20and%20generating%20spurious%20failure%20alerts%20on%20every%20release.%0A%0ATo%20avoid%20the%20conflict%2C%20the%20%60pypi-publish%60%20job%20should%20be%20guarded%20so%20it%20only%20runs%20when%20the%20release%20was%20created%20by%20a%20human%2C%20not%20by%20%60github-actions%5Bbot%5D%60%3A%0A%0A%60if%3A%20%24%7B%7B%20github.event_name%20%3D%3D%20'workflow_dispatch'%20%7C%7C%20%28github.event_name%20%3D%3D%20'release'%20%26%26%20github.actor%20!%3D%20'github-actions%5Bbot%5D'%29%20%7D%7D%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpublish.yml%3A55-57%0A**Tests%20run%20twice%20in%20%60publish.yml%60**%0A%0AThe%20%60release-build%60%20job%20already%20%60needs%3A%20%5Btest%5D%60%2C%20where%20%60test%60%20calls%20%60test.yml%60%20and%20runs%20the%20full%204-version%20matrix.%20The%20%60Run%20tests%60%20step%20here%20repeats%20a%20subset%20of%20those%20tests%20on%20a%20single%20Python%20version%2C%20adding%20several%20minutes%20to%20every%20%60publish.yml%60%20invocation%20with%20no%20additional%20signal.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/publish.yml:14-16
**Duplicate PyPI publish race condition**

`publish.yml` keeps `release: published` as a trigger, but `release.yml` now creates a GitHub Release programmatically via `gh release create`. That event fires `publish.yml`, so every successful `release.yml` run launches *two* independent pipelines racing to `pypa/gh-action-pypi-publish`. Whichever finishes second will receive a PyPI 400 "File already exists" error, causing `publish.yml` to fail and generating spurious failure alerts on every release.

To avoid the conflict, the `pypi-publish` job should be guarded so it only runs when the release was created by a human, not by `github-actions[bot]`:

`if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.actor != 'github-actions[bot]') }}`

### Issue 2 of 2
.github/workflows/publish.yml:55-57
**Tests run twice in `publish.yml`**

The `release-build` job already `needs: [test]`, where `test` calls `test.yml` and runs the full 4-version matrix. The `Run tests` step here repeats a subset of those tests on a single Python version, adding several minutes to every `publish.yml` invocation with no additional signal.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): inline build+publish into ..."](https://github.com/punitarani/fli/commit/0637230ec27c21066ace1e41758054f27a3bdd7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33183398)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->