### PR TITLE
fix(ci): pin upload-artifact to v7 in npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -125,7 +125,7 @@ jobs:
         run: npm pack
 
       - name: Upload tarball
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: npm-tarball
           path: fli-js/*.tgz


### PR DESCRIPTION
## Summary

The first npm release failed in the `publish-npm.yml` → `release-build` job at the **"Getting action download info"** stage with:

```
Error: Unable to resolve action `actions/upload-artifact@v8`, unable to find version `v8`
```

`actions/upload-artifact` and `actions/download-artifact` are separate action repos with independent version tags: `download-artifact` has a `v8`, but `upload-artifact`'s latest major is `v7`. The `release-build` job referenced the non-existent `upload-artifact@v8`.

## Change

- `.github/workflows/publish-npm.yml:128`: `actions/upload-artifact@v8` → `actions/upload-artifact@v7`

This aligns with the 4 other `upload-artifact@v7` references already in the repo. `download-artifact@v8` (line 158) is valid and left unchanged.

## Why it wasn't caught earlier

`upload-artifact@v8` was only referenced in the npm publish path, which had never run until the first `fli-js-v*` release — so existing green CI never exercised it.

## After merge

The release itself already happened (version bumped, tag + GitHub Release created); only the publish step failed. Don't re-run `release-npm` (it would bump again) — instead re-publish the existing version by re-running the failed `Upload npm Package` run, or `workflow_dispatch` `publish-npm.yml` with `environment=npm`.

https://claude.ai/code/session_01R2vZihmSWV2wvRawjF4Gjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2vZihmSWV2wvRawjF4Gjo)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken `actions/upload-artifact@v8` reference in the npm publish workflow — a version that does not exist for that action — replacing it with `v7`, which is the latest major and matches all four other `upload-artifact` usages in the repository.

- Corrects `.github/workflows/publish-npm.yml` line 128: `upload-artifact@v8` → `upload-artifact@v7`, unblocking the `release-build` → `npm-publish` artifact handoff.
- `download-artifact@v8` (line 158) is intentionally left unchanged, as that action's v8 tag is valid.

<h3>Confidence Score: 5/5</h3>

Single-line targeted fix restoring a broken CI step with no impact on application code.

The change is exactly one line, corrects a confirmed runtime failure, and aligns with every other upload-artifact reference in the codebase. There is nothing to break here.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-npm.yml | Corrects a non-existent `actions/upload-artifact@v8` reference to the valid `v7`, matching all other upload-artifact usages in the repo |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([release published or workflow_dispatch]) --> B[fli-js-tests\nformat, lint, typecheck, tests]
    B --> C[release-build\nbuild, pack tarball]
    C -->|upload-artifact v7| D[(artifact: npm-tarball)]
    D -->|download-artifact v8| E[npm-publish\nnpm publish provenance]
    E --> F([npmjs.com/package/fli])
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pin upload-artifact to v7 in np..."](https://github.com/punitarani/fli/commit/bf3e8d4d864804c1cc5f8b23b3b4f16e18e86486) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33623267)</sub>

<!-- /greptile_comment -->