### PR TITLE
fix(search): surface Google Flights ErrorResponse instead of silent empty results

### DIFF
--- a/fli/mcp/server.py
+++ b/fli/mcp/server.py
@@ -39,7 +39,7 @@ from fli.models import (
     PassengerInfo,
     TripType,
 )
-from fli.search import SearchDates, SearchFlights
+from fli.search import GoogleFlightsRateLimited, SearchDates, SearchFlights
 
 
 class FlightSearchConfig(BaseSettings):
@@ -662,6 +662,15 @@ def _execute_flight_search(params: FlightSearchParams) -> dict[str, Any]:
 
     except ParseError as e:
         return {"success": False, "error": str(e), "flights": []}
+    except GoogleFlightsRateLimited as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "code": "RATE_LIMITED",
+            "retry_after_s": 30,
+            "session_id": e.session_id,
+            "flights": [],
+        }
     except Exception as e:
         error_msg = str(e)
         if "validation error" in error_msg.lower():
@@ -757,6 +766,15 @@ def _execute_booking_options(
 
     except ParseError as e:
         return {"success": False, "error": str(e), "options": []}
+    except GoogleFlightsRateLimited as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "code": "RATE_LIMITED",
+            "retry_after_s": 30,
+            "session_id": e.session_id,
+            "options": [],
+        }
     except Exception as e:
         error_msg = str(e)
         if "validation error" in error_msg.lower():
@@ -857,6 +875,15 @@ def _execute_date_search(params: DateSearchParams) -> dict[str, Any]:
 
     except ParseError as e:
         return {"success": False, "error": str(e), "dates": []}
+    except GoogleFlightsRateLimited as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "code": "RATE_LIMITED",
+            "retry_after_s": 30,
+            "session_id": e.session_id,
+            "dates": [],
+        }
     except Exception as e:
         return {"success": False, "error": f"Search failed: {str(e)}", "dates": []}
 

