### PR TITLE
feat: add min-duration and max-duration to dates search

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The MCP server provides two main tools:
 | `start_date`        | string | Start of date range in YYYY-MM-DD format                    |
 | `end_date`          | string | End of date range in YYYY-MM-DD format                      |
 | `trip_duration`     | int    | Trip duration in days (for round-trips)                     |
+| `min_duration`      | int    | Minimum trip duration in days                               |
+| `max_duration`      | int    | Maximum trip duration in days                               |
 | `is_round_trip`     | bool   | Whether to search for round-trip flights                    |
 | `cabin_class`       | string | ECONOMY, PREMIUM_ECONOMY, BUSINESS, or FIRST                |
 | `max_stops`         | string | ANY, NON_STOP, ONE_STOP, or TWO_PLUS_STOPS                  |
@@ -244,6 +246,8 @@ fli multi \
 | `--from`                | Start date                                 | `2026-01-01`             |
 | `--to`                  | End date                                   | `2026-02-01`             |
 | `--duration, -d`        | Trip duration in days                      | `3`                      |
+| `--min-duration`        | Minimum trip duration in days              | `3`                      |
+| `--max-duration`        | Maximum trip duration in days              | `5`                      |
 | `--round, -R`           | Round-trip search                          | (flag)                   |
 | `--airlines, -a`        | Airline IATA codes                         | `BA,KL`                  |
 | `--exclude-airlines, -A`| Airline IATA codes to **exclude**          | `DL,B6`                  |

--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -1,5 +1,6 @@
 """Date search CLI command for finding cheapest travel dates."""
 
+import time
 from datetime import datetime, timedelta
 from typing import Annotated
 
@@ -76,13 +77,27 @@ def dates(
         datetime.now() + timedelta(days=60)
     ).strftime("%Y-%m-%d"),
     trip_duration: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--duration",
             "-d",
             help="Trip duration in days",
         ),
