### PR TITLE
fix(ci): sync fli-js bun.lock with zod 4.4.3 bump

### DIFF
--- a/fli-js/bun.lock
+++ b/fli-js/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "fli",
       "dependencies": {
-        "zod": "^3.23.8",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -63,6 +63,6 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }
 }

--- a/fli-js/package.json
+++ b/fli-js/package.json
@@ -68,7 +68,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
## Summary

Dependabot PR #178 bumped `zod` from `3.25.76` to `^4.4.3` in `fli-js/package.json` but did **not** update `fli-js/bun.lock` (dependabot can't always refresh Bun lockfiles). As a result `bun install --frozen-lockfile` failed with `lockfile had changes, but lockfile is frozen`, which broke the **`fli-js / Format & lint`** CI job and cascaded into **`fli-js / Bun tests`** being skipped (it `needs` the lint job).

This branch carries the same zod bump plus the regenerated lockfile so the two stay in sync.

## Changes
- `fli-js/bun.lock`: zod `3.25.76` → `4.4.3` (the only lockfile delta; no other dependencies churned)
- `fli-js/package.json`: zod `^4.4.3` (from the dependabot bump)

## Verification (local, zod 4.4.3)
- `bun install --frozen-lockfile` ✅
- `bun run format:check` ✅
- `bun run lint` (biome + oxlint) ✅
- `bun run typecheck` ✅
- enum-sync check (`bun run generate:enums` → no diff) ✅
- `bun run test:ci` — **261 pass / 0 fail** ✅

The existing zod usage (`z.object`, `.int().nonnegative().default()`, `.nullable().optional()`, `.transform()`, `z.infer`) is compatible with zod 4 — no source changes were needed.

## Test plan
- [ ] CI `fli-js / Format & lint` passes
- [ ] CI `fli-js / Bun tests` runs and passes

https://claude.ai/code/session_01XDToUKLWfPY9FqQQ1LSUCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDToUKLWfPY9FqQQ1LSUCT)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CI breakage caused by Dependabot bumping `zod` in `package.json` without regenerating `bun.lock`, which caused `bun install --frozen-lockfile` to fail and blocked the lint and test jobs.

- **`fli-js/bun.lock`**: zod resolved version updated from `3.25.76` → `4.4.3`; no other dependency entries changed.
- **`fli-js/package.json`**: version range updated from `^3.23.8` → `^4.4.3` to match the lockfile.
- The existing zod API surface used in the codebase (`z.object`, `.default()`, `.nullable().optional()`, `.transform()`, `z.infer`) is unaffected by zod v4 breaking changes — the potentially impactful `default-inside-optional` change does not apply here since no field chains both `.default()` and `.optional()` on the same schema.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to keeping the lockfile in sync with the package.json dependency range, with no source code modifications.

Only two files change: the lockfile and `package.json`. The zod v4 API surface in use (`z.object`, `.default()`, `.nullable().optional()`, `.transform()`, `z.infer`) has no breaking changes for these patterns, and the author confirmed 261 tests pass with typecheck and lint clean.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli-js/bun.lock | Lockfile regenerated to resolve zod 3.25.76 → 4.4.3; only the zod entry changed, all other dependencies are untouched. |
| fli-js/package.json | Version range updated from `^3.23.8` to `^4.4.3`, matching the regenerated lockfile; no other changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot PR #178\nBumps package.json zod ^3.23.8 → ^4.4.3] --> B{bun.lock in sync?}
    B -- No --> C[bun install --frozen-lockfile FAILS\nlockfile had changes but is frozen]
    C --> D[fli-js / Format & lint FAILS]
    D --> E[fli-js / Bun tests SKIPPED\nneeds lint job]
    B -- Yes PR #179 --> F[bun install --frozen-lockfile PASSES]
    F --> G[fli-js / Format & lint PASSES]
    G --> H[fli-js / Bun tests PASSES\n261 pass / 0 fail]
```

<sub>Reviews (1): Last reviewed commit: ["deps(fli-js): sync bun.lock with zod 4.4..."](https://github.com/punitarani/fli/commit/e49ef85ba0640011d2a18aa43aed3d177a4e0923) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33621824)</sub>

<!-- /greptile_comment -->