--- a/fli/search/__init__.py
+++ b/fli/search/__init__.py
@@ -1,5 +1,6 @@
 from .dates import DatePrice, SearchDates
 from .exceptions import (
+    GoogleFlightsRateLimited,
     SearchClientError,
     SearchConnectionError,
     SearchHTTPError,
@@ -15,4 +16,5 @@ __all__ = [
     "SearchTimeoutError",
     "SearchConnectionError",
     "SearchHTTPError",
+    "GoogleFlightsRateLimited",
 ]

--- a/fli/search/_wire.py
+++ b/fli/search/_wire.py
@@ -118,3 +118,77 @@ def parse_first_wrb_payload(body: str | bytes) -> Any:
     for chunk in iter_wrb_chunks(body):
         return chunk
     return None
+
+
+# Protobuf type URL Google embeds in the wrb.fr envelope when the request was
+# rejected mid-pipeline (rate-limit / fingerprint / quota). The "rejected"
+# envelope keeps the wrb.fr row but sets its inner-JSON slot (``row[2]``) to
+# ``null`` and stashes the error detail in ``row[5]``. ``parse_first_wrb_payload``
+# correctly returns None for that shape, but callers had no way to distinguish
+# "no flights match these filters" (success with empty result set) from
+# "Google rejected the request" (transient failure to retry / back off).
+RATE_LIMIT_ERROR_MARKER = "travel.frontend.flights.ErrorResponse"
+
+
+def is_rate_limit_response(body: str | bytes) -> bool:
+    """Return True if ``body`` looks like Google's ErrorResponse envelope.
+
+    Uses a substring match on the protobuf type URL Google embeds in the
+    envelope. The marker is part of a stable protobuf descriptor
+    (``type.googleapis.com/travel.frontend.flights.ErrorResponse``) so the
+    check is robust to envelope-position drift — any future field
+    reshuffle inside the envelope still keeps the type URL.
+    """
+    if isinstance(body, bytes):
+        try:
+            body = body.decode("utf-8", errors="ignore")
+        except UnicodeDecodeError:
+            return False
+    return RATE_LIMIT_ERROR_MARKER in body
+
+
+def extract_error_session_id(body: str | bytes) -> str | None:
+    """Best-effort: pull the session id from an ErrorResponse envelope.
+
+    Returns ``None`` when the body has no recognisable session id, or
+    when the envelope shape differs from the captured sample. The session
+    id is only used to enrich the exception message — never required for
+    correctness.
+    """
+    if isinstance(body, bytes):
+        try:
+            body = body.decode("utf-8", errors="ignore")
+        except UnicodeDecodeError:
+            return None
+    if RATE_LIMIT_ERROR_MARKER not in body:
+        return None
+    # Strip the JSONP prefix and parse the outer chunk list.
+    raw = body.lstrip()
+    if raw.startswith(")]}'"):
+        raw = raw[len(")]}'") :]
+    raw = raw.lstrip()
+    if not raw:
+        return None
+    try:
+        outer = json.loads(raw)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(outer, list):
+        return None
+    for row in outer:
+        if (
+            isinstance(row, list)
+            and len(row) >= 6
+            and row[0] == "wrb.fr"
+            and isinstance(row[5], list)
+        ):
+            try:
+                details = row[5][2][0]
+                # details = [type_url, [[_, [session_meta], 0, session_id, ...], 0]]
+                if isinstance(details, list) and len(details) >= 2 and isinstance(details[1], list):
+                    candidate = details[1][0][3]
+                    if isinstance(candidate, str) and candidate:
+                        return candidate
+            except (IndexError, TypeError):
+                continue
+    return None

--- a/fli/search/client.py
+++ b/fli/search/client.py
@@ -21,6 +21,7 @@ callers cooperate cleanly under Google's 10 req/sec ceiling.
 from __future__ import annotations
 
 import os
+import random
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -33,6 +34,44 @@ from fli.search.exceptions import (
     SearchHTTPError,
     SearchTimeoutError,
 )
+
+# Pool of curl_cffi browser fingerprints used for per-request rotation.
+# Google's per-IP throttling appears to also key off TLS / HTTP-2 fingerprint
+# (JA3 + ALPN + frame settings + h2 priority frames). Sticking to a single
+# ``impersonate="chrome"`` across a tight burst of flight queries exhausts
+# the per-fingerprint quota and Google starts returning the ErrorResponse
+# envelope (see PR #208 and ``tests/search/fixtures/flight_search_rate_limit_error.txt``).
+# Rotating per request spreads the load across multiple browser identities.
+#
+# The pool intentionally mixes Chrome variants with Firefox + Safari to widen
+# the JA3 surface. Order doesn't matter — :func:`pick_impersonate` samples
+# uniformly. Add new values as curl_cffi ships them; verify each is in
+# ``curl_cffi.requests.BrowserType`` first.
+_IMPERSONATE_POOL = (
+    "chrome120",
+    "chrome124",
+    "chrome131",
+    "firefox133",
+    "safari17_0",
+)
+
+
+def pick_impersonate() -> str:
+    """Return a random curl_cffi impersonation profile from the rotation pool.
+
+    Per-request rotation spreads tight bursts of flight queries across
+    multiple TLS / HTTP-2 fingerprints so callers running airfare-table
+    workflows (one-way + round-trip + many filter combinations in close
+    succession) don't exhaust Google's per-fingerprint quota and trip the
+    rejected-envelope path surfaced by :class:`GoogleFlightsRateLimited`.
+
+    The rotation is best-effort: it reduces the rate of rate-limit hits
+    but does not eliminate them. Callers should still handle the
+    :class:`GoogleFlightsRateLimited` exception (or its MCP equivalent
+    ``{"code": "RATE_LIMITED"}``) and back off.
+    """
+    return random.choice(_IMPERSONATE_POOL)
+
 
 # ``curl_cffi`` adds ~100ms to import time on first load — we only need
 # it once an HTTP request actually fires, so import lazily on first use.

--- a/fli/search/dates.py
+++ b/fli/search/dates.py
@@ -21,7 +21,7 @@ from fli.search._wire import (
     is_rate_limit_response,
     parse_first_wrb_payload,
 )
-from fli.search.client import get_client
+from fli.search.client import get_client, pick_impersonate
 from fli.search.exceptions import GoogleFlightsRateLimited
 
 logger = logging.getLogger(__name__)
@@ -182,7 +182,7 @@ class SearchDates:
         response = self.client.post(
             url=url,
             data=f"f.req={encoded_filters}",
-            impersonate="chrome",
+            impersonate=pick_impersonate(),
             allow_redirects=True,
         )
         response.raise_for_status()

--- a/fli/search/dates.py
+++ b/fli/search/dates.py
@@ -16,8 +16,13 @@ from fli.models import DateSearchFilters
 from fli.models.google_flights.base import TripType
 from fli.search._concurrency import parallel_map
 from fli.search._urls import with_locale_params
-from fli.search._wire import parse_first_wrb_payload
+from fli.search._wire import (
+    extract_error_session_id,
+    is_rate_limit_response,
+    parse_first_wrb_payload,
+)
 from fli.search.client import get_client
+from fli.search.exceptions import GoogleFlightsRateLimited
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +189,15 @@ class SearchDates:
 
         data = parse_first_wrb_payload(response.text)
         if data is None:
+            if is_rate_limit_response(response.text):
+                session_id = extract_error_session_id(response.text)
+                raise GoogleFlightsRateLimited(
+                    "Google Flights rejected the date search with an "
+                    "ErrorResponse envelope instead of date rows. Likely "
+                    "rate-limited or quota-exhausted on this client "
+                    "fingerprint. Retry after a short backoff (30-60s).",
+                    session_id=session_id,
+                )
             return None
 
         try:

--- a/fli/search/exceptions.py
+++ b/fli/search/exceptions.py
@@ -28,3 +28,25 @@ class SearchHTTPError(SearchClientError):
         """Store the HTTP status alongside the message for richer logging."""
         super().__init__(message)
         self.status_code = status_code
+
+
+class GoogleFlightsRateLimited(SearchClientError):
+    """Google Flights returned an ErrorResponse instead of flight rows.
+
+    The response is HTTP 200 with a ``wrb.fr`` chunk whose inner payload is
+    ``null`` and an outer ``ErrorResponse`` marker in ``row[5]`` of the
+    ``GetShoppingResults`` envelope. Previously this surfaced as a silent
+    empty result; callers had no way to distinguish "rate-limited" from
+    "no flights match these filters". This exception makes the failure
+    explicit so the CLI / MCP server can surface a retryable error and
+    library users can implement their own backoff.
+
+    Triggered by per-IP / per-session-fingerprint throttling. A short
+    backoff (~30-60s) is usually enough; rotating ``curl_cffi``'s
+    ``impersonate`` fingerprint sometimes helps.
+    """
+
+    def __init__(self, message: str, *, session_id: str | None = None):
+        """Store the session id captured from the error envelope, if any."""
+        super().__init__(message)
+        self.session_id = session_id

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -33,7 +33,7 @@ from fli.search._wire import (
     iter_wrb_chunks,
     parse_first_wrb_payload,
 )
-from fli.search.client import get_client
+from fli.search.client import get_client, pick_impersonate
 from fli.search.exceptions import GoogleFlightsRateLimited
 
 logger = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ class SearchFlights:
         response = self.client.post(
             url=url,
             data=f"f.req={encoded}",
-            impersonate="chrome",
+            impersonate=pick_impersonate(),
             allow_redirects=True,
         )
         response.raise_for_status()
@@ -352,7 +352,7 @@ class SearchFlights:
         response = self.client.post(
             url=url,
             data=f"f.req={encoded}",
-            impersonate="chrome",
+            impersonate=pick_impersonate(),
             allow_redirects=True,
         )
         response.raise_for_status()

--- a/fli/search/flights.py
+++ b/fli/search/flights.py
@@ -27,8 +27,14 @@ from fli.search._decoders import (
 )
 from fli.search._urls import with_locale_params
 from fli.search._urls import with_locale_params as _with_locale_params  # noqa: F401
-from fli.search._wire import iter_wrb_chunks, parse_first_wrb_payload
+from fli.search._wire import (
+    extract_error_session_id,
+    is_rate_limit_response,
+    iter_wrb_chunks,
+    parse_first_wrb_payload,
+)
 from fli.search.client import get_client
+from fli.search.exceptions import GoogleFlightsRateLimited
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +179,21 @@ class SearchFlights:
 
         inner = parse_first_wrb_payload(response.text)
         if inner is None:
+            # Google sometimes returns HTTP 200 with an ErrorResponse envelope
+            # (rate-limit / fingerprint reject / quota) instead of flight data.
+            # The wrb.fr row is present but its inner-JSON slot is null. Raise
+            # so callers can distinguish "rejected, retry" from "no flights
+            # match these filters" instead of swallowing as an empty result.
+            if is_rate_limit_response(response.text):
+                session_id = extract_error_session_id(response.text)
+                raise GoogleFlightsRateLimited(
+                    "Google Flights rejected the request with an ErrorResponse "
+                    "envelope instead of flight rows. Likely rate-limited or "
+                    "quota-exhausted on this client fingerprint. Retry after a "
+                    "short backoff (30-60s); rotating curl_cffi's `impersonate` "
+                    "value sometimes helps if backoff alone is not enough.",
+                    session_id=session_id,
+                )
             return None
 
         if capture_session:

--- a/tests/search/fixtures/flight_search_rate_limit_error.txt
+++ b/tests/search/fixtures/flight_search_rate_limit_error.txt
@@ -1,0 +1,3 @@
+)]}'
+
+[["wrb.fr",null,null,null,null,[13,null,[["type.googleapis.com/travel.frontend.flights.ErrorResponse",[[null,[[1782183274701731,54776872,2101123823],null,null,null,null,[[0]]],0,"avU5aqPqKqioj8oP77Xy6Qc","HNWGCqEBKFkQAY0-mABG----------okrt5AAAAAGo59WoKnS6iA"],0]]]]],["di",49],["af.httprm",49,"2038896757614171247",16]]

