### PR TITLE
Add click runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 
 dependencies = [
     "babel>=2.17.0",
+    "click>=8.1.0",
     "curl-cffi>=0.7.4",
     "httpx>=0.28.1",
     "plotext>=5.3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -641,6 +641,7 @@ version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },
+    { name = "click" },
     { name = "curl-cffi" },
     { name = "httpx" },
     { name = "plotext" },
@@ -678,6 +679,7 @@ mcp = [
 [package.metadata]
 requires-dist = [
     { name = "babel", specifier = ">=2.17.0" },
+    { name = "click", specifier = ">=8.1.0" },
     { name = "curl-cffi", specifier = ">=0.7.4" },
     { name = "fastapi", marker = "extra == 'mcp'", specifier = ">=0.115.6" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.2" },


### PR DESCRIPTION
## Summary

- add `click>=8.1.0` to runtime dependencies because `fli.cli.utils` imports `click.Context` and `click.Parameter`
- refresh `uv.lock` so the package metadata includes the direct dependency

Closes #197.

## Verification

```bash
uv lock
uv run fli --help
uv run python -c "from importlib.metadata import metadata; print([v for v in metadata('flights').get_all('Requires-Dist') if v.lower().startswith('click')])"
```

Note: I ran the `uv run` smoke checks from an ASCII-only temporary path on Windows to avoid an unrelated Python site initialization issue caused by non-UTF-8 `.pth` decoding under the local non-ASCII workspace path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR declares `click>=8.1.0` as an explicit runtime dependency in `pyproject.toml` and refreshes `uv.lock` accordingly, fixing the case where `fli/cli/utils.py` directly imports `click.Context` and `click.Parameter` without `click` being a declared direct dependency.

- `pyproject.toml`: adds `click>=8.1.0` to `dependencies`; the version floor matches what `typer>=0.15.1` already requires transitively, so no conflict is introduced.
- `uv.lock`: adds `click` to the `flights` package dependency and metadata sections, keeping the lock file consistent with the updated manifest.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly promotes click from an implicit transitive dependency to an explicit runtime dependency, matching the direct import already present in the codebase.

The two-file change is minimal and precise: the version floor added to pyproject.toml matches what typer already pulls in, so no version conflicts are introduced. The lock file is consistently refreshed. No logic, API, or behavior changes are involved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Adds `click>=8.1.0` to runtime dependencies; version floor is correct and consistent with typer's own requirement for click. |
| uv.lock | Lock file regenerated to list click as a direct dependency of the flights package; change is consistent with pyproject.toml. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["fli/cli/utils.py"] -->|"from click import Context, Parameter"| B["click (direct import)"]
    A -->|"import typer"| C["typer>=0.15.1"]
    C -->|"requires"| D["click>=8.1.0 (transitive)"]
    B -.->|"was only resolved via"| D
    E["pyproject.toml\ndependencies"] -->|"now explicitly declares"| F["click>=8.1.0 (direct dep)"]
    F --> B
```

<sub>Reviews (1): Last reviewed commit: ["Update lockfile for click dependency"](https://github.com/punitarani/fli/commit/4b2cb1f4a04a1549e4e752a64e0396ca61f4ae62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36316276)</sub>

<!-- /greptile_comment -->