### PR TITLE
docs(fli-js): import as "fli" via alias install

### DIFF
--- a/fli-js/README.md
+++ b/fli-js/README.md
@@ -8,9 +8,20 @@ filter encoding, same wire-format decoders.
 
 ## Install
 
+The package is published as `@punitarani/fli`. Install it under the local
+alias `fli` so you can `import … from "fli"`:
+
 ```bash
-bun add @punitarani/fli   # or: npm install @punitarani/fli / pnpm add @punitarani/fli
+npm  i   fli@npm:@punitarani/fli
+# or: pnpm add fli@npm:@punitarani/fli
+# or: yarn add fli@npm:@punitarani/fli
+# or: bun  add fli@npm:@punitarani/fli
 ```
+
+> The `fli@npm:@punitarani/fli` form installs the scoped package under the
+> name `fli` in your `node_modules`, so every import below resolves as
+> `"fli"`. Prefer the scoped name directly? Install `@punitarani/fli` and
+> import from `"@punitarani/fli"` instead.
 
 ## Quick start
 
@@ -24,7 +35,7 @@ import {
   SearchFlights,
   SeatType,
   SortBy,
-} from "@punitarani/fli";
+} from "fli";
 
 const filters = new FlightSearchFilters({
   passenger_info: { adults: 1, children: 0, infants_in_seat: 0, infants_on_lap: 0 },
@@ -47,7 +58,7 @@ console.log(results);
 ### Date-range search
 
 ```ts
-import { Airport, DateSearchFilters, FlightSegment, SearchDates } from "@punitarani/fli";
+import { Airport, DateSearchFilters, FlightSegment, SearchDates } from "fli";
 
 const filters = new DateSearchFilters({
   passenger_info: { adults: 1, children: 0, infants_in_seat: 0, infants_on_lap: 0 },
@@ -77,7 +88,7 @@ The TypeScript port uses native `fetch` (Bun's built-in) and replaces
   explicit `proxy` option on `new Client({...})`).
 
 ```ts
-import { Client, SearchFlights } from "@punitarani/fli";
+import { Client, SearchFlights } from "fli";
 
 const search = new SearchFlights(
   new Client({ proxy: "http://user:pass@proxy.example.com:8080" }),


### PR DESCRIPTION
## Summary

Make the documented usage `import … from "fli"` (instead of `from "@punitarani/fli"`) while keeping the published name `@punitarani/fli`.

### Why an alias install
In Node/npm the import specifier *is* the installed package's name. The unscoped `fli` name is owned by another npm account, so we can't publish under it, and there's no `package.json` field that lets consumers import a package under a different name than it's installed as. The one supported way to get `import … from "fli"` is an **install-time alias**, which all package managers support:

```bash
npm i fli@npm:@punitarani/fli
```

This installs the scoped package under the local name `fli` in `node_modules`, so the bare `"fli"` specifier resolves.

## Changes (`fli-js/README.md` only)
- Install section now shows the alias install for npm/pnpm/yarn/bun, with a short note explaining what it does and offering the plain scoped install (`@punitarani/fli` + `from "@punitarani/fli"`) as an alternative.
- The Quick start, SearchDates, and Client examples now `import … from "fli"`.

No source/package.json changes — the publish name stays `@punitarani/fli`; this is purely how consumers are guided to install and import.

https://claude.ai/code/session_01R2vZihmSWV2wvRawjF4Gjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2vZihmSWV2wvRawjF4Gjo)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `fli-js/README.md` to guide consumers to install the scoped package `@punitarani/fli` under the local alias `fli`, enabling cleaner `import … from "fli"` syntax. No source files or `package.json` are changed.

- Install section now shows `pkg@npm:@punitarani/fli` alias commands for npm, pnpm, yarn, and bun, with a blockquote explaining the mechanism and offering the plain scoped install as an alternative.
- All three import examples (Quick start, Date-range search, HTTP/proxy) are updated from `"@punitarani/fli"` to `"fli"` to match the aliased install.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no source or package.json modifications; safe to merge.

The change touches only the README. The alias install pattern (`pkg@npm:scope/pkg`) is natively supported by npm, pnpm, yarn, and bun, so the documented commands are correct. All updated import examples are consistent with the aliased install. The alternative scoped-name path is preserved and clearly explained.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli-js/README.md | Documentation-only change: rewrites the install section to use npm alias syntax and updates all import examples from `@punitarani/fli` to `fli`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant npm/pnpm/yarn/bun
    participant node_modules

    User->>npm/pnpm/yarn/bun: "install fli@npm:@punitarani/fli"
    npm/pnpm/yarn/bun->>node_modules: "place @punitarani/fli files under fli/ alias"
    note over node_modules: node_modules/fli/ → @punitarani/fli contents

    User->>User: "import { SearchFlights } from "fli""
    User->>node_modules: resolve specifier "fli"
    node_modules-->>User: "returns @punitarani/fli exports"
```

<sub>Reviews (1): Last reviewed commit: ["docs(fli-js): import as &quot;fli&quot; via alias ..."](https://github.com/punitarani/fli/commit/f3e2f1ce9e124ed40cbc77b0a8ea58881020fce0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33626382)</sub>

<!-- /greptile_comment -->