--- a/tests/search/test_impersonate_rotation.py
+++ b/tests/search/test_impersonate_rotation.py
@@ -1,0 +1,65 @@
+"""Tests for the per-request impersonate rotation in :mod:`fli.search.client`.
+
+Per-request rotation is the second half of the rate-limit-resilience pair
+(PR #208 surfaces the error; rotation reduces how often callers hit it).
+The pool intentionally mixes Chrome variants with Firefox + Safari to
+spread the JA3 surface so Google's per-fingerprint quota is harder to
+exhaust on a tight burst of flight queries.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from curl_cffi.requests import BrowserType
+
+from fli.search.client import _IMPERSONATE_POOL, pick_impersonate
+
+
+class TestImpersonatePool:
+    def test_pool_is_non_empty(self):
+        assert len(_IMPERSONATE_POOL) >= 2, "pool too small to actually rotate"
+
+    def test_pool_has_diverse_browsers(self):
+        # Pool must include at least 2 distinct browser families so rotation
+        # spreads JA3 fingerprints rather than just chrome-version variants.
+        families = {name[:4] for name in _IMPERSONATE_POOL}
+        assert len(families) >= 2, (
+            f"pool {_IMPERSONATE_POOL} only covers families {families}; "
+            "include at least 2 of chrome/firefox/safari to widen JA3 surface"
+        )
+
+    def test_every_pool_entry_is_valid_curl_cffi_browser(self):
+        # If curl_cffi drops a browser version in a future release, the
+        # constant value here would silently still resolve as a string
+        # but the request would fail at HTTP time. Catch the mismatch
+        # at unit-test time instead.
+        valid = {b.value for b in BrowserType}
+        for name in _IMPERSONATE_POOL:
+            assert name in valid, (
+                f"pool entry {name!r} is not in curl_cffi.requests.BrowserType "
+                f"(known: {sorted(valid)[:10]}...)"
+            )
+
+
+class TestPickImpersonate:
+    def test_returns_pool_member(self):
+        for _ in range(20):
+            assert pick_impersonate() in _IMPERSONATE_POOL
+
+    def test_actually_rotates(self):
+        # 500 picks against a 5-entry pool should sample every entry
+        # with overwhelming probability (chance of missing one is
+        # (4/5)^500 ~= 10^-49). If we ever return the same value 500
+        # times, rotation regressed to a constant.
+        seen = Counter(pick_impersonate() for _ in range(500))
+        assert len(seen) == len(_IMPERSONATE_POOL), (
+            f"expected all {len(_IMPERSONATE_POOL)} pool members; got {seen}"
+        )
+        # Each member should appear roughly 100 times (500/5); allow a
+        # generous +/- 40% band so test isn't flaky on biased RNG seeds.
+        expected = 500 / len(_IMPERSONATE_POOL)
+        for name, count in seen.items():
+            assert 0.6 * expected < count < 1.4 * expected, (
+                f"rotation imbalance: {name} appeared {count} times (expected ~{int(expected)})"
+            )

--- a/tests/search/test_rate_limit_detection.py
+++ b/tests/search/test_rate_limit_detection.py
@@ -1,0 +1,212 @@
+"""End-to-end tests that rate-limit ErrorResponse envelopes raise instead of swallow.
+
+Prior to this fix, Google's rate-limit / fingerprint-reject envelope (HTTP 200
+with ``wrb.fr`` row whose inner JSON is ``null`` and a protobuf-typed
+``ErrorResponse`` blob in ``row[5]``) was silently mapped to "no flights match
+your filters". Callers had no way to distinguish the two cases. These tests
+lock in the new behaviour: the search core raises
+:class:`GoogleFlightsRateLimited`, and the MCP layer surfaces a tailored
+``code="RATE_LIMITED"`` response.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fli.models import (
+    Airport,
+    DateSearchFilters,
+    FlightSearchFilters,
+    FlightSegment,
+    PassengerInfo,
+    TripType,
+)
+from fli.search import GoogleFlightsRateLimited, SearchDates, SearchFlights
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "flight_search_rate_limit_error.txt"
+
+
+class _RateLimitedResponse:
+    """Stand-in for ``curl_cffi``'s response object, returning the captured body."""
+
+    __slots__ = ("text", "status_code")
+
+    def __init__(self, text: str):
+        self.text = text
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _RateLimitedClient:
+    """Always returns the captured rate-limit envelope, regardless of input."""
+
+    def __init__(self, body: str):
+        self._body = body
+
+    def post(self, url: str, **kwargs: Any) -> _RateLimitedResponse:
+        return _RateLimitedResponse(self._body)
+
+    def get(self, url: str, **kwargs: Any) -> _RateLimitedResponse:
+        return self._post(url, **kwargs)
+
+
+@pytest.fixture
+def rate_limit_body() -> str:
+    return FIXTURE_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def rate_limit_client(rate_limit_body: str) -> _RateLimitedClient:
+    return _RateLimitedClient(rate_limit_body)
+
+
+def _one_way_filters() -> FlightSearchFilters:
+    return FlightSearchFilters(
+        passenger_info=PassengerInfo(adults=1),
+        flight_segments=[
+            FlightSegment(
+                departure_airport=[[Airport.BZN, 0]],
+                arrival_airport=[[Airport.SEA, 0]],
+                travel_date="2026-07-15",
+            )
+        ],
+    )
+
+
+def _round_trip_filters() -> FlightSearchFilters:
+    return FlightSearchFilters(
+        trip_type=TripType.ROUND_TRIP,
+        passenger_info=PassengerInfo(adults=1),
+        flight_segments=[
+            FlightSegment(
+                departure_airport=[[Airport.BZN, 0]],
+                arrival_airport=[[Airport.SEA, 0]],
+                travel_date="2026-07-15",
+            ),
+            FlightSegment(
+                departure_airport=[[Airport.SEA, 0]],
+                arrival_airport=[[Airport.BZN, 0]],
+                travel_date="2026-07-22",
+            ),
+        ],
+    )
+
+
+def _date_filters() -> DateSearchFilters:
+    return DateSearchFilters(
+        passenger_info=PassengerInfo(adults=1),
+        flight_segments=[
+            FlightSegment(
+                departure_airport=[[Airport.BZN, 0]],
+                arrival_airport=[[Airport.SEA, 0]],
+                travel_date="2026-07-15",
+            )
+        ],
+        from_date="2026-07-10",
+        to_date="2026-07-25",
+    )
+
+
+class TestSearchFlightsRateLimit:
+    def test_one_way_raises(self, rate_limit_client: _RateLimitedClient) -> None:
+        search = SearchFlights()
+        search.client = rate_limit_client
+        with pytest.raises(GoogleFlightsRateLimited) as exc_info:
+            search.search(_one_way_filters(), currency="USD")
+        assert "ErrorResponse" in str(exc_info.value)
+        # Real captured fixture exposes this session id.
+        assert exc_info.value.session_id == "avU5aqPqKqioj8oP77Xy6Qc"
+
+    def test_round_trip_raises(self, rate_limit_client: _RateLimitedClient) -> None:
+        # The first outbound POST already hits rate-limit; the expansion fan-out
+        # is never reached because _fetch_flights raises before _expand_multi_leg.
+        search = SearchFlights()
+        search.client = rate_limit_client
+        with pytest.raises(GoogleFlightsRateLimited):
+            search.search(_round_trip_filters(), currency="USD")
+
+    def test_no_silent_empty_result(self, rate_limit_client: _RateLimitedClient) -> None:
+        # Regression guard against the silent-empty bug.
+        search = SearchFlights()
+        search.client = rate_limit_client
+        with pytest.raises(GoogleFlightsRateLimited):
+            result = search.search(_one_way_filters(), currency="USD")
+            # If we ever reach this line, the bug came back.
+            assert result is None or len(result) == 0, (
+                f"silent fallback returned {len(result) if result else 'None'} results"
+            )
+
+
+class TestSearchDatesRateLimit:
+    def test_search_dates_raises(self, rate_limit_client: _RateLimitedClient) -> None:
+        search = SearchDates()
+        search.client = rate_limit_client
+        with pytest.raises(GoogleFlightsRateLimited):
+            search.search(_date_filters(), currency="USD")
+
+
+class TestMCPServerRateLimit:
+    """MCP layer should convert the exception into a structured error.
+
+    Not a vanilla ``success=False, error="Search failed: ..."`` — callers
+    keying off the ``code`` field can implement targeted backoff.
+    """
+
+    def test_execute_flight_search_returns_rate_limit_code(
+        self, rate_limit_body: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fli.mcp import server
+
+        rate_limited = _RateLimitedClient(rate_limit_body)
+        original_init = SearchFlights.__init__
+
+        def _patched_init(self, *args: Any, **kwargs: Any) -> None:
+            original_init(self, *args, **kwargs)
+            self.client = rate_limited
+
+        # Patch SearchFlights to ship the fake client on construction so the
+        # MCP layer's own `SearchFlights()` picks it up without extra wiring.
+        monkeypatch.setattr(SearchFlights, "__init__", _patched_init, raising=True)
+        params = server.FlightSearchParams(
+            origin="BZN",
+            destination="SEA",
+            departure_date="2026-07-15",
+            currency="USD",
+        )
+        result = server._execute_flight_search(params)
+        assert result["success"] is False
+        assert result["code"] == "RATE_LIMITED"
+        assert result["retry_after_s"] == 30
+        assert result["session_id"] == "avU5aqPqKqioj8oP77Xy6Qc"
+        assert result["flights"] == []
+
+    def test_execute_date_search_returns_rate_limit_code(
+        self, rate_limit_body: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from fli.mcp import server
+
+        rate_limited = _RateLimitedClient(rate_limit_body)
+        original_init = SearchDates.__init__
+
+        def _patched_init(self, *args: Any, **kwargs: Any) -> None:
+            original_init(self, *args, **kwargs)
+            self.client = rate_limited
+
+        monkeypatch.setattr(SearchDates, "__init__", _patched_init, raising=True)
+        params = server.DateSearchParams(
+            origin="BZN",
+            destination="SEA",
+            start_date="2026-07-10",
+            end_date="2026-07-25",
+            currency="USD",
+        )
+        result = server._execute_date_search(params)
+        assert result["success"] is False
+        assert result["code"] == "RATE_LIMITED"
+        assert result["retry_after_s"] == 30
+        assert result["dates"] == []

--- a/tests/search/test_wire.py
+++ b/tests/search/test_wire.py
@@ -1,8 +1,16 @@
 """Tests for the wire-format parser shared by all FlightsFrontendService responses."""
 
 import json
+from pathlib import Path
 
-from fli.search._wire import iter_wrb_chunks, parse_first_wrb_payload
+from fli.search._wire import (
+    extract_error_session_id,
+    is_rate_limit_response,
+    iter_wrb_chunks,
+    parse_first_wrb_payload,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 def _single_chunk(payload):
@@ -121,6 +129,57 @@ class TestIterWrbChunksEdgeCases:
         body = "".join(parts)
         chunks = list(iter_wrb_chunks(body))
         assert chunks == [[1, "alpha"], [2, "beta"]]
+
+
+class TestRateLimitDetection:
+    """Detect Google's `ErrorResponse` envelope (per-IP / fingerprint reject)."""
+
+    FIXTURE = "flight_search_rate_limit_error.txt"
+
+    def test_real_capture_is_detected(self):
+        body = (FIXTURES / self.FIXTURE).read_text(encoding="utf-8")
+        assert is_rate_limit_response(body) is True
+
+    def test_real_capture_returns_none_from_parse_first(self):
+        # Sanity: parse_first_wrb_payload still returns None (no flight rows),
+        # so callers like _fetch_flights see the None and fall through to the
+        # new rate-limit check before returning None / empty.
+        body = (FIXTURES / self.FIXTURE).read_text(encoding="utf-8")
+        assert parse_first_wrb_payload(body) is None
+
+    def test_session_id_extracted_from_real_capture(self):
+        body = (FIXTURES / self.FIXTURE).read_text(encoding="utf-8")
+        session_id = extract_error_session_id(body)
+        # The captured fixture has session id "avU5aqPqKqioj8oP77Xy6Qc" in
+        # row[5][2][0][1][0][3] of the wrb.fr envelope.
+        assert session_id == "avU5aqPqKqioj8oP77Xy6Qc"
+
+    def test_normal_success_body_not_flagged(self):
+        body = _single_chunk([1, "alpha"])
+        assert is_rate_limit_response(body) is False
+        assert extract_error_session_id(body) is None
+
+    def test_bytes_input_detected(self):
+        body = (FIXTURES / self.FIXTURE).read_bytes()
+        assert is_rate_limit_response(body) is True
+
+    def test_empty_body_not_flagged(self):
+        assert is_rate_limit_response("") is False
+        assert extract_error_session_id("") is None
+
+    def test_marker_inside_string_payload_still_detected(self):
+        # If Google ever embeds the marker inside an inner JSON string (e.g.
+        # documentation or a successful response that quotes the type URL),
+        # we still flag it — false positives are acceptable here because a
+        # genuine ErrorResponse SUPPRESSES flight rows; misdetecting a body
+        # that DID contain flights would surface as the raise overriding a
+        # parse, which never happens because parse_first_wrb_payload returns
+        # a non-None payload first and the caller never reaches the check.
+        # This test documents that contract: substring match is the intent.
+        body = ")]}'\n\n" + json.dumps(
+            [["wrb.fr", None, json.dumps(["see travel.frontend.flights.ErrorResponse"])]]
+        )
+        assert is_rate_limit_response(body) is True
 
     def test_multiple_wrb_chunks_all_yielded_with_mixed_rows(self):
         # Two separate multi-chunks, each with only wrb.fr rows.


### PR DESCRIPTION
## Summary

Google Flights occasionally returns HTTP 200 with an `ErrorResponse` envelope (rate-limit / fingerprint reject / quota): a `wrb.fr` row whose inner-JSON slot is `null` and a protobuf-typed error blob in `row[5]`. `parse_first_wrb_payload` correctly returns `None` for that shape, but `_fetch_flights` then returned `None` -> `SearchFlights.search()` returned `None` -> the MCP layer reported `{"success": true, "count": 0}`.

Callers had no way to distinguish "rate-limited, retry with backoff" from "no flights match these filters". Symptoms surface for users as #142 (round-trip empty) and contribute to #200 (general empty results): each round-trip fires N+1 requests (one outbound + per-top-N expansion), so a few hit the per-IP quota first and ALL subsequent queries silently fail.

Reproduced consistently from a single residential IP: third or fourth round-trip search in a short window returns the error envelope, and one-way queries from the same client also start coming back empty. Switching IP or waiting ~60s restores normal results.

## Changes

- **New exception** `GoogleFlightsRateLimited(SearchClientError)` in `fli/search/exceptions.py` with optional `session_id` from the rejected envelope, exported from `fli.search`.
- **`fli/search/_wire.py`**: adds `is_rate_limit_response(body)` (substring match against the stable protobuf type URL `travel.frontend.flights.ErrorResponse`) and `extract_error_session_id(body)` (best-effort session-id pull from `row[5][2][0][1][0][3]`).
- **`fli/search/flights.py` `_fetch_flights`**: when `parse_first_wrb_payload` returns `None`, check `is_rate_limit_response`; if true, raise `GoogleFlightsRateLimited` instead of silently returning `None`. Otherwise behaviour unchanged.
- **`fli/search/dates.py` `_fetch_dates`**: same treatment for `SearchDates`.
- **`fli/mcp/server.py`**: `_execute_flight_search`, `_execute_booking_options`, and `_execute_date_search` each catch the new exception and return a structured payload:

  ```json
  {
    "success": false,
    "error": "Google Flights rejected ...",
    "code": "RATE_LIMITED",
    "retry_after_s": 30,
    "session_id": "...",
    "flights": []
  }
  ```

  MCP clients can key off `code == "RATE_LIMITED"` for targeted backoff instead of treating the silent empty as "no matches".

## Tests

- **`tests/search/test_rate_limit_detection.py`** (6 cases): exercises one-way, round-trip, search_dates, and both MCP executors via the captured real-life rate-limit fixture using the project's existing fake-client pattern.
- **`TestRateLimitDetection` group in `tests/search/test_wire.py`** (7 cases): wire-level detection + session-id extraction from the same fixture, plus negative cases (empty body, success body, bytes input).
- **`tests/search/fixtures/flight_search_rate_limit_error.txt`**: real captured 325-byte response from a `BZN -> SEA` round-trip query when the client was rate-limited.

Full unit-test suite (213 tests, excluding live-network tests) passes locally on Windows + Python 3.14. The one pre-existing failure in `test_snapshot_fixtures.py::test_jfk_fra_oneworld_has_results` is a cp1252 encoding issue on Windows unrelated to this change (also fails on `main`).

## Backwards compatibility

- Public API: only adds (`GoogleFlightsRateLimited` exception, two helper functions, structured MCP error). No signature changes.
- Existing tests' behaviour unchanged: the rejected envelope's `parse_first_wrb_payload` still returns `None`. The new raise only fires in the previously-unreachable branch where `inner is None` AND the body carries the `ErrorResponse` marker.
- Library users who were catching `Exception` continue to work; users who were catching `SearchClientError` get a more specific exception type for free.

## Closes / relates to

- Closes #142 (round-trip search missing results) on the surfacing side. Actual backoff / retry is left to callers but the structured error makes it implementable in 5 lines.
- Partially addresses #200 (search returns no results, Python API returns None): callers can now distinguish "genuinely no flights" from "rate-limited".

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent-empty-result bug where Google Flights' HTTP 200 `ErrorResponse` envelope (rate-limit / fingerprint reject) was indistinguishable from "no matching flights." It introduces `GoogleFlightsRateLimited`, wires detection into `_fetch_flights` and `_fetch_dates`, and surfaces a structured `code: "RATE_LIMITED"` response at the MCP layer.

- **New exception and detection helpers**: `GoogleFlightsRateLimited(SearchClientError)` is added to `fli/search/exceptions.py` and exported from `fli.search`; `is_rate_limit_response` (substring match on a stable protobuf type URL) and `extract_error_session_id` (best-effort path navigation) are added to `_wire.py`.
- **Search core changes**: Both `SearchFlights._fetch_flights` and `SearchDates._fetch_dates` now raise `GoogleFlightsRateLimited` when `parse_first_wrb_payload` returns `None` and the body carries the error marker, replacing a silent `return None`.
- **MCP layer**: All three executor functions catch the new exception and return `{\"success\": false, \"code\": \"RATE_LIMITED\", \"retry_after_s\": 30, ...}` so MCP clients can implement targeted backoff.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core detection logic is correct and the changes are additive. The one latent bug is confined to a test helper method that no current test path exercises.

The production logic is sound and well-tested via the captured fixture. The test helper `_RateLimitedClient.get` references the non-existent `self._post`, which will surface as an `AttributeError` the first time a GET-based search path is added and tested through this fake client. Both `is_rate_limit_response` and `extract_error_session_id` also carry an unreachable `except UnicodeDecodeError` block, and there is no test for the `_execute_booking_options` rate-limit handler.

tests/search/test_rate_limit_detection.py — fix the `self._post` typo in `_RateLimitedClient.get` and add a test for `_execute_booking_options`. fli/search/_wire.py — remove the dead `except UnicodeDecodeError` branches.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| fli/search/_wire.py | Adds `is_rate_limit_response` and `extract_error_session_id` helpers. Both contain an unreachable `except UnicodeDecodeError` block because `errors="ignore"` is used. The session-id path navigation is fragile but correctly documented as best-effort. |
| fli/search/exceptions.py | Adds `GoogleFlightsRateLimited(SearchClientError)` with an optional `session_id` attribute. Clean hierarchy, correct `__init__`, no issues. |
| fli/search/flights.py | Integrates rate-limit detection in `_fetch_flights` — raises `GoogleFlightsRateLimited` when `parse_first_wrb_payload` returns `None` and the body contains the error marker. Logic is correct and only fires in the previously-unreachable `inner is None` branch. |
| fli/search/dates.py | Mirrors the same rate-limit detection pattern in `_fetch_dates`. Symmetric and correct. |
| fli/mcp/server.py | Adds `GoogleFlightsRateLimited` catch blocks to all three executors, returning `code: "RATE_LIMITED"` structured errors. The `retry_after_s: 30` is hardcoded but acceptable. |
| tests/search/test_rate_limit_detection.py | New end-to-end tests cover one-way, round-trip, date-search, and MCP executor paths. Contains a latent bug in `_RateLimitedClient.get` (calls non-existent `self._post`). Also missing a test for `_execute_booking_options`. |
| tests/search/test_wire.py | Adds 7 wire-level unit tests for `is_rate_limit_response` and `extract_error_session_id`, including positive, negative, bytes, and empty-body cases. |
| fli/search/__init__.py | Exports `GoogleFlightsRateLimited` from the public `fli.search` namespace. Correctly added to both the import and `__all__`. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP POST to Google Flights] --> B[response.raise_for_status]
    B --> C[parse_first_wrb_payload]
    C -->|non-None| D[Decode flight/date rows]
    C -->|None| E{is_rate_limit_response?}
    E -->|Yes| F[extract_error_session_id]
    F --> G[raise GoogleFlightsRateLimited]
    E -->|No| H[return None]
    D --> I[Return results]
    G --> J{MCP layer catch}
    J --> K[Return RATE_LIMITED structured error]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[HTTP POST to Google Flights] --> B[response.raise_for_status]
    B --> C[parse_first_wrb_payload]
    C -->|non-None| D[Decode flight/date rows]
    C -->|None| E{is_rate_limit_response?}
    E -->|Yes| F[extract_error_session_id]
    F --> G[raise GoogleFlightsRateLimited]
    E -->|No| H[return None]
    D --> I[Return results]
    G --> J{MCP layer catch}
    J --> K[Return RATE_LIMITED structured error]
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atests%2Fsearch%2Ftest_rate_limit_detection.py%3A55-58%0A**Typo%20in%20%60_RateLimitedClient.get%60%20%E2%80%94%20calls%20non-existent%20%60self._post%60**%0A%0AThe%20%60get%60%20method%20calls%20%60self._post%28url%2C%20**kwargs%29%60%20but%20no%20such%20attribute%20exists%20on%20the%20class%20%28only%20%60post%60%20is%20defined%29.%20Any%20test%20path%20that%20exercises%20an%20HTTP%20GET%20through%20this%20fake%20client%20will%20immediately%20raise%20%60AttributeError%60%20instead%20of%20returning%20the%20mocked%20rate-limit%20response%2C%20silently%20hiding%20the%20intended%20coverage.%20The%20affected%20method%20is%20currently%20untriggered%20by%20the%20existing%20test%20suite%20since%20both%20%60_fetch_flights%60%20and%20%60_fetch_dates%60%20use%20%60POST%60%2C%20but%20the%20latent%20bug%20is%20one%20future%20%60get%60-based%20search%20path%20away%20from%20causing%20confusing%20failures.%0A%0A%23%23%23%20Issue%202%20of%204%0Afli%2Fsearch%2F_wire.py%3A142-147%0A**%60except%20UnicodeDecodeError%60%20is%20dead%20code%20after%20%60errors%3D%22ignore%22%60**%0A%0A%60bytes.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%60%20never%20raises%20%60UnicodeDecodeError%60%20%E2%80%94%20the%20%60errors%3D%22ignore%22%60%20flag%20suppresses%20decode%20errors%20by%20silently%20dropping%20bad%20bytes.%20The%20%60except%60%20clause%20is%20therefore%20unreachable%20in%20both%20%60is_rate_limit_response%60%20and%20%60extract_error_session_id%60.%20This%20pattern%20appears%20twice%20in%20the%20new%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20isinstance%28body%2C%20bytes%29%3A%0A%20%20%20%20%20%20%20%20body%20%3D%20body.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%0A%20%20%20%20return%20RATE_LIMIT_ERROR_MARKER%20in%20body%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Afli%2Fsearch%2F_wire.py%3A158-163%0ASame%20dead-code%20%60except%20UnicodeDecodeError%60%20in%20%60extract_error_session_id%60%20%E2%80%94%20%60errors%3D%22ignore%22%60%20makes%20the%20clause%20unreachable.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20isinstance%28body%2C%20bytes%29%3A%0A%20%20%20%20%20%20%20%20body%20%3D%20body.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%0A%20%20%20%20if%20RATE_LIMIT_ERROR_MARKER%20not%20in%20body%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Atests%2Fsearch%2Ftest_rate_limit_detection.py%3A153-212%0A**%60_execute_booking_options%60%20rate-limit%20path%20has%20no%20test%20coverage**%0A%0AThe%20PR%20adds%20a%20%60GoogleFlightsRateLimited%60%20catch%20block%20in%20%60_execute_booking_options%60%20%28server.py%20lines%20~766-777%29%20but%20%60TestMCPServerRateLimit%60%20only%20exercises%20%60_execute_flight_search%60%20and%20%60_execute_date_search%60.%20A%20test%20analogous%20to%20%60test_execute_flight_search_returns_rate_limit_code%60%20is%20missing%20for%20the%20booking-options%20path%2C%20so%20any%20regression%20in%20its%20structured%20error%20response%20%28e.g.%2C%20wrong%20key%20name%20or%20missing%20%60code%60%20field%29%20would%20go%20undetected.%0A%0A&pr=208&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atests%2Fsearch%2Ftest_rate_limit_detection.py%3A55-58%0A**Typo%20in%20%60_RateLimitedClient.get%60%20%E2%80%94%20calls%20non-existent%20%60self._post%60**%0A%0AThe%20%60get%60%20method%20calls%20%60self._post%28url%2C%20**kwargs%29%60%20but%20no%20such%20attribute%20exists%20on%20the%20class%20%28only%20%60post%60%20is%20defined%29.%20Any%20test%20path%20that%20exercises%20an%20HTTP%20GET%20through%20this%20fake%20client%20will%20immediately%20raise%20%60AttributeError%60%20instead%20of%20returning%20the%20mocked%20rate-limit%20response%2C%20silently%20hiding%20the%20intended%20coverage.%20The%20affected%20method%20is%20currently%20untriggered%20by%20the%20existing%20test%20suite%20since%20both%20%60_fetch_flights%60%20and%20%60_fetch_dates%60%20use%20%60POST%60%2C%20but%20the%20latent%20bug%20is%20one%20future%20%60get%60-based%20search%20path%20away%20from%20causing%20confusing%20failures.%0A%0A%23%23%23%20Issue%202%20of%204%0Afli%2Fsearch%2F_wire.py%3A142-147%0A**%60except%20UnicodeDecodeError%60%20is%20dead%20code%20after%20%60errors%3D%22ignore%22%60**%0A%0A%60bytes.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%60%20never%20raises%20%60UnicodeDecodeError%60%20%E2%80%94%20the%20%60errors%3D%22ignore%22%60%20flag%20suppresses%20decode%20errors%20by%20silently%20dropping%20bad%20bytes.%20The%20%60except%60%20clause%20is%20therefore%20unreachable%20in%20both%20%60is_rate_limit_response%60%20and%20%60extract_error_session_id%60.%20This%20pattern%20appears%20twice%20in%20the%20new%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20isinstance%28body%2C%20bytes%29%3A%0A%20%20%20%20%20%20%20%20body%20%3D%20body.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%0A%20%20%20%20return%20RATE_LIMIT_ERROR_MARKER%20in%20body%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Afli%2Fsearch%2F_wire.py%3A158-163%0ASame%20dead-code%20%60except%20UnicodeDecodeError%60%20in%20%60extract_error_session_id%60%20%E2%80%94%20%60errors%3D%22ignore%22%60%20makes%20the%20clause%20unreachable.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20isinstance%28body%2C%20bytes%29%3A%0A%20%20%20%20%20%20%20%20body%20%3D%20body.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%0A%20%20%20%20if%20RATE_LIMIT_ERROR_MARKER%20not%20in%20body%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Atests%2Fsearch%2Ftest_rate_limit_detection.py%3A153-212%0A**%60_execute_booking_options%60%20rate-limit%20path%20has%20no%20test%20coverage**%0A%0AThe%20PR%20adds%20a%20%60GoogleFlightsRateLimited%60%20catch%20block%20in%20%60_execute_booking_options%60%20%28server.py%20lines%20~766-777%29%20but%20%60TestMCPServerRateLimit%60%20only%20exercises%20%60_execute_flight_search%60%20and%20%60_execute_date_search%60.%20A%20test%20analogous%20to%20%60test_execute_flight_search_returns_rate_limit_code%60%20is%20missing%20for%20the%20booking-options%20path%2C%20so%20any%20regression%20in%20its%20structured%20error%20response%20%28e.g.%2C%20wrong%20key%20name%20or%20missing%20%60code%60%20field%29%20would%20go%20undetected.%0A%0A&repo=punitarani%2Ffli&pr=208&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22punitarani%2Ffli%22%20on%20the%20existing%20branch%20%22fix%2Fsurface-rate-limit-errors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsurface-rate-limit-errors%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Atests%2Fsearch%2Ftest_rate_limit_detection.py%3A55-58%0A**Typo%20in%20%60_RateLimitedClient.get%60%20%E2%80%94%20calls%20non-existent%20%60self._post%60**%0A%0AThe%20%60get%60%20method%20calls%20%60self._post%28url%2C%20**kwargs%29%60%20but%20no%20such%20attribute%20exists%20on%20the%20class%20%28only%20%60post%60%20is%20defined%29.%20Any%20test%20path%20that%20exercises%20an%20HTTP%20GET%20through%20this%20fake%20client%20will%20immediately%20raise%20%60AttributeError%60%20instead%20of%20returning%20the%20mocked%20rate-limit%20response%2C%20silently%20hiding%20the%20intended%20coverage.%20The%20affected%20method%20is%20currently%20untriggered%20by%20the%20existing%20test%20suite%20since%20both%20%60_fetch_flights%60%20and%20%60_fetch_dates%60%20use%20%60POST%60%2C%20but%20the%20latent%20bug%20is%20one%20future%20%60get%60-based%20search%20path%20away%20from%20causing%20confusing%20failures.%0A%0A%23%23%23%20Issue%202%20of%204%0Afli%2Fsearch%2F_wire.py%3A142-147%0A**%60except%20UnicodeDecodeError%60%20is%20dead%20code%20after%20%60errors%3D%22ignore%22%60**%0A%0A%60bytes.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%60%20never%20raises%20%60UnicodeDecodeError%60%20%E2%80%94%20the%20%60errors%3D%22ignore%22%60%20flag%20suppresses%20decode%20errors%20by%20silently%20dropping%20bad%20bytes.%20The%20%60except%60%20clause%20is%20therefore%20unreachable%20in%20both%20%60is_rate_limit_response%60%20and%20%60extract_error_session_id%60.%20This%20pattern%20appears%20twice%20in%20the%20new%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20isinstance%28body%2C%20bytes%29%3A%0A%20%20%20%20%20%20%20%20body%20%3D%20body.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%0A%20%20%20%20return%20RATE_LIMIT_ERROR_MARKER%20in%20body%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Afli%2Fsearch%2F_wire.py%3A158-163%0ASame%20dead-code%20%60except%20UnicodeDecodeError%60%20in%20%60extract_error_session_id%60%20%E2%80%94%20%60errors%3D%22ignore%22%60%20makes%20the%20clause%20unreachable.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20isinstance%28body%2C%20bytes%29%3A%0A%20%20%20%20%20%20%20%20body%20%3D%20body.decode%28%22utf-8%22%2C%20errors%3D%22ignore%22%29%0A%20%20%20%20if%20RATE_LIMIT_ERROR_MARKER%20not%20in%20body%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Atests%2Fsearch%2Ftest_rate_limit_detection.py%3A153-212%0A**%60_execute_booking_options%60%20rate-limit%20path%20has%20no%20test%20coverage**%0A%0AThe%20PR%20adds%20a%20%60GoogleFlightsRateLimited%60%20catch%20block%20in%20%60_execute_booking_options%60%20%28server.py%20lines%20~766-777%29%20but%20%60TestMCPServerRateLimit%60%20only%20exercises%20%60_execute_flight_search%60%20and%20%60_execute_date_search%60.%20A%20test%20analogous%20to%20%60test_execute_flight_search_returns_rate_limit_code%60%20is%20missing%20for%20the%20booking-options%20path%2C%20so%20any%20regression%20in%20its%20structured%20error%20response%20%28e.g.%2C%20wrong%20key%20name%20or%20missing%20%60code%60%20field%29%20would%20go%20undetected.%0A%0A&repo=punitarani%2Ffli&pr=208&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
tests/search/test_rate_limit_detection.py:55-58
**Typo in `_RateLimitedClient.get` — calls non-existent `self._post`**

The `get` method calls `self._post(url, **kwargs)` but no such attribute exists on the class (only `post` is defined). Any test path that exercises an HTTP GET through this fake client will immediately raise `AttributeError` instead of returning the mocked rate-limit response, silently hiding the intended coverage. The affected method is currently untriggered by the existing test suite since both `_fetch_flights` and `_fetch_dates` use `POST`, but the latent bug is one future `get`-based search path away from causing confusing failures.

### Issue 2 of 4
fli/search/_wire.py:142-147
**`except UnicodeDecodeError` is dead code after `errors="ignore"`**

`bytes.decode("utf-8", errors="ignore")` never raises `UnicodeDecodeError` — the `errors="ignore"` flag suppresses decode errors by silently dropping bad bytes. The `except` clause is therefore unreachable in both `is_rate_limit_response` and `extract_error_session_id`. This pattern appears twice in the new code.

```suggestion
    if isinstance(body, bytes):
        body = body.decode("utf-8", errors="ignore")
    return RATE_LIMIT_ERROR_MARKER in body
```

### Issue 3 of 4
fli/search/_wire.py:158-163
Same dead-code `except UnicodeDecodeError` in `extract_error_session_id` — `errors="ignore"` makes the clause unreachable.

```suggestion
    if isinstance(body, bytes):
        body = body.decode("utf-8", errors="ignore")
    if RATE_LIMIT_ERROR_MARKER not in body:
```

### Issue 4 of 4
tests/search/test_rate_limit_detection.py:153-212
**`_execute_booking_options` rate-limit path has no test coverage**

The PR adds a `GoogleFlightsRateLimited` catch block in `_execute_booking_options` (server.py lines ~766-777) but `TestMCPServerRateLimit` only exercises `_execute_flight_search` and `_execute_date_search`. A test analogous to `test_execute_flight_search_returns_rate_limit_code` is missing for the booking-options path, so any regression in its structured error response (e.g., wrong key name or missing `code` field) would go undetected.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search): surface Google Flights Erro..."](https://github.com/punitarani/fli/commit/2d07c5111fb7c78a9c1475d0f599afaea467844e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39202643)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->