-    ] = 3,
+    ] = None,
+    min_duration: Annotated[
+        int | None,
+        typer.Option(
+            "--min-duration",
+            help="Minimum trip duration in days (requires --round)",
+        ),
+    ] = None,
+    max_duration: Annotated[
+        int | None,
+        typer.Option(
+            "--max-duration",
+            help="Maximum trip duration in days (requires --round)",
+        ),
+    ] = None,
     airlines: Annotated[
         list[str] | None,
         typer.Option(
@@ -268,6 +283,15 @@ def dates(
         end_date = normalize_cli_date(end_date)
         departure_window = normalize_cli_time_range(departure_window)
 
+        if (min_duration is not None or max_duration is not None) and trip_duration is not None:
+            raise ValueError("Cannot specify both --duration and --min-duration/--max-duration")
+
+        if trip_duration is None and min_duration is None and max_duration is None:
+            trip_duration = 3
+
+        if (min_duration is not None or max_duration is not None) and not is_round_trip:
+            raise ValueError("--min-duration and --max-duration require --round")
+
         # Parse parameters using shared utilities
         origin_airport = resolve_airport(origin)
         destination_airport = resolve_airport(destination)
@@ -293,6 +317,8 @@ def dates(
             "start_date": start_date,
             "end_date": end_date,
             "trip_duration": trip_duration,
+            "min_duration": min_duration,
+            "max_duration": max_duration,
             "is_round_trip": is_round_trip,
             "cabin_class": seat_type.name,
             "max_stops": stops.name,
@@ -319,16 +345,6 @@ def dates(
                 latest_arrival=None,
             )
 
-        # Build flight segments using shared builder
-        segments, trip_type = build_date_search_segments(
-            origin=origin_airport,
-            destination=destination_airport,
-            start_date=start_date,
-            trip_duration=trip_duration,
-            is_round_trip=is_round_trip,
-            time_restrictions=time_restrictions,
-        )
-
         # Build layover constraints (min / max duration; airports stay
         # restricted via the existing model field).
         layover_restrictions = None
@@ -340,34 +356,69 @@ def dates(
                 max_duration=max_layover,
             )
 
-        # Create search filters
-        filters = DateSearchFilters(
-            trip_type=trip_type,
-            passenger_info=PassengerInfo(adults=1),
-            flight_segments=segments,
-            stops=stops,
-            seat_type=seat_type,
-            airlines=parsed_airlines,
-            airlines_exclude=parsed_exclude_airlines,
-            alliances=parsed_alliances,
-            alliances_exclude=parsed_exclude_alliances,
-            layover_restrictions=layover_restrictions,
-            from_date=start_date,
-            to_date=end_date,
-            duration=trip_duration if trip_type == TripType.ROUND_TRIP else None,
-        )
+        durations_to_search = []
+        if min_duration is not None or max_duration is not None:
+            actual_min = min_duration if min_duration is not None else 1
+            if max_duration is not None:
+                actual_max = max_duration
+            else:
+                from_dt = datetime.strptime(start_date, "%Y-%m-%d")
+                to_dt = datetime.strptime(end_date, "%Y-%m-%d")
+                actual_max = max(actual_min, (to_dt - from_dt).days)
+            durations_to_search = list(range(actual_min, actual_max + 1))
+        else:
+            durations_to_search = [trip_duration] if trip_type == TripType.ROUND_TRIP else [None]
 
-        # Perform search; pass currency/language/country through as URL params.
         search_client = SearchDates()
-        results = search_client.search(
-            filters,
-            currency=currency,
-            language=language,
-            country=country,
-        )
+        all_results = []
+        seen_dates = set()
 
-        if not results:
-            results = []
+        for idx, current_duration in enumerate(durations_to_search):
+            if idx > 0:
+                time.sleep(1)
+
+            # Build flight segments using shared builder
+            segments, _ = build_date_search_segments(
+                origin=origin_airport,
+                destination=destination_airport,
+                start_date=start_date,
+                trip_duration=current_duration if current_duration is not None else 3,
+                is_round_trip=is_round_trip,
+                time_restrictions=time_restrictions,
+            )
+
+            # Create search filters
+            filters = DateSearchFilters(
+                trip_type=trip_type,
+                passenger_info=PassengerInfo(adults=1),
+                flight_segments=segments,
+                stops=stops,
+                seat_type=seat_type,
+                airlines=parsed_airlines,
+                airlines_exclude=parsed_exclude_airlines,
+                alliances=parsed_alliances,
+                alliances_exclude=parsed_exclude_alliances,
+                layover_restrictions=layover_restrictions,
+                from_date=start_date,
+                to_date=end_date,
+                duration=current_duration,
+            )
+
+            results = search_client.search(
+                filters,
+                currency=currency,
+                language=language,
+                country=country,
+            )
+            
+            if results:
+                for res in results:
+                    date_tuple = tuple(res.date)
+                    if date_tuple not in seen_dates:
+                        seen_dates.add(date_tuple)
+                        all_results.append(res)
+
+        results = all_results
 
         if selected_days:
             results = filter_dates_by_days(results, selected_days, trip_type)
@@ -435,6 +486,8 @@ def dates(
                         "start_date": start_date,
                         "end_date": end_date,
                         "trip_duration": trip_duration,
+                        "min_duration": min_duration,
+                        "max_duration": max_duration,
                         "is_round_trip": is_round_trip,
                         "cabin_class": cabin_class,
                         "max_stops": max_stops,
@@ -490,6 +543,8 @@ def dates(
                         "start_date": start_date,
                         "end_date": end_date,
                         "trip_duration": trip_duration,
+                        "min_duration": min_duration,
+                        "max_duration": max_duration,
                         "is_round_trip": is_round_trip,
                         "cabin_class": cabin_class,
                         "max_stops": max_stops,

--- a/fli/cli/commands/dates.py
+++ b/fli/cli/commands/dates.py
@@ -89,6 +89,7 @@ def dates(
         typer.Option(
             "--min-duration",
             help="Minimum trip duration in days (requires --round)",
+            min=1,
         ),
     ] = None,
     max_duration: Annotated[
@@ -96,6 +97,7 @@ def dates(
         typer.Option(
             "--max-duration",
             help="Maximum trip duration in days (requires --round)",
+            min=1,
         ),
     ] = None,
     airlines: Annotated[
@@ -365,6 +367,10 @@ def dates(
                 from_dt = datetime.strptime(start_date, "%Y-%m-%d")
                 to_dt = datetime.strptime(end_date, "%Y-%m-%d")
                 actual_max = max(actual_min, (to_dt - from_dt).days)
+            if actual_min > actual_max:
+                raise ValueError(
+                    f"--min-duration ({actual_min}) must not exceed --max-duration ({actual_max})"
+                )
             durations_to_search = list(range(actual_min, actual_max + 1))
         else:
             durations_to_search = [trip_duration] if trip_type == TripType.ROUND_TRIP else [None]

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -815,6 +815,12 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
                 from_dt = datetime.strptime(params.start_date, "%Y-%m-%d")
                 to_dt = datetime.strptime(params.end_date, "%Y-%m-%d")
                 actual_max = max(actual_min, (to_dt - from_dt).days)
+            if actual_min > actual_max:
+                return {
+                    "success": False,
+                    "error": f"min_duration ({actual_min}) must not exceed max_duration ({actual_max})",
+                    "dates": [],
+                }
             durations_to_search = list(range(actual_min, actual_max + 1))
         else:
             durations_to_search = [params.trip_duration] if params.is_round_trip else [None]

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -825,6 +825,7 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
         else:
             durations_to_search = [params.trip_duration] if params.is_round_trip else [None]
 
+        trip_type = TripType.ROUND_TRIP if params.is_round_trip else TripType.ONE_WAY
         currency = parse_currency(params.currency)
         search_client = SearchDates()
         all_results = []

--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -7,6 +7,7 @@ travel dates.
 
 import json
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any
 
@@ -195,8 +196,14 @@ class DateSearchParams(BaseModel):
     )
     start_date: str = Field(description="Start of date range in YYYY-MM-DD format")
     end_date: str = Field(description="End of date range in YYYY-MM-DD format")
-    trip_duration: int = Field(
-        3, ge=1, description="Trip duration in days (for round-trip searches)"
+    trip_duration: int | None = Field(
+        None, ge=1, description="Trip duration in days (for round-trip searches)"
+    )
+    min_duration: int | None = Field(
+        None, ge=1, description="Minimum trip duration in days (requires round-trip)"
+    )
+    max_duration: int | None = Field(
+        None, ge=1, description="Maximum trip duration in days (requires round-trip)"
     )
     is_round_trip: bool = Field(False, description="Search for round-trip flights")
     airlines: list[str] | None = Field(
@@ -767,6 +774,15 @@ def _execute_booking_options(
 def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
     """Execute a date search and return formatted results."""
     try:
+        if (params.min_duration is not None or params.max_duration is not None) and params.trip_duration is not None:
+            return {"success": False, "error": "Cannot specify both trip_duration and min/max duration", "dates": []}
+            
+        if params.trip_duration is None and params.min_duration is None and params.max_duration is None:
+            params.trip_duration = 3
+            
+        if (params.min_duration is not None or params.max_duration is not None) and not params.is_round_trip:
+            return {"success": False, "error": "min_duration and max_duration require is_round_trip to be true", "dates": []}
+
         # Parse inputs using shared utilities (supports comma-separated multi-airport)
         origins = _resolve_airports(params.origin)
         destinations = _resolve_airports(params.destination)
@@ -781,16 +797,6 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
         departure_window = params.departure_window or CONFIG.default_departure_window
         time_restrictions = build_time_restrictions(departure_window) if departure_window else None
 
-        # Build flight segments (pass full lists for multi-airport support)
-        segments, trip_type = build_date_search_segments(
-            origin=origins,
-            destination=destinations,
-            start_date=params.start_date,
-            trip_duration=params.trip_duration,
-            is_round_trip=params.is_round_trip,
-            time_restrictions=time_restrictions,
-        )
-
         layover_restrictions = None
         if params.min_layover is not None or params.max_layover is not None:
             from fli.models import LayoverRestrictions
@@ -800,32 +806,71 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
                 max_duration=params.max_layover,
             )
 
-        # Create search filters
-        filters = DateSearchFilters(
-            trip_type=trip_type,
-            passenger_info=PassengerInfo(adults=params.passengers),
-            flight_segments=segments,
-            stops=max_stops,
-            seat_type=cabin_class,
-            airlines=airlines,
-            airlines_exclude=airlines_exclude,
-            alliances=alliances,
-            alliances_exclude=alliances_exclude,
-            layover_restrictions=layover_restrictions,
-            from_date=params.start_date,
-            to_date=params.end_date,
-            duration=params.trip_duration if params.is_round_trip else None,
-        )
+        durations_to_search = []
+        if params.min_duration is not None or params.max_duration is not None:
+            actual_min = params.min_duration if params.min_duration is not None else 1
+            if params.max_duration is not None:
+                actual_max = params.max_duration
+            else:
+                from_dt = datetime.strptime(params.start_date, "%Y-%m-%d")
+                to_dt = datetime.strptime(params.end_date, "%Y-%m-%d")
+                actual_max = max(actual_min, (to_dt - from_dt).days)
+            durations_to_search = list(range(actual_min, actual_max + 1))
+        else:
+            durations_to_search = [params.trip_duration] if params.is_round_trip else [None]
 
-        # Perform search
         currency = parse_currency(params.currency)
         search_client = SearchDates()
-        dates = search_client.search(
-            filters,
-            currency=currency,
-            language=params.language,
-            country=params.country,
-        )
+        all_results = []
+        seen_dates = set()
+
+        for idx, current_duration in enumerate(durations_to_search):
+            if idx > 0:
+                time.sleep(1)
+
+            # Build flight segments (pass full lists for multi-airport support)
+            segments, trip_type = build_date_search_segments(
+                origin=origins,
+                destination=destinations,
+                start_date=params.start_date,
+                trip_duration=current_duration if current_duration is not None else 3,
+                is_round_trip=params.is_round_trip,
+                time_restrictions=time_restrictions,
+            )
+
+            # Create search filters
+            filters = DateSearchFilters(
+                trip_type=trip_type,
+                passenger_info=PassengerInfo(adults=params.passengers),
+                flight_segments=segments,
+                stops=max_stops,
+                seat_type=cabin_class,
+                airlines=airlines,
+                airlines_exclude=airlines_exclude,
+                alliances=alliances,
+                alliances_exclude=alliances_exclude,
+                layover_restrictions=layover_restrictions,
+                from_date=params.start_date,
+                to_date=params.end_date,
+                duration=current_duration,
+            )
+
+            # Perform search
+            dates_chunk = search_client.search(
+                filters,
+                currency=currency,
+                language=params.language,
+                country=params.country,
+            )
+
+            if dates_chunk:
+                for d in dates_chunk:
+                    date_tuple = tuple(d.date)
+                    if date_tuple not in seen_dates:
+                        seen_dates.add(date_tuple)
+                        all_results.append(d)
+
+        dates = all_results
 
         if not dates:
             return {
@@ -1042,9 +1087,17 @@ def search_dates(
     start_date: Annotated[str, Field(description="Start of date range in YYYY-MM-DD format")],
     end_date: Annotated[str, Field(description="End of date range in YYYY-MM-DD format")],
     trip_duration: Annotated[
-        int,
+        int | None,
         Field(description="Trip duration in days for round-trips", ge=1),
-    ] = 3,
+    ] = None,
+    min_duration: Annotated[
+        int | None,
+        Field(description="Minimum trip duration in days for round-trips", ge=1),
+    ] = None,
+    max_duration: Annotated[
+        int | None,
+        Field(description="Maximum trip duration in days for round-trips", ge=1),
+    ] = None,
     is_round_trip: Annotated[
         bool,
         Field(description="Search for round-trip flights"),
@@ -1118,6 +1171,8 @@ def search_dates(
         start_date=start_date,
         end_date=end_date,
         trip_duration=trip_duration,
+        min_duration=min_duration,
+        max_duration=max_duration,
         is_round_trip=is_round_trip,
         airlines=airlines,
         cabin_class=cabin_class,

--- a/tests/cli/test_dates.py
+++ b/tests/cli/test_dates.py
@@ -297,3 +297,43 @@ def test_dates_json_empty_results(runner, mock_search_dates, mock_console):
     assert payload["success"] is True
     assert payload["count"] == 0
     assert payload["dates"] == []
+
+
+def test_dates_min_max_duration(runner, mock_search_dates, mock_console):
+    """Test dates search with min and max duration."""
+    mock_search_dates.search.return_value = [
+        DatePrice(
+            date=(
+                datetime.now() + timedelta(days=1),
+                datetime.now() + timedelta(days=5),
+            ),
+            price=599.98,
+        ),
+    ]
+    result = runner.invoke(
+        app,
+        ["dates", "JFK", "LAX", "--round", "--min-duration", "3", "--max-duration", "5"],
+    )
+    assert result.exit_code == 0
+    # Should call search 3 times (durations 3, 4, 5)
+    assert mock_search_dates.search.call_count == 3
+
+
+def test_dates_min_max_duration_without_round(runner, mock_search_dates, mock_console):
+    """Test dates search with min/max duration but without --round fails."""
+    result = runner.invoke(
+        app,
+        ["dates", "JFK", "LAX", "--min-duration", "3"],
+    )
+    assert result.exit_code == 1
+    assert "require --round" in result.stdout
+
+
+def test_dates_conflict_duration(runner, mock_search_dates, mock_console):
+    """Test dates search with both --duration and --min-duration fails."""
+    result = runner.invoke(
+        app,
+        ["dates", "JFK", "LAX", "--round", "--duration", "4", "--min-duration", "3"],
+    )
+    assert result.exit_code == 1
+    assert "Cannot specify both" in result.stdout

--- a/tests/mcp/test_mcp_server_unit.py
+++ b/tests/mcp/test_mcp_server_unit.py
@@ -595,3 +595,58 @@ class TestExecuteBookingOptions:
         assert "booking_url" in result
         assert "note" in result
         assert "booking_url" in result["note"]
+
+
+class TestExecuteDateSearchMinMaxDuration:
+    @pytest.fixture
+    def valid_params(self):
+        from fli.mcp.server import DateSearchParams
+        return DateSearchParams(
+            origin="JFK",
+            destination="LHR",
+            start_date="2026-12-01",
+            end_date="2026-12-10",
+            trip_duration=None,
+            min_duration=3,
+            max_duration=5,
+            is_round_trip=True,
+        )
+
+    def test_min_max_duration_iteration(self, monkeypatch, valid_params):
+        from fli.mcp.server import _execute_date_search
+        
+        call_count = 0
+        def mock_search(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            dr = MagicMock()
+            dr.date = ("2026-12-01", "2026-12-05")
+            dr.price = 350.0
+            dr.currency = "USD"
+            return [dr]
+
+        monkeypatch.setattr("fli.mcp.server.SearchDates.search", mock_search)
+        
+        result = _execute_date_search(valid_params)
+        
+        assert result["success"] is True
+        assert call_count == 3  # Durations 3, 4, 5
+        assert result["count"] == 1  # Deduplicated because date mocks are identical
+
+    def test_min_max_duration_requires_round_trip(self, valid_params):
+        from fli.mcp.server import _execute_date_search
+        
+        valid_params.is_round_trip = False
+        result = _execute_date_search(valid_params)
+        
+        assert result["success"] is False
+        assert "require is_round_trip" in result["error"]
+
+    def test_min_max_duration_conflicts_with_trip_duration(self, valid_params):
+        from fli.mcp.server import _execute_date_search
+        
+        valid_params.trip_duration = 4
+        result = _execute_date_search(valid_params)
+        
+        assert result["success"] is False
+        assert "Cannot specify both" in result["error"]


### PR DESCRIPTION
## Motivation

`fli dates --round --duration N` forces you to pick a single trip length upfront. If you want the cheapest option within a range (e.g. "I am happy with 4-7 nights"), you have to run the command once per duration and merge the results by hand. This PR removes that friction.

## What this adds

`--min-duration` and `--max-duration` on `fli dates` and the `search_dates` MCP tool. When both flags are given with `--round`, the command searches every duration in the range, deduplicates results by `(departure_date, return_date)` pair, and returns the merged list sorted by price.

```
fli dates BGY NAP --round --min-duration 4 --max-duration 7 --from 2026-07-01 --to 2026-08-01
```

## Validation

- Incompatible with `--duration` -- explicit error if used together
- Requires `--round` -- explicit error if omitted
- `--min-duration` must not exceed `--max-duration` -- explicit error, never a silent empty result
- Both flags reject 0 and negative values at parse time (`min=1`, consistent with `--min-layover`)
- 1-second delay between API calls to respect rate limits

## Files changed

| File | Change |
|---|---|
| `fli/cli/commands/dates.py` | New flags, iteration/dedup loop, input validation |
| `fli/mcp/server.py` | Mirrors CLI changes for `search_dates` |
| `tests/cli/test_dates.py` | Happy path, missing `--round`, `--duration` conflict |
| `tests/mcp/test_mcp_server_unit.py` | Iteration count, round-trip requirement, conflict |
| `README.md` | Documents new flags in Dates Command and MCP tables |

## Test plan

- [x] `uv run pytest tests/cli/test_dates.py tests/mcp/test_mcp_server_unit.py -vv` -- all new tests pass
- [x] `fli dates BGY NAP --round --min-duration 5 --max-duration 5` -- identical output to `--duration 5`
- [x] `fli dates BGY NAP --round --min-duration 3 --max-duration 7` -- results for multiple durations, merged and deduplicated
- [x] `fli dates BGY NAP --min-duration 3 --max-duration 7` (no `--round`) -- exits with clear error
- [x] `fli dates BGY NAP --round --duration 5 --min-duration 3` -- exits with clear error
- [x] `fli dates BGY NAP --round --min-duration 7 --max-duration 3` -- exits with clear error (min > max)
- [x] `fli dates BGY NAP --round --min-duration 0` -- rejected at parse time (typer min=1 constraint)